### PR TITLE
Saving Parameters

### DIFF
--- a/Source/Processors/ArduinoOutput.cpp
+++ b/Source/Processors/ArduinoOutput.cpp
@@ -38,7 +38,7 @@ ArduinoOutput::~ArduinoOutput()
 
 AudioProcessorEditor* ArduinoOutput::createEditor()
 {
-    editor = new ArduinoOutputEditor(this);
+    editor = new ArduinoOutputEditor(this, true);
  	return editor;
 }
 

--- a/Source/Processors/Editors/ArduinoOutputEditor.cpp
+++ b/Source/Processors/Editors/ArduinoOutputEditor.cpp
@@ -25,8 +25,8 @@
 #include <stdio.h>
 
 
-ArduinoOutputEditor::ArduinoOutputEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+ArduinoOutputEditor::ArduinoOutputEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 

--- a/Source/Processors/Editors/ArduinoOutputEditor.h
+++ b/Source/Processors/Editors/ArduinoOutputEditor.h
@@ -46,7 +46,7 @@ class ArduinoOutputEditor : public GenericEditor
 
 {
 public:
-	ArduinoOutputEditor (GenericProcessor* parentNode);
+	ArduinoOutputEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~ArduinoOutputEditor();
 
 	void receivedEvent();

--- a/Source/Processors/Editors/EventNodeEditor.cpp
+++ b/Source/Processors/Editors/EventNodeEditor.cpp
@@ -26,8 +26,8 @@
 #include <stdio.h>
 
 
-EventNodeEditor::EventNodeEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+EventNodeEditor::EventNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 	desiredWidth = 200;

--- a/Source/Processors/Editors/EventNodeEditor.h
+++ b/Source/Processors/Editors/EventNodeEditor.h
@@ -44,7 +44,7 @@ class FilterViewport;
 class EventNodeEditor : public GenericEditor
 {
 public:
-	EventNodeEditor (GenericProcessor* parentNode);
+	EventNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~EventNodeEditor();
 	void buttonEvent(Button* button);
 

--- a/Source/Processors/Editors/FPGAOutputEditor.cpp
+++ b/Source/Processors/Editors/FPGAOutputEditor.cpp
@@ -26,8 +26,8 @@
 #include <stdio.h>
 
 
-FPGAOutputEditor::FPGAOutputEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+FPGAOutputEditor::FPGAOutputEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 

--- a/Source/Processors/Editors/FPGAOutputEditor.h
+++ b/Source/Processors/Editors/FPGAOutputEditor.h
@@ -46,7 +46,7 @@ class FPGAOutputEditor : public GenericEditor
 
 {
 public:
-	FPGAOutputEditor (GenericProcessor* parentNode);
+	FPGAOutputEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~FPGAOutputEditor();
 
 	void receivedEvent();

--- a/Source/Processors/Editors/FilterEditor.cpp
+++ b/Source/Processors/Editors/FilterEditor.cpp
@@ -26,8 +26,8 @@
 #include <stdio.h>
 
 
-FilterEditor::FilterEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+FilterEditor::FilterEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 	desiredWidth = 180;

--- a/Source/Processors/Editors/FilterEditor.h
+++ b/Source/Processors/Editors/FilterEditor.h
@@ -44,7 +44,7 @@ class FilterViewport;
 class FilterEditor : public GenericEditor
 {
 public:
-	FilterEditor (GenericProcessor* parentNode);
+	FilterEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~FilterEditor();
 	void buttonEvent(Button* button);
 

--- a/Source/Processors/Editors/GenericEditor.cpp
+++ b/Source/Processors/Editors/GenericEditor.cpp
@@ -33,59 +33,78 @@
 
 #include <math.h>
 
-GenericEditor::GenericEditor (GenericProcessor* owner) 
+GenericEditor::GenericEditor (GenericProcessor* owner, bool useDefaultParameterEditors=true)
 	: AudioProcessorEditor (owner), isSelected(false),
 	  desiredWidth(150), tNum(-1), isEnabled(true),
 	  accumulator(0.0), isFading(false), drawerButton(0),
 	  channelSelector(0)
 
 {
+    constructorInitialize(owner, useDefaultParameterEditors);
+}
+
+
+/*GenericEditor::GenericEditor (GenericProcessor* owner)
+: AudioProcessorEditor (owner), isSelected(false),
+desiredWidth(150), tNum(-1), isEnabled(true),
+accumulator(0.0), isFading(false), drawerButton(0),
+channelSelector(0)
+
+{
+    bool useDefaultParameterEditors=true;
+    constructorInitialize(owner, useDefaultParameterEditors);
+}
+*/
+GenericEditor::~GenericEditor()
+{
+	deleteAllChildren();
+}
+
+void GenericEditor::constructorInitialize(GenericProcessor* owner, bool useDefaultParameterEditors){
+    
 	name = getAudioProcessor()->getName();
-
+    
 	nodeId = owner->getNodeId();
-
+    
 	MemoryInputStream mis(BinaryData::silkscreenserialized, BinaryData::silkscreenserializedSize, false);
     Typeface::Ptr typeface = new CustomTypeface(mis);
     titleFont = Font(typeface);
-
+    
     if (!owner->isMerger() && !owner->isSplitter())
     {
     	drawerButton = new DrawerButton("name");
     	drawerButton->addListener(this);
     	addAndMakeVisible(drawerButton);
-
+        
     	if (!owner->isSink())
     	{
     		channelSelector = new ChannelSelector(true, titleFont);
     	} else {
     		channelSelector = new ChannelSelector(false, titleFont);
     	}
-
+        
     	addChildComponent(channelSelector);
     	channelSelector->setVisible(false);
-
-
+        
+        
 	}
-
-	backgroundGradient = ColourGradient(Colour(190, 190, 190), 0.0f, 0.0f, 
-										 Colour(185, 185, 185), 0.0f, 120.0f, false);
+    
+	backgroundGradient = ColourGradient(Colour(190, 190, 190), 0.0f, 0.0f,
+                                        Colour(185, 185, 185), 0.0f, 120.0f, false);
 	backgroundGradient.addColour(0.2f, Colour(155, 155, 155));
-
-	addParameterEditors();
-
+    
+    addParameterEditors(useDefaultParameterEditors);
+    
 	backgroundColor = Colour(10,10,10);
-
+    
 	//fadeIn();
+    
 }
 
-GenericEditor::~GenericEditor()
+void GenericEditor::addParameterEditors(bool useDefaultParameterEditors)
 {
-	deleteAllChildren();
-}
-
-void GenericEditor::addParameterEditors()
-{
-	
+	if (useDefaultParameterEditors) {
+        
 	int maxX = 15;
 	int maxY = 30;
 
@@ -106,7 +125,10 @@ void GenericEditor::addParameterEditors()
 		maxY += dHeight;
 		maxY += 10;
 	}
+    }
 }
+
+
 
 
 void GenericEditor::refreshColors()

--- a/Source/Processors/Editors/GenericEditor.h
+++ b/Source/Processors/Editors/GenericEditor.h
@@ -65,8 +65,12 @@ class GenericEditor : public AudioProcessorEditor,
 
 {
 public:
-	/** Constructor. Loads fonts and creates default buttons.*/
-	GenericEditor (GenericProcessor* owner);
+    /** Constructor. Loads fonts and creates default buttons. 
+     useDefaultParameter Editors false means custom parameter editors will be used.*/
+	GenericEditor (GenericProcessor* owner, bool useDefaultParameterEditors);
+    
+    /** Constructor. Loads fonts and creates default buttons.*/
+    //GenericEditor (GenericProcessor* owner);
 
 	/** Destructor.*/
 	virtual ~GenericEditor();
@@ -209,6 +213,7 @@ public:
 	/** Stores the font used to display the editor's name. */
 	Font titleFont;
 
+
 protected:
 
 	/** A pointer to the button that opens the drawer for the ChannelSelector. */
@@ -217,11 +222,16 @@ protected:
 	/** Determines the width of the ChannelSelector drawer when opened. */
 	int drawerWidth;
 
+
 	/** Can be overridden to customize the layout of ParameterEditors. */
-	virtual void addParameterEditors();
+    //Ideally this would be virtual, but since it's run in the construct and because virtual functions don't get overriden in the constructor, it's not.
+    void addParameterEditors(bool useStandard);
+
 
 	/** A pointer to the editor's ChannelSelector. */
 	ChannelSelector* channelSelector;
+    
+    
 
 private:
 
@@ -241,6 +251,9 @@ private:
 	bool isEnabled;
 
 	int tNum;
+   
+    /**initializing function Used to share constructor functions*/
+    void constructorInitialize(GenericProcessor* owner, bool useDefaultParameterEditors);
 
 	String name;
 
@@ -324,7 +337,6 @@ private:
     bool isEnabled;
 
     void resized();
-
 };
 
 

--- a/Source/Processors/Editors/LfpDisplayEditor.cpp
+++ b/Source/Processors/Editors/LfpDisplayEditor.cpp
@@ -24,8 +24,8 @@
 #include "LfpDisplayEditor.h"
 
 
-LfpDisplayEditor::LfpDisplayEditor (GenericProcessor* parentNode) 
-	: VisualizerEditor(parentNode)
+LfpDisplayEditor::LfpDisplayEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: VisualizerEditor(parentNode, useDefaultParameterEditors)
 
 {
 

--- a/Source/Processors/Editors/LfpDisplayEditor.h
+++ b/Source/Processors/Editors/LfpDisplayEditor.h
@@ -49,7 +49,7 @@ class Visualizer;
 class LfpDisplayEditor : public VisualizerEditor
 {
 public:
-	LfpDisplayEditor (GenericProcessor*);
+	LfpDisplayEditor (GenericProcessor*, bool useDefaultParameterEditors);
 	~LfpDisplayEditor();
 
 	void buttonCallback (Button* button);

--- a/Source/Processors/Editors/MergerEditor.cpp
+++ b/Source/Processors/Editors/MergerEditor.cpp
@@ -51,8 +51,8 @@
 // {
 // }
 
-MergerEditor::MergerEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+MergerEditor::MergerEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 	desiredWidth = 90;

--- a/Source/Processors/Editors/MergerEditor.h
+++ b/Source/Processors/Editors/MergerEditor.h
@@ -43,7 +43,7 @@ class MergerEditor : public GenericEditor
 
 {
 public:
-	MergerEditor (GenericProcessor* parentNode);
+	MergerEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~MergerEditor();
 
 	virtual void buttonEvent (Button* button);

--- a/Source/Processors/Editors/RecordControlEditor.cpp
+++ b/Source/Processors/Editors/RecordControlEditor.cpp
@@ -26,8 +26,8 @@
 #include "ChannelSelector.h"
 #include <stdio.h>
 
-RecordControlEditor::RecordControlEditor (GenericProcessor* parentNode)
-	: GenericEditor(parentNode)
+RecordControlEditor::RecordControlEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 {
 	desiredWidth = 170;
 

--- a/Source/Processors/Editors/RecordControlEditor.h
+++ b/Source/Processors/Editors/RecordControlEditor.h
@@ -42,7 +42,7 @@ class RecordControlEditor : public GenericEditor,
 							public ComboBox::Listener
 {
 public:
-	RecordControlEditor (GenericProcessor* parentNode);
+	RecordControlEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	~RecordControlEditor();
 	void comboBoxChanged(ComboBox* comboBox);
 	void updateSettings();

--- a/Source/Processors/Editors/ReferenceNodeEditor.cpp
+++ b/Source/Processors/Editors/ReferenceNodeEditor.cpp
@@ -27,8 +27,8 @@
 #include <stdio.h>
 
 
-ReferenceNodeEditor::ReferenceNodeEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+ReferenceNodeEditor::ReferenceNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 	desiredWidth = 180;

--- a/Source/Processors/Editors/ReferenceNodeEditor.h
+++ b/Source/Processors/Editors/ReferenceNodeEditor.h
@@ -41,7 +41,7 @@
 class ReferenceNodeEditor : public GenericEditor
 {
 public:
-	ReferenceNodeEditor (GenericProcessor* parentNode);
+	ReferenceNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~ReferenceNodeEditor();
 	void buttonEvent(Button* button);
 

--- a/Source/Processors/Editors/ResamplingNodeEditor.cpp
+++ b/Source/Processors/Editors/ResamplingNodeEditor.cpp
@@ -26,8 +26,8 @@
 #include <stdio.h>
 
 
-ResamplingNodeEditor::ResamplingNodeEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+ResamplingNodeEditor::ResamplingNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 	desiredWidth = 180;

--- a/Source/Processors/Editors/ResamplingNodeEditor.h
+++ b/Source/Processors/Editors/ResamplingNodeEditor.h
@@ -42,7 +42,7 @@
 class ResamplingNodeEditor : public GenericEditor
 {
 public:
-	ResamplingNodeEditor (GenericProcessor* parentNode);
+	ResamplingNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~ResamplingNodeEditor();
 
 	void startAcquisition();

--- a/Source/Processors/Editors/SignalGeneratorEditor.cpp
+++ b/Source/Processors/Editors/SignalGeneratorEditor.cpp
@@ -28,8 +28,8 @@
 #include <stdio.h>
 
 
-SignalGeneratorEditor::SignalGeneratorEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode), amplitudeSlider(0), frequencySlider(0), phaseSlider(0)
+SignalGeneratorEditor::SignalGeneratorEditor (GenericProcessor* parentNode, bool useDefaultParameters=false)
+	: GenericEditor(parentNode, useDefaultParameters), amplitudeSlider(0), frequencySlider(0), phaseSlider(0)
 
 {
 	desiredWidth = 250;

--- a/Source/Processors/Editors/SignalGeneratorEditor.h
+++ b/Source/Processors/Editors/SignalGeneratorEditor.h
@@ -47,13 +47,11 @@ class SignalGeneratorEditor : public GenericEditor,
                               public Label::Listener
 {
 public:
-	SignalGeneratorEditor (GenericProcessor* parentNode);
+	SignalGeneratorEditor (GenericProcessor* parentNode, bool useDefaultParameters);
 	virtual ~SignalGeneratorEditor();
     void sliderEvent(Slider* slider);
     void buttonEvent(Button* button);
     void labelTextChanged(Label* label);
-
-    void addParameterEditors() {}
 
 private:	
 
@@ -71,7 +69,6 @@ private:
     {
         SINE, SQUARE, SAW, TRIANGLE, NOISE
     };
-
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SignalGeneratorEditor);
 
 };

--- a/Source/Processors/Editors/SourceNodeEditor.cpp
+++ b/Source/Processors/Editors/SourceNodeEditor.cpp
@@ -27,8 +27,8 @@
 #include <stdio.h>
 
 
-SourceNodeEditor::SourceNodeEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+SourceNodeEditor::SourceNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 	desiredWidth = 170;

--- a/Source/Processors/Editors/SourceNodeEditor.h
+++ b/Source/Processors/Editors/SourceNodeEditor.h
@@ -47,7 +47,7 @@ class SourceNodeEditor : public GenericEditor
 
 {
 public:
-	SourceNodeEditor (GenericProcessor* parentNode);
+	SourceNodeEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~SourceNodeEditor();
 
 private:	

--- a/Source/Processors/Editors/SpikeDetectorEditor.cpp
+++ b/Source/Processors/Editors/SpikeDetectorEditor.cpp
@@ -29,8 +29,8 @@
 
 
 
-SpikeDetectorEditor::SpikeDetectorEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode), isPlural(true)
+SpikeDetectorEditor::SpikeDetectorEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors), isPlural(true)
 
 {
 

--- a/Source/Processors/Editors/SpikeDetectorEditor.h
+++ b/Source/Processors/Editors/SpikeDetectorEditor.h
@@ -138,7 +138,7 @@ class SpikeDetectorEditor : public GenericEditor,
 
 {
 public:
-	SpikeDetectorEditor (GenericProcessor* parentNode);
+	SpikeDetectorEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~SpikeDetectorEditor();
     void buttonEvent(Button* button);
     void labelTextChanged(Label* label);

--- a/Source/Processors/Editors/SplitterEditor.cpp
+++ b/Source/Processors/Editors/SplitterEditor.cpp
@@ -51,8 +51,8 @@
 // {
 // }
 
-SplitterEditor::SplitterEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+SplitterEditor::SplitterEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 	desiredWidth = 90;

--- a/Source/Processors/Editors/SplitterEditor.h
+++ b/Source/Processors/Editors/SplitterEditor.h
@@ -42,7 +42,7 @@
 class SplitterEditor : public GenericEditor
 {
 public:
-	SplitterEditor (GenericProcessor* parentNode);
+	SplitterEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~SplitterEditor();
 
 	void buttonEvent (Button* button);

--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -61,8 +61,8 @@ void SelectorButton::paintButton(Graphics &g, bool isMouseOver, bool isButtonDow
 }
 
 
-VisualizerEditor::VisualizerEditor (GenericProcessor* parentNode, int width)
-: GenericEditor(parentNode),
+VisualizerEditor::VisualizerEditor (GenericProcessor* parentNode, int width, bool useDefaultParameterEditors=true)
+: GenericEditor(parentNode, useDefaultParameterEditors=true),
 	  tabIndex(-1), dataWindow(0),
 	  isPlaying(false),
 	  canvas(0), tabText("Tab")
@@ -72,23 +72,22 @@ VisualizerEditor::VisualizerEditor (GenericProcessor* parentNode, int width)
 	desiredWidth = width;
 
 	initializeSelectors();
-
 }
 
 
-VisualizerEditor::VisualizerEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode),
+VisualizerEditor::VisualizerEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors),
 	  tabIndex(-1), dataWindow(0),
 	  isPlaying(false),
 	  canvas(0)
-
+    
 {
 
 	desiredWidth = 180;
 	initializeSelectors();
 
-
 }
+
 void VisualizerEditor::initializeSelectors(){
 
 	windowSelector = new SelectorButton("window");

--- a/Source/Processors/Editors/VisualizerEditor.h
+++ b/Source/Processors/Editors/VisualizerEditor.h
@@ -67,8 +67,8 @@ class SelectorButton : public Button
 class VisualizerEditor : public GenericEditor
 {
 public:
-	VisualizerEditor (GenericProcessor*, int);
-	VisualizerEditor (GenericProcessor*);
+	VisualizerEditor (GenericProcessor*, int, bool useDefaultParameterEditors);
+	VisualizerEditor (GenericProcessor*, bool useDefaultParameterEditors);
 	~VisualizerEditor();
 
 	void buttonEvent (Button* button);

--- a/Source/Processors/Editors/WiFiOutputEditor.cpp
+++ b/Source/Processors/Editors/WiFiOutputEditor.cpp
@@ -25,8 +25,8 @@
 #include <stdio.h>
 
 
-WiFiOutputEditor::WiFiOutputEditor (GenericProcessor* parentNode) 
-	: GenericEditor(parentNode)
+WiFiOutputEditor::WiFiOutputEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
+	: GenericEditor(parentNode, useDefaultParameterEditors)
 
 {
 

--- a/Source/Processors/Editors/WiFiOutputEditor.h
+++ b/Source/Processors/Editors/WiFiOutputEditor.h
@@ -44,7 +44,7 @@ class WiFiOutputEditor : public GenericEditor
 
 {
 public:
-	WiFiOutputEditor (GenericProcessor* parentNode);
+	WiFiOutputEditor (GenericProcessor* parentNode, bool useDefaultParameterEditors);
 	virtual ~WiFiOutputEditor();
 
 	void receivedEvent();

--- a/Source/Processors/EventNode.cpp
+++ b/Source/Processors/EventNode.cpp
@@ -47,7 +47,7 @@ EventNode::~EventNode()
 
 AudioProcessorEditor* EventNode::createEditor()
 {
-	editor = new EventNodeEditor(this);
+	editor = new EventNodeEditor(this, true);
 	return editor;
 }
 

--- a/Source/Processors/FPGAOutput.cpp
+++ b/Source/Processors/FPGAOutput.cpp
@@ -56,7 +56,7 @@ FPGAOutput::~FPGAOutput()
 
 AudioProcessorEditor* FPGAOutput::createEditor()
 {
-	editor = new FPGAOutputEditor(this);
+	editor = new FPGAOutputEditor(this, true);
 	return editor;
 }
 

--- a/Source/Processors/FilterNode.cpp
+++ b/Source/Processors/FilterNode.cpp
@@ -55,7 +55,7 @@ FilterNode::~FilterNode()
 
 AudioProcessorEditor* FilterNode::createEditor()
 {
-	editor = new FilterEditor(this);
+	editor = new FilterEditor(this, true);
 	//setEditor(filterEditor);
 	
 	std::cout << "Creating editor." << std::endl;

--- a/Source/Processors/GenericProcessor.h
+++ b/Source/Processors/GenericProcessor.h
@@ -132,9 +132,13 @@ public:
 	/** Returns additional details about the parameter with a given index.*/
 	const String getParameterText (int parameterIndex); 
 
-	/** Returns the current value of a parameter with a given index.*/
-	float getParameter (int parameterIndex) {return 1.0;}
+	/** Returns the current value of a parameter with a given index.
+     Currently set to always return 1. See getParameterVar below*/
+	float getParameter (int parameterIndex){return 1.0;};
 
+    /**Returns the current value of a parameter with a give index */
+    var getParameterVar (int parameterIndex, int parameterChannel);
+    
 	/** JUCE method. Not used.*/
 	const String getProgramName (int index) {return "";}
 	
@@ -390,13 +394,22 @@ public:
 
 	/** An array of parameters that the user can modify.*/
 	Array<Parameter> parameters;
-
+    
+    /** Initialize Parameters */
+    //virtual void initializeParameters();
+    
 	/** Returns the parameter for a given name.*/
 	Parameter& getParameterByName(String parameterName);
 
 	/** Returns the parameter for a given index.*/
 	Parameter& getParameterReference(int parameterIndex);
+    
+    /** Saving all settings to XML*/
+    void saveToXML(XmlElement* parentElement);
 
+    /** Saving Parameters for each Channel */
+    void saveParametersToChannelsXML(XmlElement* channelParent, int channelNumber);
+    
 private:
 
 	/** Automatically extracts the number of samples in the buffer, then 
@@ -417,6 +430,7 @@ private:
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GenericProcessor);
 
 };
+
 
 
 

--- a/Source/Processors/LfpDisplayNode.cpp
+++ b/Source/Processors/LfpDisplayNode.cpp
@@ -31,6 +31,7 @@ LfpDisplayNode::LfpDisplayNode()
 	  abstractFifo(100), ttlState(0)
 
 {
+    std::cout << " LFPDisplayNodeConstructor" << std::endl;
 	displayBuffer = new AudioSampleBuffer(8, 100);
 	eventBuffer = new MidiBuffer();
 
@@ -40,7 +41,7 @@ LfpDisplayNode::LfpDisplayNode()
 	timeBaseValues.add(5);
 	timeBaseValues.add(10);
 
-	parameters.add(Parameter("timebase",timeBaseValues, 0, 0));//true);//a,0);
+	parameters.add(Parameter("timebase",timeBaseValues, 1, 0));//true);//a,0);
 
 	Array<var> displayGainValues;
 	displayGainValues.add(1);
@@ -48,7 +49,7 @@ LfpDisplayNode::LfpDisplayNode()
 	displayGainValues.add(4);
 	displayGainValues.add(8);
 
-	parameters.add(Parameter("display gain",displayGainValues, 0, 1));//true);//a,0);
+	parameters.add(Parameter("display gain",displayGainValues, 1, 1));//true);//a,0);
 
 	arrayOfOnes = new float[5000];
 
@@ -68,7 +69,7 @@ LfpDisplayNode::~LfpDisplayNode()
 AudioProcessorEditor* LfpDisplayNode::createEditor()
 {
 
-	editor = new LfpDisplayEditor(this);	
+	editor = new LfpDisplayEditor(this, true);
 	return editor;
 
 }
@@ -119,6 +120,13 @@ bool LfpDisplayNode::disable()
 
 void LfpDisplayNode::setParameter (int parameterIndex, float newValue)
 {
+    //Sets Parameter in parameters array for processor
+    Parameter* parameterPointer=parameters.getRawDataPointer();
+    parameterPointer=parameterPointer+parameterIndex;
+    parameterPointer->setValue(newValue, currentChannel);
+
+    std::cout << "Saving Parameter from " << currentChannel << ", channel ";
+    
 	LfpDisplayEditor* ed = (LfpDisplayEditor*) getEditor();
 	if (ed->canvas != 0)
 		ed->canvas->setParameter(parameterIndex, newValue);

--- a/Source/Processors/LfpDisplayNode.h
+++ b/Source/Processors/LfpDisplayNode.h
@@ -58,7 +58,7 @@ public:
 	void process(AudioSampleBuffer &buffer, MidiBuffer &midiMessages, int& nSamples);
 
 	void setParameter(int, float);
-
+    
 	void updateSettings();
 
 	bool enable();

--- a/Source/Processors/ReferenceNode.cpp
+++ b/Source/Processors/ReferenceNode.cpp
@@ -42,7 +42,7 @@ ReferenceNode::~ReferenceNode()
 
 AudioProcessorEditor* ReferenceNode::createEditor()
 {
-	editor = new ReferenceNodeEditor(this);
+	editor = new ReferenceNodeEditor(this, true);
 	
 	std::cout << "Creating editor." << std::endl;
 

--- a/Source/Processors/ResamplingNode.cpp
+++ b/Source/Processors/ResamplingNode.cpp
@@ -48,7 +48,7 @@ ResamplingNode::~ResamplingNode()
 
 AudioProcessorEditor* ResamplingNode::createEditor()
 {
-	editor = new ResamplingNodeEditor(this);
+	editor = new ResamplingNodeEditor(this, true);
 
 	//std::cout << "Creating editor." << std::endl;
 

--- a/Source/Processors/SignalGenerator.cpp
+++ b/Source/Processors/SignalGenerator.cpp
@@ -35,11 +35,13 @@ SignalGenerator::SignalGenerator()
 	: GenericProcessor("Signal Generator"),
 
 	  defaultFrequency(10.0),
-	  defaultAmplitude (0.5f),
+	  defaultAmplitude(0.5f),
 	  nOut(5), previousPhase(1000), spikeDelay(0)
 {
-
-
+    parameters.add(Parameter("Amplitude", 0.0005f, 500.0f, .5f, 0, true));
+    parameters.add(Parameter("Frequency", 0.01, 10000.0, 10, 1, true));
+    parameters.add(Parameter("Phase", -double_Pi, double_Pi, 0, 2, true));
+    parameters.add(Parameter("Waveform Type", waveformParameter, 0, 3, true));
 }
 
 
@@ -48,10 +50,17 @@ SignalGenerator::~SignalGenerator()
 
 }
 
+/*void SignalGenerator::initializeParameters(){
+    parameters.add(Parameter("Amplitude", 0.0005f, 500.0f, .5f, 1, true));
+    parameters.add(Parameter("Frequency", 0.01, 10000.0, 10, 2, true));
+    parameters.add(Parameter("Phase", -double_Pi, double_Pi, 0, 3, true));
+    parameters.add(Parameter("Waveform Type", waveformParameter, 0, 0, true));
+}
+*/
 
 AudioProcessorEditor* SignalGenerator::createEditor( )
 {
-	editor = new SignalGeneratorEditor(this);
+	editor = new SignalGeneratorEditor(this, false);
 	return editor;
 }
 
@@ -78,20 +87,25 @@ void SignalGenerator::updateSettings()
 
 void SignalGenerator::setParameter (int parameterIndex, float newValue)
 {
-	//std::cout << "Message received." << std::endl;
-
+	std::cout << "Message received." << std::endl;
+    Parameter* parameterPointer=parameters.getRawDataPointer();
+    parameterPointer=parameterPointer+parameterIndex;
+    
 	if (currentChannel > -1) {
 		if (parameterIndex == 0) {
 			amplitude.set(currentChannel,newValue*100.0f);
+            parameterPointer->setValue(newValue*100.0f, currentChannel);
 		} else if (parameterIndex == 1) {
 			frequency.set(currentChannel,newValue);
 			phasePerSample.set(currentChannel, double_Pi * 2.0 / (getSampleRate() / frequency[currentChannel]));
+            parameterPointer->setValue(newValue, currentChannel);
 		} else if (parameterIndex == 2) {
 			phase.set(currentChannel, newValue/360.0f * (double_Pi * 2.0));
+            parameterPointer->setValue(newValue/360.0f * (double_Pi * 2.0), currentChannel);
 		} else if (parameterIndex == 3) {
 			waveformType.set(currentChannel, (int) newValue);
+            parameterPointer->setValue(newValue, currentChannel);
 		}
-
 		//updateWaveform(currentChannel);
 	}
 

--- a/Source/Processors/SignalGenerator.h
+++ b/Source/Processors/SignalGenerator.h
@@ -49,7 +49,7 @@ public:
 	~SignalGenerator();
 	
 	void process(AudioSampleBuffer &buffer, MidiBuffer &midiMessages, int& nSamples);
-
+    
 	void setParameter (int parameterIndex, float newValue);
 
 	float getSampleRate() {return 44100.0;}
@@ -68,6 +68,7 @@ public:
 
 	int nOut;
 
+    
 private:
 	
 	double defaultFrequency;
@@ -79,11 +80,13 @@ private:
 
 	//void updateWaveform(int chan);
 
-	enum wvfrm
-	{
+    void initializeParameters();
+
+	enum wvfrm{
 		TRIANGLE, SINE, SQUARE, SAW, NOISE, SPIKE
 	};
-
+    
+    Array<var> waveformParameter;
 	Array<int> waveformType;
 	Array<double> frequency;
 	Array<double> amplitude;

--- a/Source/Processors/SourceNode.cpp
+++ b/Source/Processors/SourceNode.cpp
@@ -172,7 +172,7 @@ void SourceNode::setParameter (int parameterIndex, float newValue)
 
 AudioProcessorEditor* SourceNode::createEditor()
 {
-	editor = new SourceNodeEditor(this);
+	editor = new SourceNodeEditor(this, true);
 	return editor;
 }
 

--- a/Source/Processors/SpikeDetector.cpp
+++ b/Source/Processors/SpikeDetector.cpp
@@ -75,7 +75,7 @@ SpikeDetector::~SpikeDetector()
 
 AudioProcessorEditor* SpikeDetector::createEditor()
 {
-	editor = new SpikeDetectorEditor(this);
+	editor = new SpikeDetectorEditor(this, true);
 	return editor;
 }
 

--- a/Source/Processors/Utilities/Merger.cpp
+++ b/Source/Processors/Utilities/Merger.cpp
@@ -42,7 +42,7 @@ Merger::~Merger()
 
 AudioProcessorEditor* Merger::createEditor()
 {
-	editor = new MergerEditor(this);
+	editor = new MergerEditor(this, true);
 	//tEditor(editor);
 	
 	//std::cout << "Creating editor." << std::endl;

--- a/Source/Processors/Utilities/RecordControl.cpp
+++ b/Source/Processors/Utilities/RecordControl.cpp
@@ -39,7 +39,7 @@ RecordControl::~RecordControl()
 
 AudioProcessorEditor* RecordControl::createEditor()
 {
-	editor = new RecordControlEditor(this);
+	editor = new RecordControlEditor(this, true);
 	return editor;
 }
 

--- a/Source/Processors/Utilities/Splitter.cpp
+++ b/Source/Processors/Utilities/Splitter.cpp
@@ -40,7 +40,7 @@ Splitter::~Splitter()
 
 AudioProcessorEditor* Splitter::createEditor()
 {
-	editor = new SplitterEditor(this);
+	editor = new SplitterEditor(this, true);
 	//tEditor(editor);
 	
 	//std::cout << "Creating editor." << std::endl;

--- a/Source/Processors/WiFiOutput.cpp
+++ b/Source/Processors/WiFiOutput.cpp
@@ -36,7 +36,7 @@ WiFiOutput::~WiFiOutput()
 
 AudioProcessorEditor* WiFiOutput::createEditor()
 {
-	editor = new WiFiOutputEditor(this);
+	editor = new WiFiOutputEditor(this, true);
 	return editor;
 }
 

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -982,7 +982,10 @@ XmlElement* EditorViewport::createNodeXml (GenericEditor* editor,
 
     e->setAttribute ("name", name);
     e->setAttribute ("insertionPoint", insertionPt);
-
+    
+    /**Saves parameters to XML */
+    std::cout << "Create subnotes with parameters" << std::endl;
+    source->saveToXML(e);
    // source->stateSaved = true;
   
     //GenericProcessor* dest = (GenericProcessor*) source->getDestNode();
@@ -1024,7 +1027,9 @@ const String EditorViewport::saveState()
     }
 
     Array<GenericProcessor*> splitPoints;
-
+    /** Used to reset saveOrder at end, to allow saving the same processor multiple times*/
+    Array<GenericProcessor*> allProcessors;
+    
     bool moveForward;
     int saveOrder = 0;
 
@@ -1034,7 +1039,7 @@ const String EditorViewport::saveState()
     {
 
         moveForward = true;
-        
+
         XmlElement* signalChain = new XmlElement("SIGNALCHAIN");
 
         GenericEditor* editor = signalChainArray[n]->getEditor();
@@ -1051,6 +1056,7 @@ const String EditorViewport::saveState()
 
                 signalChain->addChildElement(createNodeXml(editor, insertionPt));
                 currentProcessor->saveOrder = saveOrder;
+                allProcessors.addIfNotAlreadyThere(currentProcessor);
                 saveOrder++;
 
             } else {
@@ -1116,7 +1122,13 @@ const String EditorViewport::saveState()
     }
 
     std::cout << "Saving processor graph." << std::endl;
-
+    
+    //Resets Save Order for processors, allowing them to be saved again without omitting themselves from the order.
+    int allProcessorSize=allProcessors.size();
+    for (int i=0; i<allProcessorSize; i++) {
+        allProcessors.operator[](i)->saveOrder=-1;
+    }
+    
     if (! xml->writeToFile (currentFile, String::empty))
         error = "Couldn't write to file ";
     else 


### PR DESCRIPTION
Uses the parameters array to create XML data for parameter settings on
each channel when saving.

This only works for processors that use the parameters array, though I
updated LFP and Signal Generator to update that in parallel (LFP seems
to have an unrelated bug in dealing with channels that is causing some
problems). Eventually, all parameters should be used in the parameters
array, since it opens up a lot of possible holes when using default
values (they need to be specified twice), and once loading is
implemented. I've fixed some of the problems with parameters, so this
should be easier to do.

As part of this, I also fixed the implementation of
addParameterEditors. The old way of implementing a custom parameter
editor was to rewrite the virtual function, but because it was called
in the constructor, this didn't work (constructors use the type of the
parent). Instead, all editors now also pass a bool
"useDefaultParameterEditors" which is used by addParameterEditors() to
determine whether to do anything. I think this is the best way to do
it. It's initialized to default as true, though I had some trouble with
it implicitly taking the argument and so had to add true to most of the
editor functions (which is probably good practice anyway).

I also fixed some of the functions for generic processor to get
parameter index and parameter name.

Obviously, this is of considerable less use without functions for
loading parameters, but I figured it'd be better to make available for
testing with just the loading in case the changes to Parameters broke
anything I missed.
