### PR TITLE
Compile spike sort on OS X

### DIFF
--- a/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
@@ -6,3003 +6,3858 @@
 	objectVersion = 46;
 	objects = {
 
-		0D3DFADD627629AD52668186 = { isa = PBXBuildFile; fileRef = 39F287BE4C0B4F3BD4A949FD; };
-		38568B2E6C61E2F07173B568 = { isa = PBXBuildFile; fileRef = C868329EBC1BBA606AB2EB88; };
-		C8D7AC0B88A9A2C182B2B752 = { isa = PBXBuildFile; fileRef = DBB769DEBCD6468C13A3CD25; };
-		A94130738A9973148544664A = { isa = PBXBuildFile; fileRef = F5A00ACFA3D76168F22F1205; };
-		E5CBEA12D7AD7788C9BF5737 = { isa = PBXBuildFile; fileRef = 27313EA12BC45638321922CA; };
-		9212DC2AEE118398CC970DDF = { isa = PBXBuildFile; fileRef = 243817BA562AD7FA76C834C9; };
-		3D0C7CA4AD9E3963D52E89BD = { isa = PBXBuildFile; fileRef = D685CFEA6344360FBFC355B6; };
-		3130878C465F3294A89CA142 = { isa = PBXBuildFile; fileRef = E31563D2E7DDD8315F369233; };
-		E100912B2FCE36A30D097C95 = { isa = PBXBuildFile; fileRef = 9C21DBFB38865E5AFE367C6F; };
-		CAB9D9DEF279F93132B45F90 = { isa = PBXBuildFile; fileRef = 80C1B737D2C2CB519D1787D7; };
-		CA4DCF67B48352BE633A616D = { isa = PBXBuildFile; fileRef = C055D09224D84121A3EBB29F; };
-		FD4865450F4C47FF3C6327FE = { isa = PBXBuildFile; fileRef = 56169D835A3E3029D6E3904C; };
-		512D7D16D0A95BDD0D6D6E45 = { isa = PBXBuildFile; fileRef = 4FD13AA663EEE7CC2F83033D; };
-		2D2BDB63CBD0BED07FF9E44B = { isa = PBXBuildFile; fileRef = BBE1DB78E35135B41537DCB5; };
-		4FA2949D3023FC2E377AFFB6 = { isa = PBXBuildFile; fileRef = 61317B5191E05925F232E18C; };
-		14BDAEA656AAFA60334CC55C = { isa = PBXBuildFile; fileRef = 420B0E95F1300ABFDC125DBF; };
-		C853FCE2F6C91B3643322CF0 = { isa = PBXBuildFile; fileRef = 9F577889CB6C54A2F7B1CA80; };
-		00A0D05390DB9F2B74DDAA78 = { isa = PBXBuildFile; fileRef = 1989E86F8DFDE34887AC0326; };
-		4AD3281B0CCF122A25E33667 = { isa = PBXBuildFile; fileRef = 22801F75289646F6A85E5583; };
-		F505DF3C2BA492B5A2F28D05 = { isa = PBXBuildFile; fileRef = B47B3368AA1A182B0CA1AB26; };
-		B226387EB0FCE3BE6773FF61 = { isa = PBXBuildFile; fileRef = 09BCBD414282A3AA4F66A3A5; };
-		B3B08037F49EC7540586828F = { isa = PBXBuildFile; fileRef = AC2CFF4DA5CE431FCC628BA3; };
-		B6C73582C501D8C3C03A4860 = { isa = PBXBuildFile; fileRef = B767A249792EB15A87054409; };
-		129ADFA8B25DE091AFA2D9E3 = { isa = PBXBuildFile; fileRef = D8D895B3AD895C6E7FD446BF; };
-		285FF16149C85F2793EBCBAE = { isa = PBXBuildFile; fileRef = 2B93450006102A0093F5EACB; };
-		D19775DC99C67AD20F98EF17 = { isa = PBXBuildFile; fileRef = E90FCB43DA2FF766597DA75E; };
-		CB470032BC92A30906C96258 = { isa = PBXBuildFile; fileRef = 392408C1943AC6234BAAC743; };
-		4FEC4EC2796E37A3B11B50B9 = { isa = PBXBuildFile; fileRef = 587FCA2485B9C89C2A99C23A; };
-		A44FEA7117CFE2F06B9889B4 = { isa = PBXBuildFile; fileRef = C4B0DF8094C90543A65E03E3; };
-		C0E966234C8AF91C19CF6EA4 = { isa = PBXBuildFile; fileRef = 3F6C67E29CDEDF2EF61C054F; };
-		BBE886EA79C50D0D68A5A753 = { isa = PBXBuildFile; fileRef = 65312FAD0900119CDF6CF414; };
-		9D17609E468FC65EB70ED7F4 = { isa = PBXBuildFile; fileRef = 9A21A229CFACC67E31F4F727; };
-		AE06672D2CBF8F64465B2126 = { isa = PBXBuildFile; fileRef = 3F69480D6145C77992FA59BA; };
-		69630D3ECA4D6014EE3734CD = { isa = PBXBuildFile; fileRef = C1CB526B75E406851FA918C6; };
-		0AE243437B40602D35435C32 = { isa = PBXBuildFile; fileRef = B04D87ED6AA4897B6CD3CCF6; };
-		171DBC82575004F0DAF60A80 = { isa = PBXBuildFile; fileRef = FFABF04684556C4A54A62439; };
-		04E6370E518D4C41CAC82003 = { isa = PBXBuildFile; fileRef = DC17FC0E3B6E3B7C45079DE0; };
-		4996C99F2CF9C13880F8C5D8 = { isa = PBXBuildFile; fileRef = E413F3262886677B4CBF3FA9; };
-		BEC09BF7DFCBD272B5471696 = { isa = PBXBuildFile; fileRef = B84E9C47FEE13D162CE9E5D7; };
-		0DAD0EFDC8B36F1D9BBB00BC = { isa = PBXBuildFile; fileRef = 96AED479B95D4EC31604D604; };
-		73DAB4DC87D7333E490F2D7E = { isa = PBXBuildFile; fileRef = 71C0C491E4BB214551D6EAD7; };
-		94FAD0B2F2538EE8918F9E67 = { isa = PBXBuildFile; fileRef = C91ED2E43CF9CC0E83EB50A7; };
-		B8EB3B8A25F7D8BA4F697399 = { isa = PBXBuildFile; fileRef = DDD2075B59AF7E38447BA84B; };
-		9BF1FBB0A93003FE8EC94C72 = { isa = PBXBuildFile; fileRef = 7F4241B34F5F7245653B5196; };
-		03A83ACD14BB6A18AFA4C81A = { isa = PBXBuildFile; fileRef = 33EC8C48E03E5FB60DD9D4C5; };
-		B89453078EB0A8107F39EDF3 = { isa = PBXBuildFile; fileRef = 86688D712937F3D08918C68B; };
-		A33C92B3D445EBC6C35E7ABA = { isa = PBXBuildFile; fileRef = 813CB9DFF788D612A0750FBF; };
-		F25EC78DCCC9CCEE805AE011 = { isa = PBXBuildFile; fileRef = 9215DC26F511C58DEE009209; };
-		EA6A1BDDF81818D516B93DD6 = { isa = PBXBuildFile; fileRef = 5654BDD4FBFF01AC3F17FA0D; };
-		7077270005BA819E3D5654B5 = { isa = PBXBuildFile; fileRef = DBB295F412798131D3F04045; };
-		FDCFDC9CC6D7A82131190FB0 = { isa = PBXBuildFile; fileRef = BBD9C2AED6F500D090069007; };
-		11D82BA398E9433440B76F66 = { isa = PBXBuildFile; fileRef = 9FFD9560522567A033226BD7; };
-		EDEE5E21F0C9BDB7DB796083 = { isa = PBXBuildFile; fileRef = 76F569AE7B444D8F69EE0E86; };
-		C6F08BF3EF53274A42BB88EB = { isa = PBXBuildFile; fileRef = 9BC055494F9FEE3F90630541; };
-		790911EDF00A4BF77327D99A = { isa = PBXBuildFile; fileRef = 48E12736F471C43C959AD15C; };
-		DDDFAE2042D8AD20CC78CE3C = { isa = PBXBuildFile; fileRef = 3753B3B311AE0A9F4CC5AD40; };
-		582C224AA50C9395810C8E27 = { isa = PBXBuildFile; fileRef = 308F614D30DCB9AE3767C928; };
-		704484388E63CDE33491E1AB = { isa = PBXBuildFile; fileRef = 39464D2A22940DA2DDCCCFC6; };
-		1691EC0AC4C7083D65B925E2 = { isa = PBXBuildFile; fileRef = 9D78F50147005EDB0E89E2B4; };
-		AD032CEA5DBE4D4C76D3D2D1 = { isa = PBXBuildFile; fileRef = D38E60AC4854B6E1EDE488EB; };
-		9E8544C3983B3203530B5A49 = { isa = PBXBuildFile; fileRef = CD2370F8F4A44446558A08FB; };
-		685151FF4FB872983524A5C3 = { isa = PBXBuildFile; fileRef = DAA04A0FD47097893712B241; };
-		627C7B84F5FD275FAF43663A = { isa = PBXBuildFile; fileRef = 2D41C43686CDE35E86A389D7; };
-		C59764685E62E7C4D323F84B = { isa = PBXBuildFile; fileRef = EA535EA158451360B7B8AE52; };
-		E4DA638CDD4DD574A6CD843E = { isa = PBXBuildFile; fileRef = 258938780F93A7CF41366F26; };
-		2B4A80DCF867DC025C21966B = { isa = PBXBuildFile; fileRef = 4867923F31CC3EDC9B1A5BE5; };
-		D0E9E20F9D8FDA700BB6D820 = { isa = PBXBuildFile; fileRef = 2C4730CAFED4F6292B575318; };
-		89223664B6CB2A912E36B091 = { isa = PBXBuildFile; fileRef = F115ED75E977A54AAF036B2C; };
-		30530D3307A5202B71B3D751 = { isa = PBXBuildFile; fileRef = 08618BD1F5343B5E6457237F; };
-		19BB86C918F89D1377F8A0E1 = { isa = PBXBuildFile; fileRef = 5894D40A0E8FA6E9B3EBF9D9; };
-		EE56A6BBBFA4A27A4BCF7279 = { isa = PBXBuildFile; fileRef = A7D4C9E3ED3763847C087F46; };
-		1B620FC17AAECA4C5DE741E2 = { isa = PBXBuildFile; fileRef = 66463AB11EA4D6341C32F27E; };
-		5570682BF1A39FB3E3FAC182 = { isa = PBXBuildFile; fileRef = 4A94E809624F99387E600399; };
-		ED8CB527B27C67E9E4DA027C = { isa = PBXBuildFile; fileRef = BC3B7E4E25505D9044BFACC7; };
-		DE758AF46844DF951655966C = { isa = PBXBuildFile; fileRef = B27F558F42AC78F0E564B5AF; };
-		80E5365461A5A7A32C48C563 = { isa = PBXBuildFile; fileRef = F94DD42C7BBF81C101D3F605; };
-		155C4E1F4B91745239F99C8A = { isa = PBXBuildFile; fileRef = 3F45F344950087E1266A6445; };
-		5E296916472899325DFFC828 = { isa = PBXBuildFile; fileRef = 7BF1DCDC30FDFBFAF03516C1; };
-		BEACD5086C04D68470944B72 = { isa = PBXBuildFile; fileRef = A77E8538ED93AAADC9FE2646; };
-		BECDDBEE5F3E0B715BC91F39 = { isa = PBXBuildFile; fileRef = 42C88F6EE487194784FD1D6F; };
-		65C47CAEC038F5C9FAC6811D = { isa = PBXBuildFile; fileRef = 58BBDECD171E15D0768302A1; };
-		DD77A0AB68C932F294B753C2 = { isa = PBXBuildFile; fileRef = 7B7819A5759B54D91E334447; };
-		8EF485897B3A20D8E6AC3B40 = { isa = PBXBuildFile; fileRef = 8B8C25A8261F0A21369FB9D8; };
-		A3CF90DE56808A47519FC101 = { isa = PBXBuildFile; fileRef = 07BEF02C2B930DF7847C2921; };
-		029C3B11BE586DA100895A60 = { isa = PBXBuildFile; fileRef = 28CCF04CCC028BAE0AEE5840; };
-		52E0D9DC7F5C4703257D8BEB = { isa = PBXBuildFile; fileRef = B083B1375828610D55F12CF3; };
-		EA46BA3970E958013FF85690 = { isa = PBXBuildFile; fileRef = 4B0097003751A59A11FA8C5B; };
-		88B896EB9793E0C44410D981 = { isa = PBXBuildFile; fileRef = 75B1E4EFCDA9A506CFEDB09F; };
-		6272253EB0051C1F215CD4D9 = { isa = PBXBuildFile; fileRef = 25A9484825F1B93ABC0E577F; };
-		AF26E388BF6536803E762CB1 = { isa = PBXBuildFile; fileRef = 45D78C8EF660EECE64BAA33F; };
-		0CEFF81CD8861F959DB13362 = { isa = PBXBuildFile; fileRef = 1552007C6C6AF750278C5BE5; };
-		352F3875222B1D233013AAF9 = { isa = PBXBuildFile; fileRef = 9C39C584DA6F507E773687EE; };
-		F0EC60AEFAFF3D289F8110BE = { isa = PBXBuildFile; fileRef = C5ABE6BDCA91410BA92A7BD9; };
-		C3406F00595AEFF068EDB162 = { isa = PBXBuildFile; fileRef = 169F1B20FC9FFE88C53D2735; };
-		3A2E957EB8D117C535F119E9 = { isa = PBXBuildFile; fileRef = 1AD76E8111A738A8F3717060; };
-		52AE3F7AEED81BA9ED5C4830 = { isa = PBXBuildFile; fileRef = E216D095C98F850A5FB6FB0F; };
-		3933895CA488855A23943F61 = { isa = PBXBuildFile; fileRef = 46E3A634686BFEF787229582; };
-		AF67C81811F18FCE6AA9C895 = { isa = PBXBuildFile; fileRef = 1EC95CD1D830F6D85ADB3B9D; };
-		AA16BE5A6BBD024C8FCFCDA8 = { isa = PBXBuildFile; fileRef = CAA3B9396EA62166234DAEF1; };
-		992137E90F9D41522FD56875 = { isa = PBXBuildFile; fileRef = 29FD7B383C5DDACAA7B8DFD3; };
-		7F188166D38DA7FB23311413 = { isa = PBXBuildFile; fileRef = 04C6B933E1603B4D0916570D; };
-		A454D138EC507C01D299AB0F = { isa = PBXBuildFile; fileRef = C79249376E3FDF10615E16EA; };
-		784125612E2B7AC6CD89D835 = { isa = PBXBuildFile; fileRef = 70151263C4CB8A4F79431E11; };
-		21539690A9A5DD20AFAF41D3 = { isa = PBXBuildFile; fileRef = 9136BD46BE1E28A96FBBD440; };
-		0836C50051EF59BF91D7B12D = { isa = PBXBuildFile; fileRef = 8A91849BE6B96EB8C0663469; };
-		55CD2E9F373B69C3E8363B78 = { isa = PBXBuildFile; fileRef = 6328434A329C353DB8D9512C; };
-		2B29D90B985E9EB788472EFE = { isa = PBXBuildFile; fileRef = D51315B4241B019BE43EE4F1; };
-		D0873C347977633B4421B94D = { isa = PBXBuildFile; fileRef = A252FE4E6A360CBC4AF694B3; };
-		BF3254F07C15D467D6DB3FEF = { isa = PBXBuildFile; fileRef = 10BE33089BA6F3468F36CD6C; };
-		6029B20DF2BD523AC0F78896 = { isa = PBXBuildFile; fileRef = D90290A0AA2C36CE757E46D5; };
-		6702EEA4E99D503C0EE933C4 = { isa = PBXBuildFile; fileRef = D3AE8303545E28D793312F46; };
-		89FCE8890946693CD5FC4A70 = { isa = PBXBuildFile; fileRef = 235A8987D99A191D07208D2F; };
-		C9AC286A46B3A1318F298DEF = { isa = PBXBuildFile; fileRef = ECB5A75A81B90327F58CBD9E; };
-		DA836EC803E4FF4EDEBE6386 = { isa = PBXBuildFile; fileRef = 2D2BAC4320470CF68743F58E; };
-		702C9BFCE865CB6C6B8BFB0D = { isa = PBXBuildFile; fileRef = 5DB3B3197F8C1E5EE159D6FC; };
-		739573501D1D440A72C5C2E5 = { isa = PBXBuildFile; fileRef = A3FB0EA0264580F6B00D993B; };
-		955561F4FF4484648FDB9F73 = { isa = PBXBuildFile; fileRef = 1718EC50691D8421EC00F8B3; };
-		6B67D7B6301182C7621294B6 = { isa = PBXBuildFile; fileRef = FA23A1334E4CFA77BC18A153; };
-		FAE745870674A07A65690433 = { isa = PBXBuildFile; fileRef = 788F8B7719B70465762B634B; };
-		24CC7E9A7E87F762D4AB0467 = { isa = PBXBuildFile; fileRef = 92602D7166325C7232B85EDD; };
-		66F3B79BDF9BFB631D7E3584 = { isa = PBXBuildFile; fileRef = A4E2CAAF556D557B24182414; };
-		996F9E4989EB47941D8100DA = { isa = PBXBuildFile; fileRef = 5522973FA48A13C6BED293FE; };
-		BE54C019A73BBAE05BFD7D17 = { isa = PBXBuildFile; fileRef = A98A22CF5F208ED6DBE08063; };
-		5AE42EF7A713B1EC0ACF9EDE = { isa = PBXBuildFile; fileRef = B0E8FAD5AC445F612E3468B9; };
-		71111DE81104B1536ECB6DFB = { isa = PBXBuildFile; fileRef = ECA6FDB1366BE7EC30F1539B; };
-		85A60568B3DC342C76B4E679 = { isa = PBXBuildFile; fileRef = 3AE038CACE48AF85C4FB1ED5; };
-		8A5BACA019DA9B0EFAD5CE93 = { isa = PBXBuildFile; fileRef = 555D34D0CD8776EE5996CC3A; };
-		D499273B65D901D0A101CAAA = { isa = PBXBuildFile; fileRef = E5C1D021C0FD6FAD082C5D75; };
-		95AE939ADE096394CCD2526F = { isa = PBXBuildFile; fileRef = 9F3B3184EC6D42CEA35D6ED8; };
-		E85DA5FC9A162F129ABA7113 = { isa = PBXBuildFile; fileRef = 0987F7E90136D0E08A606A22; };
-		6A13D8F42A330E2C410B43E3 = { isa = PBXBuildFile; fileRef = 7E875E681E18D693D5ADB2FB; };
-		13F1111511DD01E843E631CA = { isa = PBXBuildFile; fileRef = 79C91DDF3BC3F15D0338E504; };
-		9A80E3D1D1758A31D2169497 = { isa = PBXBuildFile; fileRef = 3774BBCA6CB133D9A854CF71; };
-		F4397EAE00E0B9F96C8B6C07 = { isa = PBXBuildFile; fileRef = 17E13CCDA0C82F92EAB05BE6; };
-		09673DA3B4D6EA61DEFC0C46 = { isa = PBXBuildFile; fileRef = 47A3942AC30A3212C01F1CAF; };
-		591CED1277A8C945EF60841C = { isa = PBXBuildFile; fileRef = 7BD2C39F13FDE202141C4B41; };
-		0987D2A72DD60B4A7D719707 = { isa = PBXBuildFile; fileRef = 94AED5D544719B438B3EE723; };
-		58D3FF3B1F462634167BDFB5 = { isa = PBXBuildFile; fileRef = 610E487E060C42B52FD5AAC9; };
-		3162B66BC8118715AAA527D7 = { isa = PBXBuildFile; fileRef = D2A3B4CDD296B4CEC6902FD7; };
-		004E78BC139419671A9EA137 = { isa = PBXBuildFile; fileRef = E08E877C3A6283CF5C803957; };
-		6306AA945375749C4FE834E6 = { isa = PBXBuildFile; fileRef = 2C89EC72FF6A7118EF459DC3; };
-		AD7D05519200FB0EE1C7617A = { isa = PBXBuildFile; fileRef = A512C5B237A77EF6FB8E11A0; };
-		C2475E008FEB33B3EA7B6C7F = { isa = PBXBuildFile; fileRef = DF3C9A1DD67E879E4E0A2727; };
-		9227961C07C0EE73E89C90B5 = { isa = PBXBuildFile; fileRef = 65F4459CC1832883FFF6C166; };
-		A2EE65335FB2810C04ECBFAF = { isa = PBXBuildFile; fileRef = 6B28CEAF75E22F2CCCACBCC7; };
-		3FF289281D3318A7BA8BB44D = { isa = PBXBuildFile; fileRef = B20469D88488F0809126CC80; };
-		9E30156DBCE4EAF9EFAF0AC4 = { isa = PBXBuildFile; fileRef = 56728EC77C65482B9C86FF4D; };
-		6510492BAE00C95DC620F493 = { isa = PBXBuildFile; fileRef = A6A579E4E4AEA865BC71148C; };
-		06BCB79AE267E5841F641E38 = { isa = PBXBuildFile; fileRef = 488D1B00C9E5FE4DAB035EDF; };
-		A0DAD4E5F7583349DC9275F2 = { isa = PBXBuildFile; fileRef = DBCA7E2FFCFD1354DD19DDD6; };
-		FCB767F14565886C9D823916 = { isa = PBXBuildFile; fileRef = C29E664781AA2396C8D59543; };
-		7015D104F55D5B128341CEA8 = { isa = PBXBuildFile; fileRef = BBDFB328C3D5FC72A0446E6A; };
-		A269A876BDF3B7011FA4C681 = { isa = PBXBuildFile; fileRef = 23609D430A25F54723269E91; };
-		58E0EC510F2A88E14AE55439 = { isa = PBXBuildFile; fileRef = 27DC0E650D6D54DF29E6DB68; };
-		002427B013C43CE3E6D4E9B5 = { isa = PBXBuildFile; fileRef = 5915DB02FB7CA8CEC1BF38A9; };
-		FA2A052548AAD146F3F5AD83 = { isa = PBXBuildFile; fileRef = 4A7695E93CE32F4E95042FCB; };
-		0052A4FD257928E5D83927E6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_WavAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		00A54510EFB9B0966D0B430C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PulsePalOutputEditor.h; path = ../../Source/Processors/Editors/PulsePalOutputEditor.h; sourceTree = "SOURCE_ROOT"; };
-		01859D6E7D95E44BD8E17D91 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_cryptography/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		018F4E079EB12A78C4F8F773 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiBuffer.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiBuffer.h"; sourceTree = "SOURCE_ROOT"; };
-		01C313C323E5CB995C939E0B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Component.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Component.cpp"; sourceTree = "SOURCE_ROOT"; };
-		01D791730840EB0BA7FD61BA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Socket.h"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_Socket.h"; sourceTree = "SOURCE_ROOT"; };
-		020205BB77179A9BE3FFF1E1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_QuickTimeMovieComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_video/native/juce_win32_QuickTimeMovieComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0242AB5BCD8C002DC2E30BAC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiOutput.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiOutput.h"; sourceTree = "SOURCE_ROOT"; };
-		027C1143CC66EA8F73C39A74 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ThreadWithProgressWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ThreadWithProgressWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		0287B009511521BEAAE8A52C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataThread.h; path = ../../Source/Processors/DataThreads/DataThread.h; sourceTree = "SOURCE_ROOT"; };
-		028D4D3C0862B4B1312E2395 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SourceNodeEditor.h; path = ../../Source/Processors/Editors/SourceNodeEditor.h; sourceTree = "SOURCE_ROOT"; };
-		02DA588D3B873F1971ACD912 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FlacAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0316B49B86725305C70783CA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioPluginFormatManager.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		033AE5DE19F0EEDC47D41C80 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileChooserDialogBox.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooserDialogBox.cpp"; sourceTree = "SOURCE_ROOT"; };
-		03D7B457E0915E43A6AFF4B4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioUnitPluginFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		04C474E0F2F7FDEC714A673C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PathIterator.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathIterator.cpp"; sourceTree = "SOURCE_ROOT"; };
-		04C6B933E1603B4D0916570D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ImageIcon.cpp; path = ../../Source/Processors/Editors/ImageIcon.cpp; sourceTree = "SOURCE_ROOT"; };
-		04ED2387517934A84ACF9865 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BubbleComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_BubbleComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		05997833A4AA137FD64348AD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextDragAndDropTarget.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_TextDragAndDropTarget.h"; sourceTree = "SOURCE_ROOT"; };
-		05BD169B8574607A6F6AD3B6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Identifier.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_Identifier.cpp"; sourceTree = "SOURCE_ROOT"; };
-		05C35036E964AAD6024E0766 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerA-01.png"; path = "../../Resources/Images/Buttons/MergerA-01.png"; sourceTree = "SOURCE_ROOT"; };
-		05DCAE8CA29532E2169D7AC1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Matrix3D.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Matrix3D.h"; sourceTree = "SOURCE_ROOT"; };
-		06072EC6BCD3B7D8C17C2402 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioProcessor.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		078625CF5C083AD538D23401 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioCDReader.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_cd/juce_AudioCDReader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0790CCE2FCFDFA6944DFC402 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PopupMenu.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_PopupMenu.cpp"; sourceTree = "SOURCE_ROOT"; };
-		07BEF02C2B930DF7847C2921 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SerialInputEditor.cpp; path = ../../Source/Processors/Editors/SerialInputEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		07FD5E530E9E6BFB2ACA4B8C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_audio_formats.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/juce_audio_formats.h"; sourceTree = "SOURCE_ROOT"; };
-		081E86FE0B991469CFA8D7EA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CPlusPlusCodeTokeniser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CPlusPlusCodeTokeniser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		085F51FEE5C5FDAA321090A0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CachedComponentImage.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_CachedComponentImage.h"; sourceTree = "SOURCE_ROOT"; };
-		08618BD1F5343B5E6457237F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDetectCanvas.cpp; path = ../../Source/Processors/Visualization/SpikeDetectCanvas.cpp; sourceTree = "SOURCE_ROOT"; };
-		087FA26464FB283EC6FD4795 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_NamedPipe.cpp"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_NamedPipe.cpp"; sourceTree = "SOURCE_ROOT"; };
-		08907A4BA0D5628476D19C48 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RelativePointPath.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePointPath.cpp"; sourceTree = "SOURCE_ROOT"; };
-		08A7A7FD7D77C0657270E9BF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DrawableText.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableText.cpp"; sourceTree = "SOURCE_ROOT"; };
-		08DAD5894A480950C66F5873 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ArrowButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ArrowButton.h"; sourceTree = "SOURCE_ROOT"; };
-		09160DF53438B400BFE85E07 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_InputSource.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_InputSource.h"; sourceTree = "SOURCE_ROOT"; };
-		0987F7E90136D0E08A606A22 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SignalChainManager.cpp; path = ../../Source/UI/SignalChainManager.cpp; sourceTree = "SOURCE_ROOT"; };
-		09A159213372995F3CCEB85B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_String.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_String.h"; sourceTree = "SOURCE_ROOT"; };
-		09BCBD414282A3AA4F66A3A5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Cascade.cpp; path = ../../Source/Dsp/Cascade.cpp; sourceTree = "SOURCE_ROOT"; };
-		0A2AD4AB14F93364EFB9611E = { isa = PBXFileReference; lastKnownFileType = file.ttf; name = "miso-regular.ttf"; path = "../../Resources/Fonts/miso-regular.ttf"; sourceTree = "SOURCE_ROOT"; };
-		0A351ED88CF00C0697701E73 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Logger.h"; path = "../../JuceLibraryCode/modules/juce_core/logging/juce_Logger.h"; sourceTree = "SOURCE_ROOT"; };
-		0A413228C75C046CE683E0E6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_String.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_String.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0A42FFB89531588E51762D3E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Audio.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_android_Audio.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0A46EF94E558D5E19F96E646 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Timer.cpp"; path = "../../JuceLibraryCode/modules/juce_events/timers/juce_Timer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0A8BC957DBEE226346C1EA25 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BigInteger.cpp"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_BigInteger.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0AA8F001A50408977E76ED96 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RecentlyOpenedFilesList.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_RecentlyOpenedFilesList.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0AAFE3F4D106138401C190C5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GlowEffect.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/effects/juce_GlowEffect.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0B2502A656E77E00AF15A343 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ApplicationCommandInfo.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandInfo.h"; sourceTree = "SOURCE_ROOT"; };
-		0B2B7732073D56E484950C8D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RecordControlEditor.h; path = ../../Source/Processors/Editors/RecordControlEditor.h; sourceTree = "SOURCE_ROOT"; };
-		0B382285EEDD8A3FDB45C074 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ThreadPool.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ThreadPool.h"; sourceTree = "SOURCE_ROOT"; };
-		0B5B63E563EFA7E816DE3DCA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OutputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_OutputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		0BB4380EDFEAAE0DAB255B90 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BlowFish.cpp"; path = "../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_BlowFish.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0BCAC20DAB10B957168B85D6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Result.h"; path = "../../JuceLibraryCode/modules/juce_core/misc/juce_Result.h"; sourceTree = "SOURCE_ROOT"; };
-		0BF3932F3EA1149C2F7E31F9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_IPAddress.cpp"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_IPAddress.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0C646E9950FB580B21E1F2BD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_WindowsMediaAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WindowsMediaAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0CCB1C4D687001E04DE1DD9C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SubregionStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_SubregionStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0CCE619599DB39323E49FF3C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ResamplingNodeEditor.h; path = ../../Source/Processors/Editors/ResamplingNodeEditor.h; sourceTree = "SOURCE_ROOT"; };
-		0D3C20D1F00B7B1381E6B987 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TabbedButtonBar.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedButtonBar.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0D884C2CF25F23CE6B99B2A1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Singleton.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_Singleton.h"; sourceTree = "SOURCE_ROOT"; };
-		0D8ECE32F7D0FE74185F6EF4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PropertyPanel.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyPanel.h"; sourceTree = "SOURCE_ROOT"; };
-		0DBB88B6BEC06FCECE4CBD28 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ApplicationCommandInfo.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandInfo.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0DD0CBF9BBD4A503F2B7868D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ListenerList.h"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ListenerList.h"; sourceTree = "SOURCE_ROOT"; };
-		0DE9D2FE41553B4D4316DD55 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DirectoryIterator.cpp"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_DirectoryIterator.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0E4B0B8425DBA19B6F3FE4BF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_UIViewComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/embedding/juce_UIViewComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		0E98E81084F183B8426EDA7F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DynamicObject.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_DynamicObject.h"; sourceTree = "SOURCE_ROOT"; };
-		0FA84E49DB493BCC886A355F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MD5.h"; path = "../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_MD5.h"; sourceTree = "SOURCE_ROOT"; };
-		0FDD7551AC98348D4A98ADC7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ProcessorGraph.h; path = ../../Source/Processors/ProcessorGraph.h; sourceTree = "SOURCE_ROOT"; };
-		0FE8ACC50ED8E7FFC9E6B9B4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ControlPanel.h; path = ../../Source/UI/ControlPanel.h; sourceTree = "SOURCE_ROOT"; };
-		105B1452DF6CE1D80D69A9D1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ProcessorList.h; path = ../../Source/UI/ProcessorList.h; sourceTree = "SOURCE_ROOT"; };
-		106E81B939C6B35E34DD71FE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CodeEditorComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		1086169B0EE86E04B64575C2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Dsp.h; path = ../../Source/Dsp/Dsp.h; sourceTree = "SOURCE_ROOT"; };
-		108DF32ADFBA5CA48F928A92 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_File.h"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_File.h"; sourceTree = "SOURCE_ROOT"; };
-		10BE33089BA6F3468F36CD6C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioEditor.cpp; path = ../../Source/Processors/Editors/AudioEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		113404D3FDE3745DF1E8D014 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ReadWriteLock.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ReadWriteLock.h"; sourceTree = "SOURCE_ROOT"; };
-		1191BF3048664183033BFF89 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DropShadowEffect.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/effects/juce_DropShadowEffect.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1194EE0956A9645270582979 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Messaging.cpp"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_android_Messaging.cpp"; sourceTree = "SOURCE_ROOT"; };
-		11A5824E0239C86801BE2EB8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MouseEvent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseEvent.h"; sourceTree = "SOURCE_ROOT"; };
-		11D619EEF63C1827EA91F593 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_UndoManager.cpp"; path = "../../JuceLibraryCode/modules/juce_data_structures/undomanager/juce_UndoManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1246C8A62803B7E115713705 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_LocalisedStrings.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_LocalisedStrings.cpp"; sourceTree = "SOURCE_ROOT"; };
-		12B5243A9435FABAFBE20165 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Quaternion.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Quaternion.h"; sourceTree = "SOURCE_ROOT"; };
-		12B5DDCB6E5ECD93A4C55BB5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpDisplayCanvas.h; path = ../../Source/Processors/Visualization/LfpDisplayCanvas.h; sourceTree = "SOURCE_ROOT"; };
-		12BE9C084DEC40230DA8E9A6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ISCANeditor.h; path = ../../Source/Processors/Editors/ISCANeditor.h; sourceTree = "SOURCE_ROOT"; };
-		1307DAE32BA702565A67D127 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiFile.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiFile.cpp"; sourceTree = "SOURCE_ROOT"; };
-		13212C01A5E138553FAFBE9C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Drawable.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_Drawable.cpp"; sourceTree = "SOURCE_ROOT"; };
-		13D9868B08E941F6827E157C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ResizableWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ResizableWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		13D9DC48F19699485F9888A4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PathIterator.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathIterator.h"; sourceTree = "SOURCE_ROOT"; };
-		1463D2DAB3A1D8CEE825056A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioCDReader.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_cd/juce_AudioCDReader.h"; sourceTree = "SOURCE_ROOT"; };
-		146C6A6E3C6B17F2AF475B50 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLFrameBuffer.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLFrameBuffer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		14DD0220B41F74C01A9DC676 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_GlyphArrangement.h"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_GlyphArrangement.h"; sourceTree = "SOURCE_ROOT"; };
-		14F594C425F332F455A16D35 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = okFrontPanelDLL.h; path = "../../Source/Processors/DataThreads/rhythm-api/okFrontPanelDLL.h"; sourceTree = "SOURCE_ROOT"; };
-		14FE601229C9A40C6E182F28 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_MouseCursor.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_MouseCursor.mm"; sourceTree = "SOURCE_ROOT"; };
-		1518D2BA7FCAF267EF1F02E6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Windowing.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_win32_Windowing.cpp"; sourceTree = "SOURCE_ROOT"; };
-		154303EE3929F26B93792187 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SourceNode.h; path = ../../Source/Processors/SourceNode.h; sourceTree = "SOURCE_ROOT"; };
-		1552007C6C6AF750278C5BE5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordControlEditor.cpp; path = ../../Source/Processors/Editors/RecordControlEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		15870472BA2B1779521A21BD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ElectrodeButtons.h; path = ../../Source/Processors/Editors/ElectrodeButtons.h; sourceTree = "SOURCE_ROOT"; };
-		159790C750B1F8B485DBB499 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_FileChooser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_win32_FileChooser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		161E095C716133CB255B6CCD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiKeyboardState.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiKeyboardState.h"; sourceTree = "SOURCE_ROOT"; };
-		167524110873F9888CF1B9E8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ApplicationCommandID.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandID.h"; sourceTree = "SOURCE_ROOT"; };
-		168823A9EBD85BFBFD2CE2EE = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-03.png"; path = "../../Resources/Images/Icons/RadioButtons-03.png"; sourceTree = "SOURCE_ROOT"; };
-		169F1B20FC9FFE88C53D2735 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FPGAOutputEditor.cpp; path = ../../Source/Processors/Editors/FPGAOutputEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		1712916024EC787B6C231732 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-03.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-03.png"; sourceTree = "SOURCE_ROOT"; };
-		1718EC50691D8421EC00F8B3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileReaderThread.cpp; path = ../../Source/Processors/DataThreads/FileReaderThread.cpp; sourceTree = "SOURCE_ROOT"; };
-		1719507D8A73EA71F1C3F306 = { isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-plain-serialized"; path = "../../Resources/Fonts/cpmono-plain-serialized"; sourceTree = "SOURCE_ROOT"; };
-		172FA5C9EC4B16BC0C45F269 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Variant.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_Variant.h"; sourceTree = "SOURCE_ROOT"; };
-		174842EA681FA29BE38A6272 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ButtonPropertyComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ButtonPropertyComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1777330D3BDAE99A93F98943 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Font.h"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Font.h"; sourceTree = "SOURCE_ROOT"; };
-		178AD28BF5BC92B58A3A3539 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MixerAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_MixerAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		17B29FF3D3EA14EF2BE149BB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentBoundsConstrainer.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBoundsConstrainer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		17CACEC7EA0A4B55A06A0993 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiDataConcatenator.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_MidiDataConcatenator.h"; sourceTree = "SOURCE_ROOT"; };
-		17CE6B2913E72ED8727ECD56 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioResamplingNode.h; path = ../../Source/Processors/AudioResamplingNode.h; sourceTree = "SOURCE_ROOT"; };
-		17E13CCDA0C82F92EAB05BE6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = InfoLabel.cpp; path = ../../Source/UI/InfoLabel.cpp; sourceTree = "SOURCE_ROOT"; };
-		17FB020EFEAED8493D3CB121 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ToolbarItemComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		1819C1C4DE5FEEDEA143E3D2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_MainMenu.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_MainMenu.mm"; sourceTree = "SOURCE_ROOT"; };
-		18A730DF335EEB3A4D13FDCA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MessageManager.cpp"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_MessageManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		18B410DA5435C02C82BA13F8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BooleanPropertyComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_BooleanPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		18C2F9CA38393D106FB834E2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioPluginFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		18CFDBCD4A5B80E78DADCFEB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RectanglePlacement.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/placement/juce_RectanglePlacement.cpp"; sourceTree = "SOURCE_ROOT"; };
-		19043050D1DADAEAB48FB803 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioCDBurner.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_cd/juce_AudioCDBurner.h"; sourceTree = "SOURCE_ROOT"; };
-		19148DBA36B94FA639DF3A72 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CustomLookAndFeel.h; path = ../../Source/UI/CustomLookAndFeel.h; sourceTree = "SOURCE_ROOT"; };
-		193FED8339417E8E6264957A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ElementComparator.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_ElementComparator.h"; sourceTree = "SOURCE_ROOT"; };
-		1989E86F8DFDE34887AC0326 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Bessel.cpp; path = ../../Source/Dsp/Bessel.cpp; sourceTree = "SOURCE_ROOT"; };
-		19A8A8E1BF043B390E02C429 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Messaging.cpp"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_linux_Messaging.cpp"; sourceTree = "SOURCE_ROOT"; };
-		19AB6653E818B409554C5606 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ScopedValueSetter.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_ScopedValueSetter.h"; sourceTree = "SOURCE_ROOT"; };
-		1A22BB28E65B6D6636CCEBF1 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-02.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-02.png"; sourceTree = "SOURCE_ROOT"; };
-		1AD76E8111A738A8F3717060 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ArduinoOutputEditor.cpp; path = ../../Source/Processors/Editors/ArduinoOutputEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		1AEEC114AFAB6E81205FBCD1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AttributedString.h"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_AttributedString.h"; sourceTree = "SOURCE_ROOT"; };
-		1B27BF1CF3F235A55CD5107D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ResamplingAudioSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ResamplingAudioSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1BF01252E3A30560525CE057 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_WebBrowserComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_win32_WebBrowserComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1C474C73937D98E9D3FFEEC0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FilePreviewComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FilePreviewComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		1C639F4C139C8D7753AA9BB6 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_gui_extra/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		1C93ECD2B04F39923E66B529 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ReferenceNodeEditor.h; path = ../../Source/Processors/Editors/ReferenceNodeEditor.h; sourceTree = "SOURCE_ROOT"; };
-		1CB0D7AC988EDEC838A1C546 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioSampleBuffer.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioSampleBuffer.h"; sourceTree = "SOURCE_ROOT"; };
-		1CCC1D4213B17ABF6222EC82 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PropertiesFile.cpp"; path = "../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_PropertiesFile.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1CFA355CD6811C253C72BDDA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_KeyPressMappingSet.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_KeyPressMappingSet.h"; sourceTree = "SOURCE_ROOT"; };
-		1D1ABA743E533A4B7A50DBB0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ReverbAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ReverbAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		1D7578F927EC030203A11978 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CodeDocument.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeDocument.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1D7FEC587CFE464A21830C4D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_SystemTrayIcon.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_win32_SystemTrayIcon.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1DF5FD417930A62110DF0419 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ModalComponentManager.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ModalComponentManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1E9FE44F0CCC6604B5469412 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_KeyMappingEditorComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_KeyMappingEditorComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1EC95CD1D830F6D85ADB3B9D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDisplayEditor.cpp; path = ../../Source/Processors/Editors/SpikeDisplayEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		1F12D1392E5DF34C3A3C445D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_NewLine.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_NewLine.h"; sourceTree = "SOURCE_ROOT"; };
-		205E9A5C31827555F1CAC30D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGL_osx.h"; path = "../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_osx.h"; sourceTree = "SOURCE_ROOT"; };
-		208DCD7025D0DF2740C01E4A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextPropertyComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_TextPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		20EB4F22A76954F2986F364A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_Windowing.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_Windowing.mm"; sourceTree = "SOURCE_ROOT"; };
-		215B159836CE40810964B773 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Uuid.h"; path = "../../JuceLibraryCode/modules/juce_core/misc/juce_Uuid.h"; sourceTree = "SOURCE_ROOT"; };
-		215E1BD79B5870D5356810F0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Visualizer.h; path = ../../Source/Processors/Visualization/Visualizer.h; sourceTree = "SOURCE_ROOT"; };
-		217032322A2570ABAC47194C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Image.h"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_Image.h"; sourceTree = "SOURCE_ROOT"; };
-		2196ED9DD4262C60135E77F5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpTriggeredAverageEditor.h; path = ../../Source/Processors/Editors/LfpTriggeredAverageEditor.h; sourceTree = "SOURCE_ROOT"; };
-		21A0260D2DB039B81DF4970C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileSearchPath.cpp"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_FileSearchPath.cpp"; sourceTree = "SOURCE_ROOT"; };
-		21C11A58CAA0F9E86AA204EC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Slider.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Slider.h"; sourceTree = "SOURCE_ROOT"; };
-		21D3C1095D2B5A834D998B74 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_OpenSL.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_android_OpenSL.cpp"; sourceTree = "SOURCE_ROOT"; };
-		222AC2E9BEFE12BE7FF88879 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Thread.cpp"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_Thread.cpp"; sourceTree = "SOURCE_ROOT"; };
-		22801F75289646F6A85E5583 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Biquad.cpp; path = ../../Source/Dsp/Biquad.cpp; sourceTree = "SOURCE_ROOT"; };
-		229989EC8A6F145C81348CA9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PhaseDetector.h; path = ../../Source/Processors/PhaseDetector.h; sourceTree = "SOURCE_ROOT"; };
-		235A8987D99A191D07208D2F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = okFrontPanelDLL.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/okFrontPanelDLL.cpp"; sourceTree = "SOURCE_ROOT"; };
-		23609D430A25F54723269E91 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_gui_basics.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/juce_gui_basics.mm"; sourceTree = "SOURCE_ROOT"; };
-		23A6BA852B71DAAF3F709428 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RHD2000Thread.h; path = ../../Source/Processors/DataThreads/RHD2000Thread.h; sourceTree = "SOURCE_ROOT"; };
-		23C7EA9C89CC98A5EFEC12FA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_GZIPCompressorOutputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPCompressorOutputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		23D82A4C165DD596474F30E4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ColourSelector.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_ColourSelector.h"; sourceTree = "SOURCE_ROOT"; };
-		23EAFAEA6457DB4E452F8715 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SignalGenerator.h; path = ../../Source/Processors/SignalGenerator.h; sourceTree = "SOURCE_ROOT"; };
-		23F048594D4C9AD8C3399877 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_SystemStats.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_android_SystemStats.cpp"; sourceTree = "SOURCE_ROOT"; };
-		243817BA562AD7FA76C834C9 = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMIDI.framework; path = System/Library/Frameworks/CoreMIDI.framework; sourceTree = SDKROOT; };
-		24D86195580EFB86AC084DCC = { isa = PBXFileReference; lastKnownFileType = file.otf; name = "cpmono_extra_light.otf"; path = "../../Resources/Fonts/cpmono_extra_light.otf"; sourceTree = "SOURCE_ROOT"; };
-		25433DB6D2EAEBB307EFB960 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_graphics/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		256E22D98B16B09BD521C4A4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioProcessorEditor.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		258938780F93A7CF41366F26 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordControl.cpp; path = ../../Source/Processors/Utilities/RecordControl.cpp; sourceTree = "SOURCE_ROOT"; };
-		25A9484825F1B93ABC0E577F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PulsePalOutputEditor.cpp; path = ../../Source/Processors/Editors/PulsePalOutputEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		25ABEB43042E98C668A16432 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDisplayEditor.h; path = ../../Source/Processors/Editors/SpikeDisplayEditor.h; sourceTree = "SOURCE_ROOT"; };
-		25DCA4D0E86DFB51AF637D21 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Midi.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_Midi.cpp"; sourceTree = "SOURCE_ROOT"; };
-		25F7BEADC001FA3D1EA9B32C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DrawablePath.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawablePath.cpp"; sourceTree = "SOURCE_ROOT"; };
-		261B5AA82F2A86CC5500D8D2 = { isa = PBXFileReference; lastKnownFileType = image.png; name = ArduinoIcon.png; path = ../../Resources/Images/Icons/ArduinoIcon.png; sourceTree = "SOURCE_ROOT"; };
-		265EDA19C88E74249FD66609 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SignalGeneratorEditor.h; path = ../../Source/Processors/Editors/SignalGeneratorEditor.h; sourceTree = "SOURCE_ROOT"; };
-		266FC6DA3123E576811DD828 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FlacAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		26FF78F12CCB8725C0DAF9C2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiInput.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiInput.h"; sourceTree = "SOURCE_ROOT"; };
-		27313EA12BC45638321922CA = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
-		27548017AB2ABAF17E1D5DF5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileInputSource.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_FileInputSource.h"; sourceTree = "SOURCE_ROOT"; };
-		27DC0E650D6D54DF29E6DB68 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_gui_extra.mm"; path = "../../JuceLibraryCode/modules/juce_gui_extra/juce_gui_extra.mm"; sourceTree = "SOURCE_ROOT"; };
-		2847E92BB432EEB9D5A59260 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StringArray.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_StringArray.h"; sourceTree = "SOURCE_ROOT"; };
-		284F3E94F0C96EA1DD89E606 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileFilter.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileFilter.cpp"; sourceTree = "SOURCE_ROOT"; };
-		28847C807E6B05303FB8FB34 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_Strings.mm"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_mac_Strings.mm"; sourceTree = "SOURCE_ROOT"; };
-		28CCF04CCC028BAE0AEE5840 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ElectrodeButtons.cpp; path = ../../Source/Processors/Editors/ElectrodeButtons.cpp; sourceTree = "SOURCE_ROOT"; };
-		28D5AEEEFC4FA8877419C829 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_posix_NamedPipe.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_posix_NamedPipe.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2924B990E35D3B51AA245978 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MessageListener.h"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_MessageListener.h"; sourceTree = "SOURCE_ROOT"; };
-		29381F22B8FDF48C3EAC3A9F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLPixelFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLPixelFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		29D7893C278FFE00782637B6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Bessel.h; path = ../../Source/Dsp/Bessel.h; sourceTree = "SOURCE_ROOT"; };
-		29FD7B383C5DDACAA7B8DFD3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MergerEditor.cpp; path = ../../Source/Processors/Editors/MergerEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		2A3230DEAAC86A9090950703 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Path.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Path.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2AB1CC4252DB09507ED31482 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Application.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/application/juce_Application.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2AE12F85965B8BE4A0E12F67 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PropertiesFile.h"; path = "../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_PropertiesFile.h"; sourceTree = "SOURCE_ROOT"; };
-		2B134713E91426120A994CB7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Random.cpp"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_Random.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2B19F2DE42A91F56C2380F9A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Expression.cpp"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_Expression.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2B93450006102A0093F5EACB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Design.cpp; path = ../../Source/Dsp/Design.cpp; sourceTree = "SOURCE_ROOT"; };
-		2BC005B37A0FB3179C2F3AC7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CoreAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		2C4730CAFED4F6292B575318 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Splitter.cpp; path = ../../Source/Processors/Utilities/Splitter.cpp; sourceTree = "SOURCE_ROOT"; };
-		2C89EC72FF6A7118EF459DC3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Main.cpp; path = ../../Source/Main.cpp; sourceTree = "SOURCE_ROOT"; };
-		2D1BF69121265C83C7937EB6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioIODevice.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h"; sourceTree = "SOURCE_ROOT"; };
-		2D20F49E12A7D313049E0258 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ScopedWriteLock.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ScopedWriteLock.h"; sourceTree = "SOURCE_ROOT"; };
-		2D27078AC6729A4B47C48099 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AdvancerEditor.h; path = ../../Source/Processors/Editors/AdvancerEditor.h; sourceTree = "SOURCE_ROOT"; };
-		2D2BAC4320470CF68743F58E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rhd2000evalboard.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000evalboard.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2D41C43686CDE35E86A389D7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WiFiOutput.cpp; path = ../../Source/Processors/WiFiOutput.cpp; sourceTree = "SOURCE_ROOT"; };
-		2D577016FEEE23DD5703C924 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DialogWindow.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DialogWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2DA0032B6DF10345C4842BF5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CharacterFunctions.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_CharacterFunctions.h"; sourceTree = "SOURCE_ROOT"; };
-		2F2EDBE0623561191234AF21 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_LAMEEncoderAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_LAMEEncoderAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2F8252D3FF527D6559B12615 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_LowLevelGraphicsSoftwareRenderer.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsSoftwareRenderer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2F9BB379BCFCFE0D88CC0408 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioProcessorGraph.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h"; sourceTree = "SOURCE_ROOT"; };
-		2FE6DAFB634FF3C20F1D6FD7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CaretComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_CaretComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		2FF422D0633A28558D0227EC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComponentBuilder.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBuilder.h"; sourceTree = "SOURCE_ROOT"; };
-		301783FC4E3B19CA3C0AC85B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LowLevelGraphicsSoftwareRenderer.h"; path = "../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsSoftwareRenderer.h"; sourceTree = "SOURCE_ROOT"; };
-		3063CF211ABB734A9FD452EC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Custom.h; path = ../../Source/Dsp/Custom.h; sourceTree = "SOURCE_ROOT"; };
-		3067867C8C0F6CF6F086A6FC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileReaderEditor.h; path = ../../Source/Processors/Editors/FileReaderEditor.h; sourceTree = "SOURCE_ROOT"; };
-		308F614D30DCB9AE3767C928 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ofSerial.cpp; path = ../../Source/Processors/Serial/ofSerial.cpp; sourceTree = "SOURCE_ROOT"; };
-		313970BBDAAA4EDC8B322F3A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentMovementWatcher.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentMovementWatcher.cpp"; sourceTree = "SOURCE_ROOT"; };
-		314955FB1E6DD74C71EB8907 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioFormatReaderSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReaderSource.h"; sourceTree = "SOURCE_ROOT"; };
-		316FB94579DA666A388F429A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_WildcardFileFilter.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_WildcardFileFilter.h"; sourceTree = "SOURCE_ROOT"; };
-		31A3925602D128195100B74D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ApplicationProperties.cpp"; path = "../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_ApplicationProperties.cpp"; sourceTree = "SOURCE_ROOT"; };
-		31BE5E435604D33173940048 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ToggleButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToggleButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		31FDA03EF1B527B336FA6263 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_events/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		32976762B1DB850DB65B9504 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileInputSource.cpp"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_FileInputSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		32A1325430309CF4114C9618 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GenericAudioProcessorEditor.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		32B658D7A44849A6F640AF37 = { isa = PBXFileReference; lastKnownFileType = file.ttf; name = "miso-bold.ttf"; path = "../../Resources/Fonts/miso-bold.ttf"; sourceTree = "SOURCE_ROOT"; };
-		32CEF6C84CD06B18035B035C = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-05.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-05.png"; sourceTree = "SOURCE_ROOT"; };
-		32D568631762765C07D4BF0D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_NSViewComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/embedding/juce_NSViewComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		33A69BDDCFCD4A4DC14A9961 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_KeyPress.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyPress.cpp"; sourceTree = "SOURCE_ROOT"; };
-		33EC8C48E03E5FB60DD9D4C5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkSinkProcotol.pb.cc; path = ../../Source/Processors/NetworkSinkProcotol.pb.cc; sourceTree = "SOURCE_ROOT"; };
-		349C9FCEDC32E73DCB7AE806 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_WindowsRegistry.h"; path = "../../JuceLibraryCode/modules/juce_core/misc/juce_WindowsRegistry.h"; sourceTree = "SOURCE_ROOT"; };
-		353937A4E68C8C6916C6D1F9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileBrowserComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		35AEAE0CC0B546625E163B9B = { isa = PBXFileReference; lastKnownFileType = image.png; name = "sine_wave.png"; path = "../../Resources/Images/Icons/sine_wave.png"; sourceTree = "SOURCE_ROOT"; };
-		35C0963BAB9A82F12CDC9F76 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_NamedValueSet.cpp"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_NamedValueSet.cpp"; sourceTree = "SOURCE_ROOT"; };
-		361D8C54B3E54766CBC48046 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Biquad.h; path = ../../Source/Dsp/Biquad.h; sourceTree = "SOURCE_ROOT"; };
-		361E3A46C9BFAD1530593487 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PopupMenu.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_PopupMenu.h"; sourceTree = "SOURCE_ROOT"; };
-		3663C981D28BF165C1B601A7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OptionalScopedPointer.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_OptionalScopedPointer.h"; sourceTree = "SOURCE_ROOT"; };
-		36A9736F04AAA2F8E9D711BB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SpinLock.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_SpinLock.h"; sourceTree = "SOURCE_ROOT"; };
-		3753B3B311AE0A9F4CC5AD40 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ofArduino.cpp; path = ../../Source/Processors/Serial/ofArduino.cpp; sourceTree = "SOURCE_ROOT"; };
-		3774BBCA6CB133D9A854CF71 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CustomLookAndFeel.cpp; path = ../../Source/UI/CustomLookAndFeel.cpp; sourceTree = "SOURCE_ROOT"; };
-		381F5DC605AE69088004DF80 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineB-01.png"; path = "../../Resources/Images/Buttons/PipelineB-01.png"; sourceTree = "SOURCE_ROOT"; };
-		38313692308D501E4CADF1D5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Layout.h; path = ../../Source/Dsp/Layout.h; sourceTree = "SOURCE_ROOT"; };
-		38711221C089A16CC29E93D2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ActionListener.h"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ActionListener.h"; sourceTree = "SOURCE_ROOT"; };
-		38A9627672C2562DBE257A05 = { isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-extralight-serialized"; path = "../../Resources/Fonts/cpmono-extralight-serialized"; sourceTree = "SOURCE_ROOT"; };
-		38B5A37F33AE3FB2014BF095 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_StringArray.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_StringArray.cpp"; sourceTree = "SOURCE_ROOT"; };
-		38E493BFC36AC80B1CDAAF35 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TreeView.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TreeView.h"; sourceTree = "SOURCE_ROOT"; };
-		390856DF83DAC70909D5B397 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Button.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_Button.h"; sourceTree = "SOURCE_ROOT"; };
-		390EA3109658E8C51EFC8F61 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PluginDirectoryScanner.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginDirectoryScanner.cpp"; sourceTree = "SOURCE_ROOT"; };
-		392408C1943AC6234BAAC743 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Elliptic.cpp; path = ../../Source/Dsp/Elliptic.cpp; sourceTree = "SOURCE_ROOT"; };
-		393801D2B91773D376D874B0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ImageButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ImageButton.h"; sourceTree = "SOURCE_ROOT"; };
-		39422C7D01635DD9C00B5136 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_mac_CoreMidi.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_CoreMidi.cpp"; sourceTree = "SOURCE_ROOT"; };
-		39464D2A22940DA2DDCCCFC6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EventDetector.cpp; path = ../../Source/Processors/EventDetector.cpp; sourceTree = "SOURCE_ROOT"; };
-		39D2C460FE587C5F564495A0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SerialInputEditor.h; path = ../../Source/Processors/Editors/SerialInputEditor.h; sourceTree = "SOURCE_ROOT"; };
-		39F287BE4C0B4F3BD4A949FD = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
-		3A2C762575D9728B1F822ED3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AsyncUpdater.cpp"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_AsyncUpdater.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3A6E9EC3DA618EBA06B9DEEB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioSubsectionReader.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioSubsectionReader.h"; sourceTree = "SOURCE_ROOT"; };
-		3A6FE617A781EEFFD39E1216 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-02.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-02.png"; sourceTree = "SOURCE_ROOT"; };
-		3A71F2C959CA7DD3C33DC411 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_mac_CarbonViewWrapperComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_CarbonViewWrapperComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		3A9826A8C3B668BCC760BEB7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_gui_basics.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/juce_gui_basics.h"; sourceTree = "SOURCE_ROOT"; };
-		3AC9B61C10692BBA96D2F775 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGL_android.h"; path = "../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_android.h"; sourceTree = "SOURCE_ROOT"; };
-		3AE038CACE48AF85C4FB1ED5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = GenericProcessor.cpp; path = ../../Source/Processors/GenericProcessor.cpp; sourceTree = "SOURCE_ROOT"; };
-		3AFF1BE2EC512169120121CF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_IPAddress.h"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_IPAddress.h"; sourceTree = "SOURCE_ROOT"; };
-		3B307527FC3241258EA68519 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ToneGeneratorAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ToneGeneratorAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		3BC3A723444252E177C1B1BD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioFormatWriter.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatWriter.h"; sourceTree = "SOURCE_ROOT"; };
-		3BEB59C6E8F833331C0783D5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_IIRFilter.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_IIRFilter.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3C18EC09535EA506FC0CBC62 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGL_ios.h"; path = "../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_ios.h"; sourceTree = "SOURCE_ROOT"; };
-		3C1E0B87DA3E9AC60D2894F7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TableListBox.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableListBox.h"; sourceTree = "SOURCE_ROOT"; };
-		3C92F249799E7CBF41FABEA0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_WebBrowserComponent.mm"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_WebBrowserComponent.mm"; sourceTree = "SOURCE_ROOT"; };
-		3D100F6FDB04756402F3BCC9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_mac_CoreGraphicsContext.h"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsContext.h"; sourceTree = "SOURCE_ROOT"; };
-		3DA70F9AAA904543B519874B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioPluginInstance.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioPluginInstance.h"; sourceTree = "SOURCE_ROOT"; };
-		3E0942A2D72F50FDE27C14AE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_StretchableObjectResizer.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableObjectResizer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3E22E947444B5849011B6C4E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MouseInputSource.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseInputSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3E5E427D405905C53A37283D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SystemAudioVolume.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_SystemAudioVolume.h"; sourceTree = "SOURCE_ROOT"; };
-		3EAE25787DBFBA8EFC42A277 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RecordNode.h; path = ../../Source/Processors/RecordNode.h; sourceTree = "SOURCE_ROOT"; };
-		3EAF57CE45DBACE2F88DA4C5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileChooser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3EE92345839A4E5F608D82AC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Sampler.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/sampler/juce_Sampler.h"; sourceTree = "SOURCE_ROOT"; };
-		3F3F8C49FB5AB1B91221845E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkEvents.h; path = ../../Source/Processors/NetworkEvents.h; sourceTree = "SOURCE_ROOT"; };
-		3F45F344950087E1266A6445 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = OscilloscopeEditor.cpp; path = ../../Source/Processors/Editors/OscilloscopeEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		3F56A025C4D83EBDB66E3676 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AppleRemote.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_AppleRemote.h"; sourceTree = "SOURCE_ROOT"; };
-		3F69480D6145C77992FA59BA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RootFinder.cpp; path = ../../Source/Dsp/RootFinder.cpp; sourceTree = "SOURCE_ROOT"; };
-		3F6C67E29CDEDF2EF61C054F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Param.cpp; path = ../../Source/Dsp/Param.cpp; sourceTree = "SOURCE_ROOT"; };
-		3F8DFB0DB8B82F0C2CFBCA05 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BufferingAudioSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_BufferingAudioSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3FA24B406E4A9F9F54421C6A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ChannelRemappingAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ChannelRemappingAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		3FB80C5CFD953986778DCBA2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Files.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_linux_Files.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3FC794735FA8DDA39A62224B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UIComponent.h; path = ../../Source/UI/UIComponent.h; sourceTree = "SOURCE_ROOT"; };
-		3FFC2A3429D8B1D957D18CA7 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerB-02.png"; path = "../../Resources/Images/Buttons/MergerB-02.png"; sourceTree = "SOURCE_ROOT"; };
-		3FFD5E5D5C1D8B48DBBB9D18 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Result.cpp"; path = "../../JuceLibraryCode/modules/juce_core/misc/juce_Result.cpp"; sourceTree = "SOURCE_ROOT"; };
-		402BC572EE3E8EC418946CE0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioTransportSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioTransportSource.h"; sourceTree = "SOURCE_ROOT"; };
-		405298E6CE1C80EC7CC43A87 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileTreeComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileTreeComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		40C22F3CD61DDB9C7B3DCCA6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_KeyListener.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyListener.h"; sourceTree = "SOURCE_ROOT"; };
-		4133FE7830C52BBA035D82B8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TimeSliceThread.cpp"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_TimeSliceThread.cpp"; sourceTree = "SOURCE_ROOT"; };
-		414D8E6E4EE98E66C2583A50 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TextPropertyComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_TextPropertyComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		416B99B14B44CB16B725C4B2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StretchableObjectResizer.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableObjectResizer.h"; sourceTree = "SOURCE_ROOT"; };
-		4179FCF100DC52282D0F9753 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_JSON.h"; path = "../../JuceLibraryCode/modules/juce_core/json/juce_JSON.h"; sourceTree = "SOURCE_ROOT"; };
-		41AF61914A96159E9EA194B0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Clipboard.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_linux_Clipboard.cpp"; sourceTree = "SOURCE_ROOT"; };
-		420843E39C285B620B220C1D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LeakedObjectDetector.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_LeakedObjectDetector.h"; sourceTree = "SOURCE_ROOT"; };
-		420B0E95F1300ABFDC125DBF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AccessClass.cpp; path = ../../Source/AccessClass.cpp; sourceTree = "SOURCE_ROOT"; };
-		42BF0530EADF336E58D39CD3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FloatVectorOperations.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.h"; sourceTree = "SOURCE_ROOT"; };
-		42C88F6EE487194784FD1D6F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AdvancerEditor.cpp; path = ../../Source/Processors/Editors/AdvancerEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		43420911407CC35CE2A02B38 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_StretchableLayoutManager.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		434E153E6C8337C1E4A2709A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ButtonPropertyComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ButtonPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		4434939E139A45962C8CFB4C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DrawableShape.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableShape.cpp"; sourceTree = "SOURCE_ROOT"; };
-		44E04E5F584A8BFAD062A09D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ShapeButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ShapeButton.h"; sourceTree = "SOURCE_ROOT"; };
-		45258533F9F65AC96D3080B3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MultiTouchMapper.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_MultiTouchMapper.h"; sourceTree = "SOURCE_ROOT"; };
-		4540694F9744C9F4D29149CE = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_opengl/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		455FFBB0C34B760D892D2D57 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLPixelFormat.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLPixelFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		45883809F1335E6C745F8155 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ModalComponentManager.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ModalComponentManager.h"; sourceTree = "SOURCE_ROOT"; };
-		458A112D564ED066211FD482 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ToneGeneratorAudioSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ToneGeneratorAudioSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		45A66E543B62A2C32AB3BA23 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioDeviceSelectorComponent.h"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioDeviceSelectorComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		45C7B3A0676BC07190A2338B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDetectCanvas.h; path = ../../Source/Processors/Visualization/SpikeDetectCanvas.h; sourceTree = "SOURCE_ROOT"; };
-		45D440B69BDB210B17CD424B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ImageComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ImageComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		45D78C8EF660EECE64BAA33F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RHD2000Editor.cpp; path = ../../Source/Processors/Editors/RHD2000Editor.cpp; sourceTree = "SOURCE_ROOT"; };
-		4608E765A643BC0CB2C1BB02 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CriticalSection.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_CriticalSection.h"; sourceTree = "SOURCE_ROOT"; };
-		463A302B39C7815EB981CEBD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Point.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Point.h"; sourceTree = "SOURCE_ROOT"; };
-		4650B5724FE3C0608FB07A04 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TextLayout.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_TextLayout.cpp"; sourceTree = "SOURCE_ROOT"; };
-		46E3A634686BFEF787229582 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ParameterEditor.cpp; path = ../../Source/Processors/Editors/ParameterEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		46EF49B14DF7357A8287D9D8 = { isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Info.plist; sourceTree = "SOURCE_ROOT"; };
-		47041E3794FA20F67F39AE63 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ChildProcess.cpp"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ChildProcess.cpp"; sourceTree = "SOURCE_ROOT"; };
-		475824F60D47C28C392954A7 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_audio_processors/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		47976F6BE2942EED64AEA4D2 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-04.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-04.png"; sourceTree = "SOURCE_ROOT"; };
-		47A3942AC30A3212C01F1CAF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataViewport.cpp; path = ../../Source/UI/DataViewport.cpp; sourceTree = "SOURCE_ROOT"; };
-		47BDFDD28759B342B1C50BC0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AbstractFifo.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_AbstractFifo.h"; sourceTree = "SOURCE_ROOT"; };
-		47EE021D6C891095140ED7A9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_ios_UIViewComponentPeer.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm"; sourceTree = "SOURCE_ROOT"; };
-		482A60A44EE6CB84FCB9DC88 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioThumbnailBase.h"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnailBase.h"; sourceTree = "SOURCE_ROOT"; };
-		483ABD5C1CF789943AB4AFB6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComponentPeer.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ComponentPeer.h"; sourceTree = "SOURCE_ROOT"; };
-		4867923F31CC3EDC9B1A5BE5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Merger.cpp; path = ../../Source/Processors/Utilities/Merger.cpp; sourceTree = "SOURCE_ROOT"; };
-		488D1B00C9E5FE4DAB035EDF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_cryptography.mm"; path = "../../JuceLibraryCode/modules/juce_cryptography/juce_cryptography.mm"; sourceTree = "SOURCE_ROOT"; };
-		48E12736F471C43C959AD15C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PulsePal.cpp; path = ../../Source/Processors/Serial/PulsePal.cpp; sourceTree = "SOURCE_ROOT"; };
-		48E4FA55FD4440AF44EEA437 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_FileChooser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_linux_FileChooser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		48F6281AB92B232E5187D00C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SignalChainManager.h; path = ../../Source/UI/SignalChainManager.h; sourceTree = "SOURCE_ROOT"; };
-		4939A8B8300394AAD0926C0B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Legendre.h; path = ../../Source/Dsp/Legendre.h; sourceTree = "SOURCE_ROOT"; };
-		496180D5D96088CBB59035B1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawableShape.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableShape.h"; sourceTree = "SOURCE_ROOT"; };
-		4978EF4C5F506F3289BC0D99 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SubregionStream.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_SubregionStream.h"; sourceTree = "SOURCE_ROOT"; };
-		499A12199A8A8C5AEDAA47E4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FilenameComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FilenameComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		49D837FD08100AF0DB797DB4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SparseSet.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_SparseSet.h"; sourceTree = "SOURCE_ROOT"; };
-		49FA151B1837E543D18858EB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FilterEditor.h; path = ../../Source/Processors/Editors/FilterEditor.h; sourceTree = "SOURCE_ROOT"; };
-		4A28A492852AEFBF508C1FC1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativePointPath.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePointPath.h"; sourceTree = "SOURCE_ROOT"; };
-		4A7695E93CE32F4E95042FCB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_video.mm"; path = "../../JuceLibraryCode/modules/juce_video/juce_video.mm"; sourceTree = "SOURCE_ROOT"; };
-		4A94E809624F99387E600399 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpDisplayCanvas.cpp; path = ../../Source/Processors/Visualization/LfpDisplayCanvas.cpp; sourceTree = "SOURCE_ROOT"; };
-		4AD95B75DC581E32650FEDF6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_IIRFilterAudioSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_IIRFilterAudioSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4AE1520FF569371665090B39 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AiffAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4AE36D25675E32A897F97BFA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TabbedComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4AF8FD4C7E567639A190D943 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NotchFilterEditor.h; path = ../../Source/Processors/Editors/NotchFilterEditor.h; sourceTree = "SOURCE_ROOT"; };
-		4B0097003751A59A11FA8C5B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileReaderEditor.cpp; path = ../../Source/Processors/Editors/FileReaderEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		4B3DBFE485F45E62C53A90B8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MenuBarModel.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarModel.h"; sourceTree = "SOURCE_ROOT"; };
-		4B5998D72503BD73D28E828A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_osx_MessageQueue.h"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_osx_MessageQueue.h"; sourceTree = "SOURCE_ROOT"; };
-		4B74A7F0FDCE3E1706E5B320 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ApplicationCommandTarget.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandTarget.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4BB38A2CD55BF23C7C3E3387 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ToolbarItemPalette.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemPalette.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4C3EA47E012B2D63ADE599DD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PathStrokeType.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathStrokeType.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4C4E2282C145D13C86CB23FA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLHelpers.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		4C81E05B39376F54775A1027 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Colour.h"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colour.h"; sourceTree = "SOURCE_ROOT"; };
-		4CA9556E9C18029A47F34C7C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LAMEEncoderAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_LAMEEncoderAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		4CCA36B2A6C4821E493E74D2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioFormatReader.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4CF403118BBAAD5B6763542A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLContext.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLContext.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4D67518E9223C1C19BD4EF2E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Threads.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_linux_Threads.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4D84A3A970FB67566A1E5B0B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_KnownPluginList.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_KnownPluginList.h"; sourceTree = "SOURCE_ROOT"; };
-		4D8F94CA49DB11E07918B4C9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_UnitTest.cpp"; path = "../../JuceLibraryCode/modules/juce_core/unit_tests/juce_UnitTest.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4E520E7960CC5098C2352E70 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MouseCursor.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseCursor.h"; sourceTree = "SOURCE_ROOT"; };
-		4E6EE225098D32E7D5DE60B2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDisplayCanvas.h; path = ../../Source/Processors/Visualization/SpikeDisplayCanvas.h; sourceTree = "SOURCE_ROOT"; };
-		4E71B355F2BABAF69CC4114D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ConcertinaPanel.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ConcertinaPanel.h"; sourceTree = "SOURCE_ROOT"; };
-		4EC254B133A7AAE377B9B3AE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LassoComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_LassoComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		4F31D61C0C2AB3472C6C1429 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MACAddress.cpp"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_MACAddress.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4F4234DC14D3689C22655D0C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentListener.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ComponentListener.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4F4E8E3B32DB7A91B41C9FFA = { isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerB-01.png"; path = "../../Resources/Images/Buttons/MergerB-01.png"; sourceTree = "SOURCE_ROOT"; };
-		4FC4EF4B38B28638B2F09260 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PeriStimulusTimeHistogramNode.h; path = ../../Source/Processors/PeriStimulusTimeHistogramNode.h; sourceTree = "SOURCE_ROOT"; };
-		4FD13AA663EEE7CC2F83033D = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
-		50DB7E5C152DDD03F2FA4C2D = { isa = PBXFileReference; lastKnownFileType = file.otf; name = BebasNeue.otf; path = ../../Resources/Fonts/BebasNeue.otf; sourceTree = "SOURCE_ROOT"; };
-		50DD8D693741DD18106C0BA7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComponentListener.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ComponentListener.h"; sourceTree = "SOURCE_ROOT"; };
-		510ACDAD798813D7FC110197 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TabbedComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		511C443A0A806706A772E981 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Primes.cpp"; path = "../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_Primes.cpp"; sourceTree = "SOURCE_ROOT"; };
-		515213CC3271E8DEA8125D33 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DynamicLibrary.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_DynamicLibrary.h"; sourceTree = "SOURCE_ROOT"; };
-		51926BEEA63BF141D93A5B36 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RelativePoint.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePoint.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5265AD5F97C9E813E14937A7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RectanglePlacement.h"; path = "../../JuceLibraryCode/modules/juce_graphics/placement/juce_RectanglePlacement.h"; sourceTree = "SOURCE_ROOT"; };
-		5284E69CC601457D5C7C1063 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_SystemTrayIcon.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_linux_SystemTrayIcon.cpp"; sourceTree = "SOURCE_ROOT"; };
-		52A8F84DCDDF0186B511B9CD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FilenameComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FilenameComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		53130F5F47EB211416C028F6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_UnitTest.h"; path = "../../JuceLibraryCode/modules/juce_core/unit_tests/juce_UnitTest.h"; sourceTree = "SOURCE_ROOT"; };
-		5343D594AA7D444A7C6AD924 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_GZIPDecompressorInputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPDecompressorInputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		5379FC603780F30A2F05FE78 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AsyncUpdater.h"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_AsyncUpdater.h"; sourceTree = "SOURCE_ROOT"; };
-		53C8A2696FE4389E4AB4441C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Slider.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Slider.cpp"; sourceTree = "SOURCE_ROOT"; };
-		54339ADDCB6F8E9E7721A986 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Windowing.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_android_Windowing.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5522973FA48A13C6BED293FE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SignalGenerator.cpp; path = ../../Source/Processors/SignalGenerator.cpp; sourceTree = "SOURCE_ROOT"; };
-		555D34D0CD8776EE5996CC3A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ProcessorGraph.cpp; path = ../../Source/Processors/ProcessorGraph.cpp; sourceTree = "SOURCE_ROOT"; };
-		55811E331B55E0547326CF22 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TopLevelWindow.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TopLevelWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		558E925DAC57ADF8810559AC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Windowing.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_linux_Windowing.cpp"; sourceTree = "SOURCE_ROOT"; };
-		55EBFCA56B915C8CD043365C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_DirectWriteTypeLayout.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_DirectWriteTypeLayout.cpp"; sourceTree = "SOURCE_ROOT"; };
-		55F7467B96E236DD558228C9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CharPointer_UTF8.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_UTF8.h"; sourceTree = "SOURCE_ROOT"; };
-		560A28C1966B1817873CF764 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiMessageSequence.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessageSequence.cpp"; sourceTree = "SOURCE_ROOT"; };
-		56169D835A3E3029D6E3904C = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickTime.framework; path = System/Library/Frameworks/QuickTime.framework; sourceTree = SDKROOT; };
-		562E4A50364EEDC3AA2AACB8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativeTime.h"; path = "../../JuceLibraryCode/modules/juce_core/time/juce_RelativeTime.h"; sourceTree = "SOURCE_ROOT"; };
-		563F35B171FAF2540923CE45 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioDataConverters.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioDataConverters.cpp"; sourceTree = "SOURCE_ROOT"; };
-		564380494D23DB70680FB0B5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TreeView.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TreeView.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5654BDD4FBFF01AC3F17FA0D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChannelMappingNode.cpp; path = ../../Source/Processors/ChannelMappingNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		565EEC8F429ABF5F9A867137 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MouseEvent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseEvent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		56728EC77C65482B9C86FF4D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_audio_utils.mm"; path = "../../JuceLibraryCode/modules/juce_audio_utils/juce_audio_utils.mm"; sourceTree = "SOURCE_ROOT"; };
-		570299171BCE863C54FBBA54 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ConcertinaPanel.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ConcertinaPanel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		57941E5B2E1FF6028A68D4A7 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-02.png"; path = "../../Resources/Images/Icons/RadioButtons-02.png"; sourceTree = "SOURCE_ROOT"; };
-		57C6DD2537116B30FB948A08 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RSAKey.h"; path = "../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_RSAKey.h"; sourceTree = "SOURCE_ROOT"; };
-		57F66B4A911601169AF195E9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioProcessorPlayer.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_utils/players/juce_AudioProcessorPlayer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		57FBA8BC3104D3AF41FBECD8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EditorViewport.h; path = ../../Source/UI/EditorViewport.h; sourceTree = "SOURCE_ROOT"; };
-		581287A24510A9EACEE09CE4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DocumentWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DocumentWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		586448E180F8ACBF5A1565B0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_gui_extra.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/juce_gui_extra.h"; sourceTree = "SOURCE_ROOT"; };
-		586B1E0743FFBE9081A25F4F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CodeEditorComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		587FCA2485B9C89C2A99C23A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Filter.cpp; path = ../../Source/Dsp/Filter.cpp; sourceTree = "SOURCE_ROOT"; };
-		5894D40A0E8FA6E9B3EBF9D9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeObject.cpp; path = ../../Source/Processors/Visualization/SpikeObject.cpp; sourceTree = "SOURCE_ROOT"; };
-		58958CC3F750D383261E2FBC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SliderPropertyComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_SliderPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		58BBDECD171E15D0768302A1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ISCANeditor.cpp; path = ../../Source/Processors/Editors/ISCANeditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		5915DB02FB7CA8CEC1BF38A9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_opengl.mm"; path = "../../JuceLibraryCode/modules/juce_opengl/juce_opengl.mm"; sourceTree = "SOURCE_ROOT"; };
-		59389DC8664617FD51740F36 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DirectShowComponent.h"; path = "../../JuceLibraryCode/modules/juce_video/playback/juce_DirectShowComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		5962848AA3DD93A29EFF5B94 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_data_structures.h"; path = "../../JuceLibraryCode/modules/juce_data_structures/juce_data_structures.h"; sourceTree = "SOURCE_ROOT"; };
-		5A746CDDE80FEA2E45B5BA66 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_AppleRemote.mm"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_AppleRemote.mm"; sourceTree = "SOURCE_ROOT"; };
-		5A7D81B70480B40EEBC2FF54 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MessageListener.cpp"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_MessageListener.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5A8D46BEB81DDF24462E3D92 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PoleFilter.h; path = ../../Source/Dsp/PoleFilter.h; sourceTree = "SOURCE_ROOT"; };
-		5AB3809F029824EE2DE0A798 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ImageFileFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageFileFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5B2A4DD7133CDE5AEC24CC07 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GenericProcessor.h; path = ../../Source/Processors/GenericProcessor.h; sourceTree = "SOURCE_ROOT"; };
-		5B2CDF3CF10A92F6CA45F3DE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioPlayHead.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioPlayHead.h"; sourceTree = "SOURCE_ROOT"; };
-		5B411F4FCF0F69798C9E4A88 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ScrollBar.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ScrollBar.h"; sourceTree = "SOURCE_ROOT"; };
-		5B6B25AA065FB6CDE7D6C507 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ApplicationProperties.h"; path = "../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_ApplicationProperties.h"; sourceTree = "SOURCE_ROOT"; };
-		5B7EC53FD2232CA799D6C018 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_DirectSound.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_DirectSound.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5BB1E90842FD8A212CC2D132 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CodeDocument.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeDocument.h"; sourceTree = "SOURCE_ROOT"; };
-		5C1D2D28960C7957A15B3FE4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ChannelRemappingAudioSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ChannelRemappingAudioSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5C5E4C396CD83C46F58644A2 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "triangle_wave.png"; path = "../../Resources/Images/Icons/triangle_wave.png"; sourceTree = "SOURCE_ROOT"; };
-		5C7EEDD80F88872A87FD561B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5CE99545433261F3B4A46252 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioFormatReaderSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReaderSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5D23F70C117457FB8547A537 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NotchFilterNode.h; path = ../../Source/Processors/NotchFilterNode.h; sourceTree = "SOURCE_ROOT"; };
-		5D9792840E8050DCC766B368 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLRenderer.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLRenderer.h"; sourceTree = "SOURCE_ROOT"; };
-		5DB3B3197F8C1E5EE159D6FC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rhd2000registers.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000registers.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5DB6A07B827D62571BB51943 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Justification.h"; path = "../../JuceLibraryCode/modules/juce_graphics/placement/juce_Justification.h"; sourceTree = "SOURCE_ROOT"; };
-		5DC1AF69A773401DB1E8FB32 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RelativeTime.cpp"; path = "../../JuceLibraryCode/modules/juce_core/time/juce_RelativeTime.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5E0F8A60411A03461FD687CE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_GroupComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_GroupComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		5E1EFF4EEA5684FA00CAA353 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ResizableBorderComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableBorderComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		5E663D5A55F191AB92A1383F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileInputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_FileInputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		5E94E897783BEEFE61E61A2C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_WebBrowserComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_android_WebBrowserComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5EA61EDD64BE1E401DD0AA5E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDisplayNode.h; path = ../../Source/Processors/SpikeDisplayNode.h; sourceTree = "SOURCE_ROOT"; };
-		5EA661C13CB7197A45F20028 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineB-02.png"; path = "../../Resources/Images/Buttons/PipelineB-02.png"; sourceTree = "SOURCE_ROOT"; };
-		5F64FDAFCA899A16C7FDDBCA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioNode.h; path = ../../Source/Processors/AudioNode.h; sourceTree = "SOURCE_ROOT"; };
-		5F6DCA68A982E930389644FD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Network.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_linux_Network.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5FEBF3F722DB6191BF659816 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ArrowButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ArrowButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		5FEFF62D585CF777C950E569 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_LookAndFeel.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		601654292170CD2D60E912A6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_ALSA.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_ALSA.cpp"; sourceTree = "SOURCE_ROOT"; };
-		603764889DE750F8E87F6428 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Direct2DGraphicsContext.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_Direct2DGraphicsContext.cpp"; sourceTree = "SOURCE_ROOT"; };
-		605C7ACB09E7739EBE4F1539 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_AudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		60B1BDA3E9E14F9515963082 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BasicNativeHeaders.h"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_BasicNativeHeaders.h"; sourceTree = "SOURCE_ROOT"; };
-		610E487E060C42B52FD5AAC9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ControlPanel.cpp; path = ../../Source/UI/ControlPanel.cpp; sourceTree = "SOURCE_ROOT"; };
-		61317B5191E05925F232E18C = { isa = PBXFileReference; lastKnownFileType = file.otf; name = "unibody-8.otf"; path = "../../Resources/Fonts/unibody-8.otf"; sourceTree = "SOURCE_ROOT"; };
-		61481DD4AAC7731CE984937D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLExtensions.h"; path = "../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGLExtensions.h"; sourceTree = "SOURCE_ROOT"; };
-		617F5DFAAE97F48FA996A781 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawableRectangle.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableRectangle.h"; sourceTree = "SOURCE_ROOT"; };
-		61B0CBF705D5FC0431776286 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLShaderProgram.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLShaderProgram.cpp"; sourceTree = "SOURCE_ROOT"; };
-		627956A7A1CB15251D02C8C5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ScopedXLock.h"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_ScopedXLock.h"; sourceTree = "SOURCE_ROOT"; };
-		6328434A329C353DB8D9512C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SourceNodeEditor.cpp; path = ../../Source/Processors/Editors/SourceNodeEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		6340B1D2FECEABBBE6C0DE28 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Types.h; path = ../../Source/Dsp/Types.h; sourceTree = "SOURCE_ROOT"; };
-		63AF6BE7FE2A9E7882743B4F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_Network.mm"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_mac_Network.mm"; sourceTree = "SOURCE_ROOT"; };
-		63F4150ABBA43B2215230034 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_IIRFilter.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_IIRFilter.h"; sourceTree = "SOURCE_ROOT"; };
-		642C4CFA27846188E3D53688 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioDeviceManager.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.h"; sourceTree = "SOURCE_ROOT"; };
-		649F22404167E0D0EA244196 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Toolbar.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Toolbar.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6514FD7E6C5EC12735E49FBC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_FileChooser.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_FileChooser.mm"; sourceTree = "SOURCE_ROOT"; };
-		651E9B78A5139F7A5BCA4D90 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PropertyComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		65312FAD0900119CDF6CF414 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PoleFilter.cpp; path = ../../Source/Dsp/PoleFilter.cpp; sourceTree = "SOURCE_ROOT"; };
-		6535D85C084292220330EDD9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ResamplingAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ResamplingAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		65751E743D5EFD4066E50746 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LagrangeInterpolator.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_LagrangeInterpolator.h"; sourceTree = "SOURCE_ROOT"; };
-		6589EAEF497ABA76A295B121 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_VSTPluginFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		658D08592154525DA1C40826 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileLogger.cpp"; path = "../../JuceLibraryCode/modules/juce_core/logging/juce_FileLogger.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6596D69CCD1502DC6BBD15F1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CharPointer_UTF32.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_UTF32.h"; sourceTree = "SOURCE_ROOT"; };
-		65980344D141B0008A94E2E4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_DirectShowComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_video/native/juce_win32_DirectShowComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		65A447DCF8A68BAABC20FC7D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileFilter.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileFilter.h"; sourceTree = "SOURCE_ROOT"; };
-		65BE7542749DCCAE33ACF40F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OldSchoolLookAndFeel.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/lookandfeel/juce_OldSchoolLookAndFeel.h"; sourceTree = "SOURCE_ROOT"; };
-		65DA1366481AB10AFB3AF344 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PerformanceCounter.h"; path = "../../JuceLibraryCode/modules/juce_core/time/juce_PerformanceCounter.h"; sourceTree = "SOURCE_ROOT"; };
-		65F4459CC1832883FFF6C166 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_audio_devices.mm"; path = "../../JuceLibraryCode/modules/juce_audio_devices/juce_audio_devices.mm"; sourceTree = "SOURCE_ROOT"; };
-		66463AB11EA4D6341C32F27E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataWindow.cpp; path = ../../Source/Processors/Visualization/DataWindow.cpp; sourceTree = "SOURCE_ROOT"; };
-		66C663401829E0F7E787F708 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PropertySet.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_PropertySet.h"; sourceTree = "SOURCE_ROOT"; };
-		66D3F831CE4F6AE89E4C869A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LinkedListPointer.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_LinkedListPointer.h"; sourceTree = "SOURCE_ROOT"; };
-		66F524552E8DE88CDC2E40FD = { isa = PBXFileReference; lastKnownFileType = file; name = "silkscreen-serialized"; path = "../../Resources/Fonts/silkscreen-serialized"; sourceTree = "SOURCE_ROOT"; };
-		66FE597910F6A68CBB6FA055 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MemoryInputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryInputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		670987D88775D6B240C34820 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_NotificationType.h"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_NotificationType.h"; sourceTree = "SOURCE_ROOT"; };
-		674FDCCEF6A1379A0F689004 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComponentBoundsConstrainer.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBoundsConstrainer.h"; sourceTree = "SOURCE_ROOT"; };
-		67BB47E709B643D4C01AB34C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioDeviceSelectorComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioDeviceSelectorComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6832130272774CD542793762 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_CoreGraphicsContext.mm"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsContext.mm"; sourceTree = "SOURCE_ROOT"; };
-		686FA8DDF2848517CBFB9E4A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MouseCursor.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseCursor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6880C148A38A5C8D0092E358 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Merger.h; path = ../../Source/Processors/Utilities/Merger.h; sourceTree = "SOURCE_ROOT"; };
-		6917A53BAA3CA2819E4C10BF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ToolbarItemComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		693E9C5C9A435F791921DAAE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioDeviceManager.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		696F2DC49934E6F01A2DF9FE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileTreeComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileTreeComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		698B0EC670DA47934444381B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Network.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_win32_Network.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6A559D9595A54EF52BF0773A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Range.h"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_Range.h"; sourceTree = "SOURCE_ROOT"; };
-		6A63308EBE68478531604BA4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DirectoryContentsList.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsList.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6ABF91320A2EB6D307091AEE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_CameraDevice.mm"; path = "../../JuceLibraryCode/modules/juce_video/native/juce_mac_CameraDevice.mm"; sourceTree = "SOURCE_ROOT"; };
-		6B28CEAF75E22F2CCCACBCC7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_audio_formats.mm"; path = "../../JuceLibraryCode/modules/juce_audio_formats/juce_audio_formats.mm"; sourceTree = "SOURCE_ROOT"; };
-		6B32691AA8B3D304B68CFA64 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MemoryMappedAudioFormatReader.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_MemoryMappedAudioFormatReader.h"; sourceTree = "SOURCE_ROOT"; };
-		6B7252D3F574AE21BE464327 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineA-02.png"; path = "../../Resources/Images/Buttons/PipelineA-02.png"; sourceTree = "SOURCE_ROOT"; };
-		6B90F5150FA8E114E8AE98BF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioFormatWriter.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatWriter.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6BA113C799640798D3F29A06 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ProgressBar.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ProgressBar.h"; sourceTree = "SOURCE_ROOT"; };
-		6BA7D7A7E3E2E646E50D334A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileSearchPathListComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileSearchPathListComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6BBBC0907D7A62E2F3AB9BDF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Colours.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colours.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6C24163DC4ECD731489CC4F6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OwnedArray.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_OwnedArray.h"; sourceTree = "SOURCE_ROOT"; };
-		6C36C3C304EB066B1DFCCD9C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SystemClipboard.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_SystemClipboard.h"; sourceTree = "SOURCE_ROOT"; };
-		6C8489C41782E3D391AF0C26 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Identifier.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_Identifier.h"; sourceTree = "SOURCE_ROOT"; };
-		6CA98F8581CEAE2DC9AEBCE9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CallbackMessage.h"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_CallbackMessage.h"; sourceTree = "SOURCE_ROOT"; };
-		6CBD8647DB17F1B58B14A3BC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_AudioCDBurner.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_AudioCDBurner.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6D34DD9AB987A67BADE71C65 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-05.png"; path = "../../Resources/Images/Icons/RadioButtons-05.png"; sourceTree = "SOURCE_ROOT"; };
-		6D4BA4399FDEB6D2195B257D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SplashScreen.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SplashScreen.h"; sourceTree = "SOURCE_ROOT"; };
-		6D4DFC260B2966E3EBFC0C79 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SliderPropertyComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_SliderPropertyComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6D59D5780ECD2CC9703CB499 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Butterworth.h; path = ../../Source/Dsp/Butterworth.h; sourceTree = "SOURCE_ROOT"; };
-		6D619C7A3A14981DC4EFF223 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_IIRFilterAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_IIRFilterAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		6D77949E9C7C9B5A7795C0E0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PathStrokeType.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathStrokeType.h"; sourceTree = "SOURCE_ROOT"; };
-		6DA8EC2F779DEBB701FE33CA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_win32_HiddenMessageWindow.h"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_win32_HiddenMessageWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		6DCDFF2618CFEECEACE87630 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_GraphicsContext.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_android_GraphicsContext.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6DD526F86CBF2C3B3487FFE1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentBuilder.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBuilder.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6E2F243D8F70CC92391204A4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MultiDocumentPanel.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_MultiDocumentPanel.h"; sourceTree = "SOURCE_ROOT"; };
-		6E444E05271A0334FAE9DCA3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TrialCircularBuffer.h; path = ../../Source/Processors/TrialCircularBuffer.h; sourceTree = "SOURCE_ROOT"; };
-		6EA1CC7DACDDBA863179521A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TemporaryFile.cpp"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_TemporaryFile.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6EF4EFD6D74D2573AC6B6A6F = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_audio_devices/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		6F9B89F7AD0E13887871D4FE = { isa = PBXFileReference; lastKnownFileType = image.png; name = SourceDrop.png; path = ../../Resources/Images/Icons/SourceDrop.png; sourceTree = "SOURCE_ROOT"; };
-		6FE8B0DD6116E6A3456ECF09 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_ios_UIViewComponent.mm"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_ios_UIViewComponent.mm"; sourceTree = "SOURCE_ROOT"; };
-		700597338DEC9AB65C4C8A5E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawableText.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableText.h"; sourceTree = "SOURCE_ROOT"; };
-		70151263C4CB8A4F79431E11 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EventNodeEditor.cpp; path = ../../Source/Processors/Editors/EventNodeEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		70BF68C222D1E0A0368EB845 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ApplicationCommandManager.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		70ECB490BD59F59D003F3BEE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_CameraDevice.cpp"; path = "../../JuceLibraryCode/modules/juce_video/native/juce_android_CameraDevice.cpp"; sourceTree = "SOURCE_ROOT"; };
-		70F06DBCA3948BCC1062E36F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelSelector.h; path = ../../Source/Processors/Editors/ChannelSelector.h; sourceTree = "SOURCE_ROOT"; };
-		71C0C491E4BB214551D6EAD7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AdvancerNode.cpp; path = ../../Source/Processors/AdvancerNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		71CF8F6995DF1BA2038C21D6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AlertWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_AlertWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		7291F19253205B1A5138908E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DynamicObject.cpp"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_DynamicObject.cpp"; sourceTree = "SOURCE_ROOT"; };
-		72C33BA70B9EE82E39F1EC6C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MP3AudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_MP3AudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		72FCE41894123FC5DB01566B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGL_win32.h"; path = "../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_win32.h"; sourceTree = "SOURCE_ROOT"; };
-		7387114E34496F4606550863 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_HyperlinkButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_HyperlinkButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		73ACB7A051EDE5F676E35FFD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PerformanceCounter.cpp"; path = "../../JuceLibraryCode/modules/juce_core/time/juce_PerformanceCounter.cpp"; sourceTree = "SOURCE_ROOT"; };
-		73C69D948D33899821536025 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SystemTrayIconComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		748AF0975561FFFE51DF5F58 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PhaseDetectorEditor.h; path = ../../Source/Processors/Editors/PhaseDetectorEditor.h; sourceTree = "SOURCE_ROOT"; };
-		748E62D05C8FFF74DCA234C7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ThreadPool.cpp"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ThreadPool.cpp"; sourceTree = "SOURCE_ROOT"; };
-		74A81014471CC0EB0D5E6571 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ValueTree.cpp"; path = "../../JuceLibraryCode/modules/juce_data_structures/values/juce_ValueTree.cpp"; sourceTree = "SOURCE_ROOT"; };
-		74DE857CEFA10BC49FF591DB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Synthesiser.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/synthesisers/juce_Synthesiser.h"; sourceTree = "SOURCE_ROOT"; };
-		753B81CCB5A6B6929679E7B7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Application.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/application/juce_Application.h"; sourceTree = "SOURCE_ROOT"; };
-		7555A13E69B99B1B6C7295FD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_InputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_InputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		758BC480F153DEA79304366B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ofArduino.h; path = ../../Source/Processors/Serial/ofArduino.h; sourceTree = "SOURCE_ROOT"; };
-		75A4EEE127FAB86D65FF5F6E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RelativeCoordinatePositioner.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinatePositioner.cpp"; sourceTree = "SOURCE_ROOT"; };
-		75B1E4EFCDA9A506CFEDB09F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PhaseDetectorEditor.cpp; path = ../../Source/Processors/Editors/PhaseDetectorEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		75E0C433EC27CFB712CD9F75 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PluginListComponent.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginListComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		75FCE8908DD9055F90E93716 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ResizableBorderComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableBorderComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		76140C0485FDDA98C3D98E2A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OldSchoolLookAndFeel.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/lookandfeel/juce_OldSchoolLookAndFeel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		766923F74E30FF5D6B12E7CE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawableComposite.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableComposite.h"; sourceTree = "SOURCE_ROOT"; };
-		76E89CBE70BF8F2476B7AA34 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SortedSet.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_SortedSet.h"; sourceTree = "SOURCE_ROOT"; };
-		76F569AE7B444D8F69EE0E86 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioResamplingNode.cpp; path = ../../Source/Processors/AudioResamplingNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		7719FB81DDF23CF0164B131D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BlowFish.h"; path = "../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_BlowFish.h"; sourceTree = "SOURCE_ROOT"; };
-		77B3E84324445076F1F907E9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Threads.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_win32_Threads.cpp"; sourceTree = "SOURCE_ROOT"; };
-		77D3770CCBB3EED01A854329 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeSortBoxes.h; path = ../../Source/Processors/SpikeSortBoxes.h; sourceTree = "SOURCE_ROOT"; };
-		783D8922D5C687E170FA1A2C = { isa = PBXFileReference; lastKnownFileType = file.otf; name = "cpmono_plain.otf"; path = "../../Resources/Fonts/cpmono_plain.otf"; sourceTree = "SOURCE_ROOT"; };
-		784233150B26826701C09103 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiKeyboardComponent.h"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		786A97B2B4E2BB6406546647 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileSearchPathListComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileSearchPathListComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		786F6A40506C2094B812F4D5 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_audio_basics/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		788F8B7719B70465762B634B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataBuffer.cpp; path = ../../Source/Processors/DataThreads/DataBuffer.cpp; sourceTree = "SOURCE_ROOT"; };
-		789139D88F449BE488BF3CCB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioFormatReader.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReader.h"; sourceTree = "SOURCE_ROOT"; };
-		78BA978C614603B5E9ECFFF1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentPeer.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ComponentPeer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		78CC9639B933CE2497264EF2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_KeyPress.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyPress.h"; sourceTree = "SOURCE_ROOT"; };
-		78FB85191B054CDE7BD07DB7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PeriStimulusTimeHistogramEditor.h; path = ../../Source/Processors/Editors/PeriStimulusTimeHistogramEditor.h; sourceTree = "SOURCE_ROOT"; };
-		793A4A777FEFA450F86C78EE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GraphicsContext.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/contexts/juce_GraphicsContext.cpp"; sourceTree = "SOURCE_ROOT"; };
-		79BBD2F2F31D76CC4F5BD012 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-04.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-04.png"; sourceTree = "SOURCE_ROOT"; };
-		79C32CA8069962F5DE48F633 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PulsePal.h; path = ../../Source/Processors/Serial/PulsePal.h; sourceTree = "SOURCE_ROOT"; };
-		79C91DDF3BC3F15D0338E504 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ProcessorList.cpp; path = ../../Source/UI/ProcessorList.cpp; sourceTree = "SOURCE_ROOT"; };
-		7A93BFD2180B5E00B124CB1A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PixelFormats.h"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_PixelFormats.h"; sourceTree = "SOURCE_ROOT"; };
-		7A9F37527280A470F201FB6E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SystemTrayIconComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7ACB1CB66D69738904358F43 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Design.h; path = ../../Source/Dsp/Design.h; sourceTree = "SOURCE_ROOT"; };
-		7B42B28FDB2E3AC67EF296F8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PracticalSocket.h; path = ../../Source/Network/PracticalSocket.h; sourceTree = "SOURCE_ROOT"; };
-		7B674BB1DA11A4E58EA71624 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_EdgeTable.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_EdgeTable.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7B7819A5759B54D91E334447 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpTriggeredAverageEditor.cpp; path = ../../Source/Processors/Editors/LfpTriggeredAverageEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		7BCE1C09508E1B9CFC79C185 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CaretComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_CaretComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7BD2C39F13FDE202141C4B41 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MessageCenter.cpp; path = ../../Source/UI/MessageCenter.cpp; sourceTree = "SOURCE_ROOT"; };
-		7BE7EBBCC4DCF760A1AA697E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DirectoryContentsList.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsList.h"; sourceTree = "SOURCE_ROOT"; };
-		7BF1DCDC30FDFBFAF03516C1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NotchFilterEditor.cpp; path = ../../Source/Processors/Editors/NotchFilterEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		7C0F2759385C66CAC3EC362D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_ActiveXComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_win32_ActiveXComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7C15112E5F287ACDD74480F5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_QuickTimeMovieComponent.h"; path = "../../JuceLibraryCode/modules/juce_video/playback/juce_QuickTimeMovieComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		7C1D87A0C78F661FB459786B = { isa = PBXFileReference; lastKnownFileType = image.png; name = "saw_wave.png"; path = "../../Resources/Images/Icons/saw_wave.png"; sourceTree = "SOURCE_ROOT"; };
-		7C6921FE817699C1B95AEBF6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ScopedReadLock.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ScopedReadLock.h"; sourceTree = "SOURCE_ROOT"; };
-		7C71195623459A6C2524D418 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiKeyboardComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7CD03E334269D693E1B84856 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioTransportSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioTransportSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7CE1E34F6A0091E720854E75 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Value.h"; path = "../../JuceLibraryCode/modules/juce_data_structures/values/juce_Value.h"; sourceTree = "SOURCE_ROOT"; };
-		7CF939BD59D45EB41B5FE628 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Button.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_Button.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7D363D7B36A55EEB3198A827 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Midi.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_android_Midi.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7D36B006AE0B139D8A3D8641 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_DirectWriteTypeface.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_DirectWriteTypeface.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7D8100DC3A532980AEAAD909 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ArrayAllocationBase.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_ArrayAllocationBase.h"; sourceTree = "SOURCE_ROOT"; };
-		7D88F7083884A5ED2DBE7534 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GroupComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_GroupComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7D9374931D760ADC65DCBFC6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataViewport.h; path = ../../Source/UI/DataViewport.h; sourceTree = "SOURCE_ROOT"; };
-		7E40891072657FB5ADC2FAB7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Array.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_Array.h"; sourceTree = "SOURCE_ROOT"; };
-		7E581214A64A535E03EA759B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AlertWindow.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_AlertWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7E875E681E18D693D5ADB2FB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EditorViewport.cpp; path = ../../Source/UI/EditorViewport.cpp; sourceTree = "SOURCE_ROOT"; };
-		7EA46209F07B2C8A83D0873A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioProcessorGraph.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7EBB3F8185EB597DEF77534D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Message.h"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_Message.h"; sourceTree = "SOURCE_ROOT"; };
-		7EBEBC6DBA8DCA5A5D8C72E1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Timer.h"; path = "../../JuceLibraryCode/modules/juce_events/timers/juce_Timer.h"; sourceTree = "SOURCE_ROOT"; };
-		7ECD5DB4BEBC44559D064E08 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Logger.cpp"; path = "../../JuceLibraryCode/modules/juce_core/logging/juce_Logger.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7EFF8622168303A4391D6CAE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RootFinder.h; path = ../../Source/Dsp/RootFinder.h; sourceTree = "SOURCE_ROOT"; };
-		7F17077973FFDD70C4B78E7E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PlatformDefs.h"; path = "../../JuceLibraryCode/modules/juce_core/system/juce_PlatformDefs.h"; sourceTree = "SOURCE_ROOT"; };
-		7F1E84C068D3E6AA13CDD699 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Justification.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/placement/juce_Justification.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7F4241B34F5F7245653B5196 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkSink.cpp; path = ../../Source/Processors/NetworkSink.cpp; sourceTree = "SOURCE_ROOT"; };
-		7F49EA0CD3379397520AA6F1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DeletedAtShutdown.cpp"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_DeletedAtShutdown.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7F92025F0B8FD4FA725CC70B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ImageConvolutionKernel.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageConvolutionKernel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7F93E4F0CC8B842AC1D3E560 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ToolbarItemPalette.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemPalette.h"; sourceTree = "SOURCE_ROOT"; };
-		7FDFE493862CE27EFCAC3F7F = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-04.png"; path = "../../Resources/Images/Icons/RadioButtons-04.png"; sourceTree = "SOURCE_ROOT"; };
-		803D306CDAC2BD3BA04534EA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioProcessorEditor.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8077C8D1C544F458947D693E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextLayout.h"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_TextLayout.h"; sourceTree = "SOURCE_ROOT"; };
-		80A612858FA1177A262744C6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_HyperlinkButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_HyperlinkButton.h"; sourceTree = "SOURCE_ROOT"; };
-		80C1B737D2C2CB519D1787D7 = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = System/Library/Frameworks/QTKit.framework; sourceTree = SDKROOT; };
-		80D57E78015C789503FE24B4 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_audio_utils/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		80E8C07F5807C65BCDFCCF94 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioSampleBuffer.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioSampleBuffer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		80EEDD40F49120ADBE9DCBDF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rhd2000datablock.h; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000datablock.h"; sourceTree = "SOURCE_ROOT"; };
-		811C4D165AD7AABF4055059C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Expression.h"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_Expression.h"; sourceTree = "SOURCE_ROOT"; };
-		813CB9DFF788D612A0750FBF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeSortBoxes.cpp; path = ../../Source/Processors/SpikeSortBoxes.cpp; sourceTree = "SOURCE_ROOT"; };
-		816EB8024DD50DE4B7E84CB8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ByteOrder.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_ByteOrder.h"; sourceTree = "SOURCE_ROOT"; };
-		81D578AA5F277EB0946050E5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_DragAndDrop.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_win32_DragAndDrop.cpp"; sourceTree = "SOURCE_ROOT"; };
-		822A504EE33F35F18A7F21AF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AiffAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		82EB2BDE7B9A4D5D945497B9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiMessageSequence.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessageSequence.h"; sourceTree = "SOURCE_ROOT"; };
-		837D266B3F62C3B05C2BC28C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BinaryData.h; path = ../../JuceLibraryCode/BinaryData.h; sourceTree = "SOURCE_ROOT"; };
-		83803D96768258DA20710764 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_XmlElement.h"; path = "../../JuceLibraryCode/modules/juce_core/xml/juce_XmlElement.h"; sourceTree = "SOURCE_ROOT"; };
-		83950E9D0D7C100B7DCA0E55 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_TextButton.h"; sourceTree = "SOURCE_ROOT"; };
-		83E5EA2AA0CB928889AC80AB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDetectorEditor.h; path = ../../Source/Processors/Editors/SpikeDetectorEditor.h; sourceTree = "SOURCE_ROOT"; };
-		847F6986DFA468BA8D80A531 = { isa = PBXFileReference; lastKnownFileType = file.ttf; name = "miso-light.ttf"; path = "../../Resources/Fonts/miso-light.ttf"; sourceTree = "SOURCE_ROOT"; };
-		84BED3AADBD3FAB6EFEC323E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkEventsEditor.h; path = ../../Source/Processors/Editors/NetworkEventsEditor.h; sourceTree = "SOURCE_ROOT"; };
-		8515A61F1E3BD62B9B95B495 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_audio_utils.h"; path = "../../JuceLibraryCode/modules/juce_audio_utils/juce_audio_utils.h"; sourceTree = "SOURCE_ROOT"; };
-		8515E367462BEF36233E2447 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_AudioUnitPluginFormat.mm"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm"; sourceTree = "SOURCE_ROOT"; };
-		8551342E7D16FCA4F9A80BC5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioSubsectionReader.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioSubsectionReader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		85928E2EF1C438EBC9EB07EA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ImageCache.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageCache.cpp"; sourceTree = "SOURCE_ROOT"; };
-		85C3F7CDF87409A56082DF67 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileListComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileListComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		86515FD9AD34D6FF96C0D8B6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BufferingAudioFormatReader.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_BufferingAudioFormatReader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		86688D712937F3D08918C68B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SerialInput.cpp; path = ../../Source/Processors/SerialInput.cpp; sourceTree = "SOURCE_ROOT"; };
-		8689288B66B16EFB106CB2F4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextInputTarget.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_TextInputTarget.h"; sourceTree = "SOURCE_ROOT"; };
-		86E8E44A13F17083ED300BD5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ChangeListener.h"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ChangeListener.h"; sourceTree = "SOURCE_ROOT"; };
-		86F4AAFCE3FEB34E325F3020 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_win32_ComSmartPtr.h"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_win32_ComSmartPtr.h"; sourceTree = "SOURCE_ROOT"; };
-		8751DF970A9E3598683BACAF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FPGAThread.h; path = ../../Source/Processors/DataThreads/FPGAThread.h; sourceTree = "SOURCE_ROOT"; };
-		879B0383EF2A8B116903A500 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ImageCache.h"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageCache.h"; sourceTree = "SOURCE_ROOT"; };
-		87B4BA68E49DD11197B7AFDB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JuceHeader.h; path = ../../JuceLibraryCode/JuceHeader.h; sourceTree = "SOURCE_ROOT"; };
-		880CC7C325EFF665AC3006D2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_KeyListener.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyListener.cpp"; sourceTree = "SOURCE_ROOT"; };
-		881237D5E366342B117C0ED7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_WildcardFileFilter.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_WildcardFileFilter.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8822ADC9DB83FAF39B841E31 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Font.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Font.cpp"; sourceTree = "SOURCE_ROOT"; };
-		886E18520E8BD77234E1B686 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FilterNode.h; path = ../../Source/Processors/FilterNode.h; sourceTree = "SOURCE_ROOT"; };
-		8882F8EBE55F52FA8E519249 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Files.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_android_Files.cpp"; sourceTree = "SOURCE_ROOT"; };
-		88E5D0906646465409715828 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PreferencesPanel.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_PreferencesPanel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		891B132A0355007B4F37454C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_GraphicsContext.h"; path = "../../JuceLibraryCode/modules/juce_graphics/contexts/juce_GraphicsContext.h"; sourceTree = "SOURCE_ROOT"; };
-		893E1A681FF162F6C9069F62 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_HashMap.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_HashMap.h"; sourceTree = "SOURCE_ROOT"; };
-		894C0CAC31D382477E7A122E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PluginDirectoryScanner.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginDirectoryScanner.h"; sourceTree = "SOURCE_ROOT"; };
-		89B0B267EF0A2A19A082EB86 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Fonts.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_android_Fonts.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8A026DB58E3555F7B070DA61 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MemoryBlock.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_MemoryBlock.h"; sourceTree = "SOURCE_ROOT"; };
-		8A91849BE6B96EB8C0663469 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpDisplayEditor.cpp; path = ../../Source/Processors/Editors/LfpDisplayEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		8A989F74B1957BCB3B9BA398 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rhd2000registers.h; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000registers.h"; sourceTree = "SOURCE_ROOT"; };
-		8AA1009705E8A9531C707ED1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_JSON.cpp"; path = "../../JuceLibraryCode/modules/juce_core/json/juce_JSON.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8AE2DDA47B2DFDEEEF69B12F = { isa = PBXFileReference; lastKnownFileType = image.png; name = FileReaderIcon.png; path = ../../Resources/Images/Icons/FileReaderIcon.png; sourceTree = "SOURCE_ROOT"; };
-		8B0C9D288C428BA5D956AE13 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiMessage.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessage.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8B49B07BC7534B247ADC756A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_WeakReference.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_WeakReference.h"; sourceTree = "SOURCE_ROOT"; };
-		8B745839B225E44C9EB5C6FA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ParameterEditor.h; path = ../../Source/Processors/Editors/ParameterEditor.h; sourceTree = "SOURCE_ROOT"; };
-		8B7EB54E1F773517A65D935C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DropShadowEffect.h"; path = "../../JuceLibraryCode/modules/juce_graphics/effects/juce_DropShadowEffect.h"; sourceTree = "SOURCE_ROOT"; };
-		8B8C25A8261F0A21369FB9D8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PeriStimulusTimeHistogramEditor.cpp; path = ../../Source/Processors/Editors/PeriStimulusTimeHistogramEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		8B9C0831BE4E09B7C0078B7E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ArduinoOutputEditor.h; path = ../../Source/Processors/Editors/ArduinoOutputEditor.h; sourceTree = "SOURCE_ROOT"; };
-		8C077447B0DFC739C7D2E437 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MemoryInputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryInputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		8C268C3D0B8EC2BB8953E7F7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ModifierKeys.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_ModifierKeys.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8C38407151E149A7E2A15801 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SHA256.h"; path = "../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_SHA256.h"; sourceTree = "SOURCE_ROOT"; };
-		8C3B6865F2053C80A6E692F1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Label.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Label.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8CAEF601359DB6CB50E89D1A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ActionBroadcaster.cpp"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ActionBroadcaster.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8D4FBD30E1C9EC0DA749BC83 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DropShadower.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_DropShadower.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8D6A419A4678968762A59B28 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BufferingAudioFormatReader.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_BufferingAudioFormatReader.h"; sourceTree = "SOURCE_ROOT"; };
-		8D9DD6147EC0553B092FD367 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RSAKey.cpp"; path = "../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_RSAKey.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8E02668CAA496759B1F31468 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkSink.h; path = ../../Source/Processors/NetworkSink.h; sourceTree = "SOURCE_ROOT"; };
-		8E61792F6D6FC75CF18095CC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioPluginFormatManager.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.h"; sourceTree = "SOURCE_ROOT"; };
-		8E696460A8A860B7A4044DFC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_WebBrowserComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		8E78AAA58721DE609F6FFC61 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DragAndDropContainer.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8EB76CA261F62A89B3D25F81 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Thread.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_Thread.h"; sourceTree = "SOURCE_ROOT"; };
-		8F0549459970F529587D6CDD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_WindowsMediaAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WindowsMediaAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		8F08D5488CE147D693BA21E2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_osx_ObjCHelpers.h"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		8F29CAC0059E3697A5A3652F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_URL.cpp"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_URL.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8F3C158B4FB92CFC48324896 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SelectedItemSet.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_SelectedItemSet.h"; sourceTree = "SOURCE_ROOT"; };
-		8F7B13BF318C11900A2277DD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_XmlDocument.h"; path = "../../JuceLibraryCode/modules/juce_core/xml/juce_XmlDocument.h"; sourceTree = "SOURCE_ROOT"; };
-		900C10C1DB76331250A04557 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = tictoc.h; path = ../../Source/Processors/tictoc.h; sourceTree = "SOURCE_ROOT"; };
-		901C720965646841A94EB099 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ActiveXControlComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/embedding/juce_ActiveXControlComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		901DB6D5FE9134F2ADB9AE46 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ChildProcess.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ChildProcess.h"; sourceTree = "SOURCE_ROOT"; };
-		90607327D7A1BB3C2C4E9264 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Random.h"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_Random.h"; sourceTree = "SOURCE_ROOT"; };
-		9069CE21141F5A4C5721BCF3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_audio_devices.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/juce_audio_devices.h"; sourceTree = "SOURCE_ROOT"; };
-		9070DC685E666BBFC2E19DA9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PropertyPanel.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyPanel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		90AD1B6A2293F625D786507A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MathsFunctions.h"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_MathsFunctions.h"; sourceTree = "SOURCE_ROOT"; };
-		90F2939F533A26AC021E42B1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ColourGradient.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_ColourGradient.cpp"; sourceTree = "SOURCE_ROOT"; };
-		911CCC0A579792DC56807DEC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DrawableRectangle.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableRectangle.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9136BD46BE1E28A96FBBD440 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SignalGeneratorEditor.cpp; path = ../../Source/Processors/Editors/SignalGeneratorEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		917988BE74F2180BFC0583A3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MissingGLDefinitions.h"; path = "../../JuceLibraryCode/modules/juce_opengl/native/juce_MissingGLDefinitions.h"; sourceTree = "SOURCE_ROOT"; };
-		918837CC0447C50774036664 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_StretchableLayoutResizerBar.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutResizerBar.cpp"; sourceTree = "SOURCE_ROOT"; };
-		91D7B1F8B94AE9CFCC53771F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EventDetector.h; path = ../../Source/Processors/EventDetector.h; sourceTree = "SOURCE_ROOT"; };
-		9200FC900D22733AE716C364 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CharPointer_UTF16.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_UTF16.h"; sourceTree = "SOURCE_ROOT"; };
-		9215DC26F511C58DEE009209 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileReader.cpp; path = ../../Source/Processors/FileReader.cpp; sourceTree = "SOURCE_ROOT"; };
-		921F5D04122F324502DA4E75 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TextEditor.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TextEditor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		92528D6653802FACF658D8EA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FPGAOutputEditor.h; path = ../../Source/Processors/Editors/FPGAOutputEditor.h; sourceTree = "SOURCE_ROOT"; };
-		92602D7166325C7232B85EDD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataThread.cpp; path = ../../Source/Processors/DataThreads/DataThread.cpp; sourceTree = "SOURCE_ROOT"; };
-		927AE946A1371490D809876E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiMessage.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessage.h"; sourceTree = "SOURCE_ROOT"; };
-		927FCF11005E78D499DAF197 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CallOutBox.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_CallOutBox.h"; sourceTree = "SOURCE_ROOT"; };
-		92CB21BEE17D1DD03106AD87 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ofSerial.h; path = ../../Source/Processors/Serial/ofSerial.h; sourceTree = "SOURCE_ROOT"; };
-		92E07CA13571893873565AC7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SplashScreen.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SplashScreen.cpp"; sourceTree = "SOURCE_ROOT"; };
-		92E3405CB31ACFE3F80BBAD4 = { isa = PBXFileReference; lastKnownFileType = image.png; name = OpenEphysBoardLogoBlack.png; path = ../../Resources/Images/Icons/OpenEphysBoardLogoBlack.png; sourceTree = "SOURCE_ROOT"; };
-		92EC6BB8A8C4C5A61F43C233 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ToggleButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToggleButton.h"; sourceTree = "SOURCE_ROOT"; };
-		9360657FDE33FA37D80075D1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_InterprocessConnection.cpp"; path = "../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnection.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9380932BED279F91B8C1C04B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Rectangle.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Rectangle.h"; sourceTree = "SOURCE_ROOT"; };
-		93EFC1AA800FC5DA2F04A213 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-04.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-04.png"; sourceTree = "SOURCE_ROOT"; };
-		93F842958BCE6A9E09862CF7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LADSPAPluginFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		9428D7423971764AC0BA9CB7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = State.h; path = ../../Source/Dsp/State.h; sourceTree = "SOURCE_ROOT"; };
-		945DC754F2EACDFFB7926DE8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileChooser.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooser.h"; sourceTree = "SOURCE_ROOT"; };
-		946FDFCA107B3F4C74C471B4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_InterprocessConnectionServer.h"; path = "../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnectionServer.h"; sourceTree = "SOURCE_ROOT"; };
-		94AED5D544719B438B3EE723 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LogWindow.cpp; path = ../../Source/UI/LogWindow.cpp; sourceTree = "SOURCE_ROOT"; };
-		94BD861806F8EA598EC09370 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ResizableCornerComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableCornerComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		95B57108E929DD11F898B7B1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileReaderThread.h; path = ../../Source/Processors/DataThreads/FileReaderThread.h; sourceTree = "SOURCE_ROOT"; };
-		95EC6B1536DC65070D0ADCEE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ListBox.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ListBox.h"; sourceTree = "SOURCE_ROOT"; };
-		967138FE8A086734ADC8CABB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Value.cpp"; path = "../../JuceLibraryCode/modules/juce_data_structures/values/juce_Value.cpp"; sourceTree = "SOURCE_ROOT"; };
-		96AED479B95D4EC31604D604 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PeriStimulusTimeHistogramNode.cpp; path = ../../Source/Processors/PeriStimulusTimeHistogramNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		96E99CD031BD069997E387FE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiBuffer.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiBuffer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		96F2A45DCB9BB53844B0ED4F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CodeTokeniser.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeTokeniser.h"; sourceTree = "SOURCE_ROOT"; };
-		971E49A78543AADB8CA1D2B7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLTexture.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLTexture.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9731D54410B06C1000370316 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Image.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_Image.cpp"; sourceTree = "SOURCE_ROOT"; };
-		97431963DB8D535DEDA9AD47 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_core.h"; path = "../../JuceLibraryCode/modules/juce_core/juce_core.h"; sourceTree = "SOURCE_ROOT"; };
-		97C4F046D88561EEE245BE99 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-05.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-05.png"; sourceTree = "SOURCE_ROOT"; };
-		982E1A954C316920557F029C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Network.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_android_Network.cpp"; sourceTree = "SOURCE_ROOT"; };
-		984BC60C0AFF3EDED692FA01 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GenericEditor.h; path = ../../Source/Processors/Editors/GenericEditor.h; sourceTree = "SOURCE_ROOT"; };
-		985F2B5047476B272B1A4BD4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EventNodeEditor.h; path = ../../Source/Processors/Editors/EventNodeEditor.h; sourceTree = "SOURCE_ROOT"; };
-		988F01B2B51B2AC7293D07DA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiMessageCollector.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiMessageCollector.cpp"; sourceTree = "SOURCE_ROOT"; };
-		98C81B13A0C34D8A4E93ADD1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ToolbarButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToolbarButton.h"; sourceTree = "SOURCE_ROOT"; };
-		98D2D452F48C86F47FB90BAD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PNGLoader.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/image_formats/juce_PNGLoader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		996E4EA6B532E4E436F50243 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DeletedAtShutdown.h"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_DeletedAtShutdown.h"; sourceTree = "SOURCE_ROOT"; };
-		9978BC2A359BC506F69E545F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SystemStats.cpp"; path = "../../JuceLibraryCode/modules/juce_core/system/juce_SystemStats.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9A21A229CFACC67E31F4F727 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RBJ.cpp; path = ../../Source/Dsp/RBJ.cpp; sourceTree = "SOURCE_ROOT"; };
-		9A29EBC10219D89919E12FCB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComponentDragger.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_ComponentDragger.h"; sourceTree = "SOURCE_ROOT"; };
-		9B178E9015CF469CFD41BC79 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BufferedInputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_BufferedInputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9B4EA34E8F90B7CC77694B7E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DialogWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DialogWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		9B5D838CB6224E82C9B36AA3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Misc.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_android_Misc.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9B9EDDFA0AE4991BC7FC7263 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MessageCenter.h; path = ../../Source/UI/MessageCenter.h; sourceTree = "SOURCE_ROOT"; };
-		9BC055494F9FEE3F90630541 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Channel.cpp; path = ../../Source/Processors/Channel.cpp; sourceTree = "SOURCE_ROOT"; };
-		9BE34B4DECBF4EBFD27C9792 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioIODeviceType.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9C21DBFB38865E5AFE367C6F = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
-		9C39C584DA6F507E773687EE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ReferenceNodeEditor.cpp; path = ../../Source/Processors/Editors/ReferenceNodeEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		9C4342320D2DD65E2BD6351C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ToolbarButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToolbarButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9C5F99C38CC703FBB871401A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ReverbAudioSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ReverbAudioSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9C701D5A7298B83CE05ECEBB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextEditorKeyMapper.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_TextEditorKeyMapper.h"; sourceTree = "SOURCE_ROOT"; };
-		9C864C7DBAF37CD0719996A9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileBrowserListener.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileBrowserListener.h"; sourceTree = "SOURCE_ROOT"; };
-		9C96B0CBFF3D34885BB8B020 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileDragAndDropTarget.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_FileDragAndDropTarget.h"; sourceTree = "SOURCE_ROOT"; };
-		9CEDA04DB321755AF74D6FAF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChebyshevII.h; path = ../../Source/Dsp/ChebyshevII.h; sourceTree = "SOURCE_ROOT"; };
-		9D050A509BEB9E3879DA35C6 = { isa = PBXFileReference; lastKnownFileType = file.ttf; name = ostrich.ttf; path = ../../Resources/Fonts/ostrich.ttf; sourceTree = "SOURCE_ROOT"; };
-		9D13E0F774807670270F4790 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Drawable.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_Drawable.h"; sourceTree = "SOURCE_ROOT"; };
-		9D2510B5E6180456C53A455E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComboBox.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ComboBox.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9D78F50147005EDB0E89E2B4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FPGAOutput.cpp; path = ../../Source/Processors/FPGAOutput.cpp; sourceTree = "SOURCE_ROOT"; };
-		9E25AA6C671FB8DCA6E30A43 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkSinkProcotol.pb.h; path = ../../Source/Processors/NetworkSinkProcotol.pb.h; sourceTree = "SOURCE_ROOT"; };
-		9EAAE3C0BFF3D753C375A5FC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DrawableImage.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableImage.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9EC1C0A21FDCB81BE0EA60EA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ApplicationBase.h"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_ApplicationBase.h"; sourceTree = "SOURCE_ROOT"; };
-		9F2853D1A12B686BE3BA2C61 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLImage.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLImage.h"; sourceTree = "SOURCE_ROOT"; };
-		9F2BCD132F453B9D9EF09F15 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-01.png"; path = "../../Resources/Images/Icons/RadioButtons-01.png"; sourceTree = "SOURCE_ROOT"; };
-		9F3B3184EC6D42CEA35D6ED8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EditorViewportButtons.cpp; path = ../../Source/UI/EditorViewportButtons.cpp; sourceTree = "SOURCE_ROOT"; };
-		9F577889CB6C54A2F7B1CA80 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PracticalSocket.cpp; path = ../../Source/Network/PracticalSocket.cpp; sourceTree = "SOURCE_ROOT"; };
-		9F61AF101B43110732BB8814 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AffineTransform.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_AffineTransform.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9F6664EB2C39D224C6BCC75E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Viewport.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_Viewport.h"; sourceTree = "SOURCE_ROOT"; };
-		9F845E950F19FEC4E6C88F91 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Typeface.h"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Typeface.h"; sourceTree = "SOURCE_ROOT"; };
-		9FC97A1CFD250F7215B4E397 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_AudioCDBurner.mm"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_AudioCDBurner.mm"; sourceTree = "SOURCE_ROOT"; };
-		9FDCF1E2B4651E58240400B9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextEditor.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TextEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		9FFD9560522567A033226BD7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PhaseDetector.cpp; path = ../../Source/Processors/PhaseDetector.cpp; sourceTree = "SOURCE_ROOT"; };
-		A0D768F1B92568344DAC9F0B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Fonts.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_Fonts.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A0E3B98412D88921BB0AA58E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioEditor.h; path = ../../Source/Processors/Editors/AudioEditor.h; sourceTree = "SOURCE_ROOT"; };
-		A15596CDCC27B86FC070D7FA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Desktop.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Desktop.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A17E8162EC7A0E513DDEB23C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PluginDescription.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_PluginDescription.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A19C4BB4BD69D4351B344A17 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MenuBarComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A234B2D091071A1B710E884B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelMappingNode.h; path = ../../Source/Processors/ChannelMappingNode.h; sourceTree = "SOURCE_ROOT"; };
-		A252FE4E6A360CBC4AF694B3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDetectorEditor.cpp; path = ../../Source/Processors/Editors/SpikeDetectorEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		A3B6D091280930A016DF8FDA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLContext.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLContext.h"; sourceTree = "SOURCE_ROOT"; };
-		A3CAB6B56641ED68D9784348 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineA-01.png"; path = "../../Resources/Images/Buttons/PipelineA-01.png"; sourceTree = "SOURCE_ROOT"; };
-		A3FB0EA0264580F6B00D993B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RHD2000Thread.cpp; path = ../../Source/Processors/DataThreads/RHD2000Thread.cpp; sourceTree = "SOURCE_ROOT"; };
-		A41AEA0D3ACB2B1E6713AE08 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLGraphicsContext.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.h"; sourceTree = "SOURCE_ROOT"; };
-		A41C5A4CD5CF8EEFF993A8B1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MathSupplement.h; path = ../../Source/Dsp/MathSupplement.h; sourceTree = "SOURCE_ROOT"; };
-		A4E2CAAF556D557B24182414 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordNode.cpp; path = ../../Source/Processors/RecordNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		A4FC82A8339698B6C1AC5F18 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LookAndFeel.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h"; sourceTree = "SOURCE_ROOT"; };
-		A512C5B237A77EF6FB8E11A0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BinaryData.cpp; path = ../../JuceLibraryCode/BinaryData.cpp; sourceTree = "SOURCE_ROOT"; };
-		A540869F28EE158A0A348C28 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ImageConvolutionKernel.h"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageConvolutionKernel.h"; sourceTree = "SOURCE_ROOT"; };
-		A54886FC74BE0DDC74094EF5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DragAndDropContainer.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.h"; sourceTree = "SOURCE_ROOT"; };
-		A5C9A0FBD818AEF57858FB31 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AffineTransform.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_AffineTransform.h"; sourceTree = "SOURCE_ROOT"; };
-		A5E8E0CF6DA1AEAEE9D872DE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StandardHeader.h"; path = "../../JuceLibraryCode/modules/juce_core/system/juce_StandardHeader.h"; sourceTree = "SOURCE_ROOT"; };
-		A65F5AD9D0C532EBB3A2067D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GZIPDecompressorInputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPDecompressorInputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A6736FBDFBB0B82E22D2B1C0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ThreadLocalValue.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ThreadLocalValue.h"; sourceTree = "SOURCE_ROOT"; };
-		A6A579E4E4AEA865BC71148C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_core.mm"; path = "../../JuceLibraryCode/modules/juce_core/juce_core.mm"; sourceTree = "SOURCE_ROOT"; };
-		A708E79EB9EB7CC44030F5D5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ColourGradient.h"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_ColourGradient.h"; sourceTree = "SOURCE_ROOT"; };
-		A764EF4F46F472715B250E41 = { isa = PBXFileReference; lastKnownFileType = image.png; name = muteon.png; path = ../../Resources/Images/Buttons/muteon.png; sourceTree = "SOURCE_ROOT"; };
-		A769611E9CBFC127AF5AFB0D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Time.cpp"; path = "../../JuceLibraryCode/modules/juce_core/time/juce_Time.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A77E8538ED93AAADC9FE2646 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkEventsEditor.cpp; path = ../../Source/Processors/Editors/NetworkEventsEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		A7875D5F8D2A632C99791002 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComboBox.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ComboBox.h"; sourceTree = "SOURCE_ROOT"; };
-		A7D4C9E3ED3763847C087F46 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDisplayCanvas.cpp; path = ../../Source/Processors/Visualization/SpikeDisplayCanvas.cpp; sourceTree = "SOURCE_ROOT"; };
-		A7FE538FF09AC8A58DE8F1BD = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-02.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-02.png"; sourceTree = "SOURCE_ROOT"; };
-		A8B4D80D55E48F50809DC5E4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_ios_Windowing.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_ios_Windowing.mm"; sourceTree = "SOURCE_ROOT"; };
-		A93F302B8D91A997F54D231B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MarkerList.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_MarkerList.h"; sourceTree = "SOURCE_ROOT"; };
-		A950BD747F318BF6D555CB06 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_Files.mm"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_mac_Files.mm"; sourceTree = "SOURCE_ROOT"; };
-		A95D898F0998F4609E992B5F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Elliptic.h; path = ../../Source/Dsp/Elliptic.h; sourceTree = "SOURCE_ROOT"; };
-		A98A22CF5F208ED6DBE08063 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ResamplingNode.cpp; path = ../../Source/Processors/ResamplingNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		A9A0BC63EB466C75D1B9326A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiMessageCollector.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiMessageCollector.h"; sourceTree = "SOURCE_ROOT"; };
-		A9F5A8F835A1A734DF7F6775 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ChoicePropertyComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ChoicePropertyComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AA3209223925B66A97AB4509 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TooltipClient.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_TooltipClient.h"; sourceTree = "SOURCE_ROOT"; };
-		AA3DAC9A4A3FF9E7D279FB23 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-03.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-03.png"; sourceTree = "SOURCE_ROOT"; };
-		AA7F6609B897B9E134377A62 = { isa = PBXFileReference; lastKnownFileType = file.otf; name = "cpmono_light.otf"; path = "../../Resources/Fonts/cpmono_light.otf"; sourceTree = "SOURCE_ROOT"; };
-		AADBA8C0AD524CE677428AFF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_GlowEffect.h"; path = "../../JuceLibraryCode/modules/juce_graphics/effects/juce_GlowEffect.h"; sourceTree = "SOURCE_ROOT"; };
-		AB4C7059669AC385B02179C1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileLogger.h"; path = "../../JuceLibraryCode/modules/juce_core/logging/juce_FileLogger.h"; sourceTree = "SOURCE_ROOT"; };
-		ABA3FCD5D762336535D56D94 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ScopedLock.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ScopedLock.h"; sourceTree = "SOURCE_ROOT"; };
-		AC116E6590D49AB2EF19CB9E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLImage.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLImage.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AC2CFF4DA5CE431FCC628BA3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChebyshevI.cpp; path = ../../Source/Dsp/ChebyshevI.cpp; sourceTree = "SOURCE_ROOT"; };
-		ACA28D2B1FECD2C57F0250A6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DirectoryContentsDisplayComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsDisplayComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		ACAE4A2D65AAC6A36DA9DBCF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OggVorbisAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AD1950C0733B3470777BF861 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BubbleMessageComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_BubbleMessageComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		AD7311B9A37893CA0C4BC119 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ZipFile.cpp"; path = "../../JuceLibraryCode/modules/juce_core/zip/juce_ZipFile.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AD7D35FCD8CF66B6C393A7F7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileBrowserComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		AD960F561259904BA68DDA73 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MemoryMappedFile.h"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_MemoryMappedFile.h"; sourceTree = "SOURCE_ROOT"; };
-		ADCB42E4C5641007A4B78025 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeObject.h; path = ../../Source/Processors/Visualization/SpikeObject.h; sourceTree = "SOURCE_ROOT"; };
-		AE1EA04666EAD34D0CA0373D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_opengl.h"; path = "../../JuceLibraryCode/modules/juce_opengl/juce_opengl.h"; sourceTree = "SOURCE_ROOT"; };
-		AE3D7946F13CE32AE41DD1B7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MatlabLikePlot.h; path = ../../Source/Processors/Visualization/MatlabLikePlot.h; sourceTree = "SOURCE_ROOT"; };
-		AE6786E4659DAC92F52E9FA3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Toolbar.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Toolbar.h"; sourceTree = "SOURCE_ROOT"; };
-		AE9359DBA841F88EF3DA9700 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileSearchPath.h"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_FileSearchPath.h"; sourceTree = "SOURCE_ROOT"; };
-		AEC2DABFC0517B4BE0CD704C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_AudioCDReader.mm"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_AudioCDReader.mm"; sourceTree = "SOURCE_ROOT"; };
-		AEF53FD0FBBFF5242EDD7032 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Viewport.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_Viewport.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AF1F3010721A6B29062E4838 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LowLevelGraphicsContext.h"; path = "../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsContext.h"; sourceTree = "SOURCE_ROOT"; };
-		AF3E3AE70160C3392B237316 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_mac_CoreAudio.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AF594F191BDCC1FFF2F31204 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ISCAN.h; path = ../../Source/Processors/ISCAN.h; sourceTree = "SOURCE_ROOT"; };
-		AF7106E30ED950436CCEC712 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_freetype_Fonts.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_freetype_Fonts.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AF8ADA74003E96998A5E4404 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Typeface.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Typeface.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AFB684CE06F9256324EE0B4C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FillType.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_FillType.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AFE835E175F7159E1E7C6CC7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CharacterFunctions.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_CharacterFunctions.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B00A9C0BAD3AF9F48E36A38F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MouseListener.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseListener.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B021D393D0E2625741512320 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RenderingHelpers.h"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_RenderingHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		B04D87ED6AA4897B6CD3CCF6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioComponent.cpp; path = ../../Source/Audio/AudioComponent.cpp; sourceTree = "SOURCE_ROOT"; };
-		B081687E52C6A5157CFCCB17 = { isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-black-serialized"; path = "../../Resources/Fonts/cpmono-black-serialized"; sourceTree = "SOURCE_ROOT"; };
-		B083B1375828610D55F12CF3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChannelMappingEditor.cpp; path = ../../Source/Processors/Editors/ChannelMappingEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		B0A076D9536B6754F34E4606 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_ASIO.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_ASIO.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B0DCDCB162FDBF972FA5B548 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_MessageManager.mm"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_mac_MessageManager.mm"; sourceTree = "SOURCE_ROOT"; };
-		B0E8FAD5AC445F612E3468B9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FilterNode.cpp; path = ../../Source/Processors/FilterNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		B1082A8A306A1947F5B0E5FC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Splitter.h; path = ../../Source/Processors/Utilities/Splitter.h; sourceTree = "SOURCE_ROOT"; };
-		B113BC1061788A9ECB1337C5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLGraphicsContext.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B11E5B5E4483AF89E6DCBAB3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ImageButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ImageButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B123E2F4439DAD65196A2A9D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ProgressBar.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ProgressBar.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B13BDA434DEF56BB48B26896 = { isa = PBXFileReference; lastKnownFileType = file; name = "miso-serialized"; path = "../../Resources/Fonts/miso-serialized"; sourceTree = "SOURCE_ROOT"; };
-		B174EBEF82212C8624300F59 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioPluginFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		B17AA637E5C357FACC38EBB7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SHA256.cpp"; path = "../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_SHA256.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B1887A7D2E27FF4DD03D16C1 = { isa = PBXFileReference; lastKnownFileType = image.png; name = DefaultDataSource.png; path = ../../Resources/Images/Icons/DefaultDataSource.png; sourceTree = "SOURCE_ROOT"; };
-		B1A8C18C6E4B3572B8B750AD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MultiTimer.cpp"; path = "../../JuceLibraryCode/modules/juce_events/timers/juce_MultiTimer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B1ECBE9C48227CBDB16E3702 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ShapeButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ShapeButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B2017626F9A05C8C0EBE9B7E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MD5.cpp"; path = "../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_MD5.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B20469D88488F0809126CC80 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_audio_processors.mm"; path = "../../JuceLibraryCode/modules/juce_audio_processors/juce_audio_processors.mm"; sourceTree = "SOURCE_ROOT"; };
-		B2241E3C5C9F93389586F357 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DirectoryIterator.h"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_DirectoryIterator.h"; sourceTree = "SOURCE_ROOT"; };
-		B23E6EBB5F99CF7FC72FAC4E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VisualizerEditor.h; path = ../../Source/Processors/Editors/VisualizerEditor.h; sourceTree = "SOURCE_ROOT"; };
-		B24098EC4FD79D5EDC9383EC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Initialisation.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/application/juce_Initialisation.h"; sourceTree = "SOURCE_ROOT"; };
-		B27F558F42AC78F0E564B5AF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioNode.cpp; path = ../../Source/Processors/AudioNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		B2EF409A1F459E964756BA7C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileInputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_FileInputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B2FA9CC4754E136F22281176 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ImageEffectFilter.h"; path = "../../JuceLibraryCode/modules/juce_graphics/effects/juce_ImageEffectFilter.h"; sourceTree = "SOURCE_ROOT"; };
-		B3BAC48D01C49D8727D08097 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ListBox.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ListBox.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B43C27BEC3AB681389FC5FC5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativeCoordinate.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinate.h"; sourceTree = "SOURCE_ROOT"; };
-		B47B3368AA1A182B0CA1AB26 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Butterworth.cpp; path = ../../Source/Dsp/Butterworth.cpp; sourceTree = "SOURCE_ROOT"; };
-		B4C52FC94D6C680C33ED85C9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_File.cpp"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_File.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B4F0C0B262654C4782B5AC49 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileChooserDialogBox.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooserDialogBox.h"; sourceTree = "SOURCE_ROOT"; };
-		B5ADA0C1BDBFAE2A2F8ECB48 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_EdgeTable.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_EdgeTable.h"; sourceTree = "SOURCE_ROOT"; };
-		B5B417E4196236A2CDE7F0CF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioFormatManager.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B5E8A19FF91BEAD02C63E05B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LowLevelGraphicsPostScriptRenderer.h"; path = "../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsPostScriptRenderer.h"; sourceTree = "SOURCE_ROOT"; };
-		B5FBD4DBD2CFE0FFF457D7F6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ReferenceCountedArray.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_ReferenceCountedArray.h"; sourceTree = "SOURCE_ROOT"; };
-		B60D02B5BF564ABC88841B1F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TableHeaderComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		B64193A23B69D4A88CDEDD0C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiOutput.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiOutput.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B64893F699A10B03AA4AFF6B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CharPointer_ASCII.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_ASCII.h"; sourceTree = "SOURCE_ROOT"; };
-		B6567CAE2B538E79E7DA814C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ThreadWithProgressWindow.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ThreadWithProgressWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B674DCA2C2A6AF6B58AA7820 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentAnimator.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentAnimator.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B678CFC6B378A58834D2E41F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_LowLevelGraphicsPostScriptRenderer.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsPostScriptRenderer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B70D836E0756C3D4EE8E20F2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDetector.h; path = ../../Source/Processors/SpikeDetector.h; sourceTree = "SOURCE_ROOT"; };
-		B767A249792EB15A87054409 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChebyshevII.cpp; path = ../../Source/Dsp/ChebyshevII.cpp; sourceTree = "SOURCE_ROOT"; };
-		B7BEB7779860FE877E4D1BC8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TextDiff.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_TextDiff.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B7D848E4F85AE11FDE4D164D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_AudioCDReader.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_AudioCDReader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B83EBFAE6306941F79044523 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DirectoryContentsDisplayComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsDisplayComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B84E9C47FEE13D162CE9E5D7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ISCAN.cpp; path = ../../Source/Processors/ISCAN.cpp; sourceTree = "SOURCE_ROOT"; };
-		B87864B2D6A2E741D4B426A3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_Threads.mm"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_mac_Threads.mm"; sourceTree = "SOURCE_ROOT"; };
-		B87C1BD13762817BE27DC2F7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FillType.h"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_FillType.h"; sourceTree = "SOURCE_ROOT"; };
-		B8A9063181FEE1920095F824 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ChangeBroadcaster.h"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ChangeBroadcaster.h"; sourceTree = "SOURCE_ROOT"; };
-		B8D19858CC01BB5F7C35ED58 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_XmlDocument.cpp"; path = "../../JuceLibraryCode/modules/juce_core/xml/juce_XmlDocument.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B917780A75945062761B6945 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WiFiOutput.h; path = ../../Source/Processors/WiFiOutput.h; sourceTree = "SOURCE_ROOT"; };
-		B93B8666F8AF2E5D2E851B1C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_VSTPluginFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B9E2607F1605D308CB331FCC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_StringPairArray.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_StringPairArray.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BA03776682290FF1AF4C0106 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PluginDescription.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_PluginDescription.h"; sourceTree = "SOURCE_ROOT"; };
-		BA09F5CDB1C01E0FC153DB8E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_NativeMessageBox.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_NativeMessageBox.h"; sourceTree = "SOURCE_ROOT"; };
-		BA2923571505AD47CA1EF878 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WiFiOutputEditor.h; path = ../../Source/Processors/Editors/WiFiOutputEditor.h; sourceTree = "SOURCE_ROOT"; };
-		BA422CC894B825834A0C5479 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GraphViewer.h; path = ../../Source/UI/GraphViewer.h; sourceTree = "SOURCE_ROOT"; };
-		BABBEE3876B90C8A57C3074D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComponentAnimator.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentAnimator.h"; sourceTree = "SOURCE_ROOT"; };
-		BAE93A5EEC37D7B4C793BFA2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_QuickTimeAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_QuickTimeAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BB0BB31575E1377F0C560D53 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RelativeCoordinate.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BB26BA9CFAE8C836251E8EAF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MainWindow.h; path = ../../Source/MainWindow.h; sourceTree = "SOURCE_ROOT"; };
-		BBC386B5A369262583AD4DDA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_QuickTimeAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_QuickTimeAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		BBCBB940B85B1695225C9A13 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AdvancerNode.h; path = ../../Source/Processors/AdvancerNode.h; sourceTree = "SOURCE_ROOT"; };
-		BBCDE855BD0A58D3779D96A8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RHD2000Editor.h; path = ../../Source/Processors/Editors/RHD2000Editor.h; sourceTree = "SOURCE_ROOT"; };
-		BBD9C2AED6F500D090069007 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ReferenceNode.cpp; path = ../../Source/Processors/ReferenceNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		BBDFB328C3D5FC72A0446E6A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_graphics.mm"; path = "../../JuceLibraryCode/modules/juce_graphics/juce_graphics.mm"; sourceTree = "SOURCE_ROOT"; };
-		BBE1DB78E35135B41537DCB5 = { isa = PBXFileReference; lastKnownFileType = file.nib; name = RecentFilesMenuTemplate.nib; path = RecentFilesMenuTemplate.nib; sourceTree = "SOURCE_ROOT"; };
-		BBF5345C0570D87C01A73FF9 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "noise_wave.png"; path = "../../Resources/Images/Icons/noise_wave.png"; sourceTree = "SOURCE_ROOT"; };
-		BC06C1E8052799F4696101C3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_SystemStats.mm"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_mac_SystemStats.mm"; sourceTree = "SOURCE_ROOT"; };
-		BC3B7E4E25505D9044BFACC7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDetector.cpp; path = ../../Source/Processors/SpikeDetector.cpp; sourceTree = "SOURCE_ROOT"; };
-		BC953E395B22FB1D305E483E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MACAddress.h"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_MACAddress.h"; sourceTree = "SOURCE_ROOT"; };
-		BCB6A6D5A0C1417D74C29632 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Files.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_win32_Files.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BCBBF8764A2101CD0E91DB5D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DropShadower.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_DropShadower.h"; sourceTree = "SOURCE_ROOT"; };
-		BD1D02C70CCE095217581A5F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_ios_MessageManager.mm"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_ios_MessageManager.mm"; sourceTree = "SOURCE_ROOT"; };
-		BD59A961F87AB628777894DC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioThumbnailCache.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnailCache.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BDFF189EC742274DD2629196 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RectangleList.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_RectangleList.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BE45C52599CD88A456166B49 = { isa = PBXFileReference; lastKnownFileType = image.png; name = monkey.png; path = ../../Resources/Images/Icons/monkey.png; sourceTree = "SOURCE_ROOT"; };
-		BE506F381B90833512348968 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FloatVectorOperations.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BEC4B69320BE492526794DFB = { isa = PBXFileReference; lastKnownFileType = image.png; name = wifi.png; path = ../../Resources/Images/Icons/wifi.png; sourceTree = "SOURCE_ROOT"; };
-		BF647E1FAE73208AC29C14F7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Sampler.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/sampler/juce_Sampler.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BF8B07C8BC86002C3DC94DEE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MemoryOutputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryOutputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		BF9B6B0B73FF87595307D858 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_gui_basics/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		BFF368651E3CEE5A900391A6 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "square_wave.png"; path = "../../Resources/Images/Icons/square_wave.png"; sourceTree = "SOURCE_ROOT"; };
-		C055D09224D84121A3EBB29F = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		C0A718EA721772EA6B837F39 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_SystemStats.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_win32_SystemStats.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C0B54E0803BA87C8BC353551 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_video.h"; path = "../../JuceLibraryCode/modules/juce_video/juce_video.h"; sourceTree = "SOURCE_ROOT"; };
-		C0C6335FEE0844872FDF4EE2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Memory.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_Memory.h"; sourceTree = "SOURCE_ROOT"; };
-		C10DC7C6E887B4EAAB8EDF38 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ChoicePropertyComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ChoicePropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		C1435AB0105CDC29A3124E4F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CustomTypeface.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_CustomTypeface.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C16065CD5A8054262B81C1A3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_cryptography.h"; path = "../../JuceLibraryCode/modules/juce_cryptography/juce_cryptography.h"; sourceTree = "SOURCE_ROOT"; };
-		C17E85281A455245543930E5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_NSViewComponentPeer.mm"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm"; sourceTree = "SOURCE_ROOT"; };
-		C195559D311BAB51CFB545BA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MultiDocumentPanel.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_MultiDocumentPanel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C1CB526B75E406851FA918C6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = State.cpp; path = ../../Source/Dsp/State.cpp; sourceTree = "SOURCE_ROOT"; };
-		C1E1CCE5796B40E0A45FB021 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioThumbnail.h"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnail.h"; sourceTree = "SOURCE_ROOT"; };
-		C209C7633D01E525231EE894 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GlyphArrangement.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_GlyphArrangement.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C224FFE93AB9ACD2263F8877 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LogWindow.h; path = ../../Source/UI/LogWindow.h; sourceTree = "SOURCE_ROOT"; };
-		C2746A86EC16D3EA9FAC2C1D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_XmlElement.cpp"; path = "../../JuceLibraryCode/modules/juce_core/xml/juce_XmlElement.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C29BC68B2721471F32906FEB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ResamplingNode.h; path = ../../Source/Processors/ResamplingNode.h; sourceTree = "SOURCE_ROOT"; };
-		C29E664781AA2396C8D59543 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_events.mm"; path = "../../JuceLibraryCode/modules/juce_events/juce_events.mm"; sourceTree = "SOURCE_ROOT"; };
-		C2D1409D20E154E43569C725 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ImagePreviewComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_ImagePreviewComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C2F9D279FCC5C4AD56A0C1DF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Decibels.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_Decibels.h"; sourceTree = "SOURCE_ROOT"; };
-		C39772F796D85E8FE98474D5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Filter.h; path = ../../Source/Dsp/Filter.h; sourceTree = "SOURCE_ROOT"; };
-		C3BD84D9B090F98DD09F5958 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Params.h; path = ../../Source/Dsp/Params.h; sourceTree = "SOURCE_ROOT"; };
-		C41504F388D0B181B003B627 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativePoint.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePoint.h"; sourceTree = "SOURCE_ROOT"; };
-		C446923C1950EB5BE5E67F15 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TargetPlatform.h"; path = "../../JuceLibraryCode/modules/juce_core/system/juce_TargetPlatform.h"; sourceTree = "SOURCE_ROOT"; };
-		C454DFC77F19AB044372610E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MarkerList.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_MarkerList.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C4B0DF8094C90543A65E03E3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Legendre.cpp; path = ../../Source/Dsp/Legendre.cpp; sourceTree = "SOURCE_ROOT"; };
-		C51CD15B311D0AAC08D0B908 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ImageIcon.h; path = ../../Source/Processors/Editors/ImageIcon.h; sourceTree = "SOURCE_ROOT"; };
-		C5287F057A6A88BC33D5498A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DrawableComposite.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableComposite.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C54760E4888674CF3CF022E6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioProcessor.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessor.h"; sourceTree = "SOURCE_ROOT"; };
-		C5785E58E6F915165729EF16 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RecordControl.h; path = ../../Source/Processors/Utilities/RecordControl.h; sourceTree = "SOURCE_ROOT"; };
-		C5ABE6BDCA91410BA92A7BD9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ResamplingNodeEditor.cpp; path = ../../Source/Processors/Editors/ResamplingNodeEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		C5D0E0996D20BEEEDBFD64FA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ValueTree.h"; path = "../../JuceLibraryCode/modules/juce_data_structures/values/juce_ValueTree.h"; sourceTree = "SOURCE_ROOT"; };
-		C5D9C53AE4AE414244E1E19A = { isa = PBXFileReference; lastKnownFileType = image.png; name = muteoff.png; path = ../../Resources/Images/Buttons/muteoff.png; sourceTree = "SOURCE_ROOT"; };
-		C5F9A0F8EB81AC15D9BDD61F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLFrameBuffer.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLFrameBuffer.h"; sourceTree = "SOURCE_ROOT"; };
-		C660716FDD337EFB1A7C6C72 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Path.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Path.h"; sourceTree = "SOURCE_ROOT"; };
-		C679AE9BBB9B1EE3BAB09E11 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileBasedDocument.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/documents/juce_FileBasedDocument.h"; sourceTree = "SOURCE_ROOT"; };
-		C67AA7952D9EF7E248118B85 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_StringPool.cpp"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_StringPool.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C67C5EC0EE8DBC501C8AA395 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_NamedPipe.h"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_NamedPipe.h"; sourceTree = "SOURCE_ROOT"; };
-		C6BDC4DAD5B40321DA67462A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ApplicationCommandTarget.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandTarget.h"; sourceTree = "SOURCE_ROOT"; };
-		C6E19D3864B40A52BCC49315 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ModifierKeys.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_ModifierKeys.h"; sourceTree = "SOURCE_ROOT"; };
-		C74399C81B1A0552CC52093E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_GenericAudioProcessorEditor.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		C79249376E3FDF10615E16EA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WiFiOutputEditor.cpp; path = ../../Source/Processors/Editors/WiFiOutputEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		C7A68BAFB04A7D5FD81FA82B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PropertyComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		C7A76C0D1B3DC4A1F059E59B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Label.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Label.h"; sourceTree = "SOURCE_ROOT"; };
-		C7CA628FE3E1E3D16B24E059 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_Threads.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_android_Threads.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C844D1792A91BE2D8808CB14 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MessageManager.h"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_MessageManager.h"; sourceTree = "SOURCE_ROOT"; };
-		C868329EBC1BBA606AB2EB88 = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		C916444FD4BFB79D4DE9FCAF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AttributedString.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_AttributedString.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C91ED2E43CF9CC0E83EB50A7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkEvents.cpp; path = ../../Source/Processors/NetworkEvents.cpp; sourceTree = "SOURCE_ROOT"; };
-		C98D4FF283E598244E89CD83 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TextDiff.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_TextDiff.h"; sourceTree = "SOURCE_ROOT"; };
-		CA09B0483969444C7CD106DC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_Fonts.mm"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_Fonts.mm"; sourceTree = "SOURCE_ROOT"; };
-		CAA3B9396EA62166234DAEF1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = VisualizerEditor.cpp; path = ../../Source/Processors/Editors/VisualizerEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		CB2C4FD47184B2FE84408CAD = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-03.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-03.png"; sourceTree = "SOURCE_ROOT"; };
-		CC35C78D5B446ABF57DDDAE0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ImageFileFormat.h"; path = "../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageFileFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		CC42C4D4230BE4F1071CB2D3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ResizableEdgeComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableEdgeComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		CC62E20B1189C697DD238810 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGL_linux.h"; path = "../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_linux.h"; sourceTree = "SOURCE_ROOT"; };
-		CCC20313AD0D0993F9EDD1B3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SplitterEditor.h; path = ../../Source/Processors/Editors/SplitterEditor.h; sourceTree = "SOURCE_ROOT"; };
-		CD2370F8F4A44446558A08FB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Parameter.cpp; path = ../../Source/Processors/Parameter.cpp; sourceTree = "SOURCE_ROOT"; };
-		CD2E26CFD0DC7F6090E15A20 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Line.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Line.h"; sourceTree = "SOURCE_ROOT"; };
-		CD41C1D09F6D73FA33993F45 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Desktop.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Desktop.h"; sourceTree = "SOURCE_ROOT"; };
-		CD492AC7B458FA6C321B9D0B = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_core/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		CD7E06ED47B243518F42DA49 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerA-02.png"; path = "../../Resources/Images/Buttons/MergerA-02.png"; sourceTree = "SOURCE_ROOT"; };
-		CD83E301AE42E6E3317D575D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TableHeaderComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		CDC18ABAFEF000C720CE8622 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CallOutBox.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_CallOutBox.cpp"; sourceTree = "SOURCE_ROOT"; };
-		CE2BD40797A6E7647FDBE736 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ColourSelector.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_ColourSelector.cpp"; sourceTree = "SOURCE_ROOT"; };
-		CF5BC8DB7D66C655DABA9129 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_android_FileChooser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/native/juce_android_FileChooser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		CF758CB1E06DDA1AB7F5C9CC = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_events.h"; path = "../../JuceLibraryCode/modules/juce_events/juce_events.h"; sourceTree = "SOURCE_ROOT"; };
-		CFB86C1F2A6076ADC36692AA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Utilities.h; path = ../../Source/Dsp/Utilities.h; sourceTree = "SOURCE_ROOT"; };
-		D01254FA41688494C3CB0889 = { isa = PBXFileReference; lastKnownFileType = file.ttf; name = silkscreen.ttf; path = ../../Resources/Fonts/silkscreen.ttf; sourceTree = "SOURCE_ROOT"; };
-		D0247929128D618A2EB01D86 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OpenGLHelpers.cpp"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLHelpers.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D056D7F6C8EA8A6BBCC5C092 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_InputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_InputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		D06A8FDAD8B22537EA594383 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StretchableLayoutResizerBar.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutResizerBar.h"; sourceTree = "SOURCE_ROOT"; };
-		D0D7CE266BD7CC5455926700 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioSourcePlayer.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioSourcePlayer.h"; sourceTree = "SOURCE_ROOT"; };
-		D0E568AD5445AF061317E01D = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_audio_formats/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		D11BC618E53E6605B3A579E1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MemoryBlock.cpp"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_MemoryBlock.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D128F31F18331117287F5EC5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ArduinoOutput.h; path = ../../Source/Processors/ArduinoOutput.h; sourceTree = "SOURCE_ROOT"; };
-		D162391A46FF93093C328F9D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GZIPCompressorOutputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPCompressorOutputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D171071934C8F7F925B0D113 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TableListBox.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableListBox.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D1D8F82F848413581B274A5D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_CameraDevice.cpp"; path = "../../JuceLibraryCode/modules/juce_video/native/juce_win32_CameraDevice.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D1F9878B45ABC403F3749567 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileBasedDocument.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/documents/juce_FileBasedDocument.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D22D3958949713747DAF59A3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_SystemStats.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_linux_SystemStats.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D2696B30CBEAD7CE72510AFA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = InfoLabel.h; path = ../../Source/UI/InfoLabel.h; sourceTree = "SOURCE_ROOT"; };
-		D2A3B4CDD296B4CEC6902FD7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UIComponent.cpp; path = ../../Source/UI/UIComponent.cpp; sourceTree = "SOURCE_ROOT"; };
-		D2CCDDF54D6D6F2BF4281F2D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BooleanPropertyComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_BooleanPropertyComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D30880F1F9F514CEEDB9F48B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppConfig.h; path = ../../JuceLibraryCode/AppConfig.h; sourceTree = "SOURCE_ROOT"; };
-		D357A886F6365DA33D639FF5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_NSViewComponent.mm"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_NSViewComponent.mm"; sourceTree = "SOURCE_ROOT"; };
-		D38E60AC4854B6E1EDE488EB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ArduinoOutput.cpp; path = ../../Source/Processors/ArduinoOutput.cpp; sourceTree = "SOURCE_ROOT"; };
-		D3AE8303545E28D793312F46 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = GenericEditor.cpp; path = ../../Source/Processors/Editors/GenericEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		D41ED9ADBE3B27E185B2E3F3 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-05.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-05.png"; sourceTree = "SOURCE_ROOT"; };
-		D46A0FAD95FD6DAC1877712B = { isa = PBXFileReference; lastKnownFileType = image.png; name = rodent.png; path = ../../Resources/Images/Icons/rodent.png; sourceTree = "SOURCE_ROOT"; };
-		D48EB74E1B5AAC7846196B01 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Fonts.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_linux_Fonts.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D4B0BD47094D79AB6382228B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLTexture.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLTexture.h"; sourceTree = "SOURCE_ROOT"; };
-		D4F94F0232F0CD426DFC44C5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PreferencesPanel.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_PreferencesPanel.h"; sourceTree = "SOURCE_ROOT"; };
-		D51315B4241B019BE43EE4F1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SplitterEditor.cpp; path = ../../Source/Processors/Editors/SplitterEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		D51575B9AA7216CCE4B558E4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TopLevelWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TopLevelWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		D55137DE3404D7DF2A1F50D0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_GIFLoader.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/image_formats/juce_GIFLoader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D5D6DAA3CFDD395096D2B072 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ReferenceCountedObject.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_ReferenceCountedObject.h"; sourceTree = "SOURCE_ROOT"; };
-		D60F42AEB8551E83215691C3 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ZipFile.h"; path = "../../JuceLibraryCode/modules/juce_core/zip/juce_ZipFile.h"; sourceTree = "SOURCE_ROOT"; };
-		D627F12C36013C7EFE0B0B63 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OscilloscopeNode.h; path = ../../Source/Processors/OscilloscopeNode.h; sourceTree = "SOURCE_ROOT"; };
-		D679982E05B9510FE239D690 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_OutputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_OutputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D685CFEA6344360FBFC355B6 = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiscRecording.framework; path = System/Library/Frameworks/DiscRecording.framework; sourceTree = SDKROOT; };
-		D71AD519382D547C958B0175 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_UndoableAction.h"; path = "../../JuceLibraryCode/modules/juce_data_structures/undomanager/juce_UndoableAction.h"; sourceTree = "SOURCE_ROOT"; };
-		D7807913367AD1B1FCBDEFAC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ApplicationBase.cpp"; path = "../../JuceLibraryCode/modules/juce_events/messages/juce_ApplicationBase.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D7E51310BD1B8EF6A2A77177 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MenuBarModel.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarModel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D840E516B1DE9F3F730283D5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_KeyboardFocusTraverser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyboardFocusTraverser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D88B0ADDC9BF206E3D2EE9F6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RectangleList.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_RectangleList.h"; sourceTree = "SOURCE_ROOT"; };
-		D8A40F2BFBEC65019C867786 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Time.h"; path = "../../JuceLibraryCode/modules/juce_core/time/juce_Time.h"; sourceTree = "SOURCE_ROOT"; };
-		D8AA3ED11D45FACF74B5FC05 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-01.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-01.png"; sourceTree = "SOURCE_ROOT"; };
-		D8AFDCC674A7514B7019EEA6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawableButton.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_DrawableButton.h"; sourceTree = "SOURCE_ROOT"; };
-		D8D895B3AD895C6E7FD446BF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Custom.cpp; path = ../../Source/Dsp/Custom.cpp; sourceTree = "SOURCE_ROOT"; };
-		D90290A0AA2C36CE757E46D5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FilterEditor.cpp; path = ../../Source/Processors/Editors/FilterEditor.cpp; sourceTree = "SOURCE_ROOT"; };
-		D952A208CC8164F0B459EC9E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_WebBrowserComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_linux_WebBrowserComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D960588B732D973B82500E2D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioProcessorListener.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorListener.h"; sourceTree = "SOURCE_ROOT"; };
-		D9C9FCA6D705B72B80DB1142 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Socket.cpp"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_Socket.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D9CB4CEC2C07346BE69262A0 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-01.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-01.png"; sourceTree = "SOURCE_ROOT"; };
-		DA0AE9F4A1DDC3555247216F = { isa = PBXFileReference; lastKnownFileType = image.png; name = IntanIcon.png; path = ../../Resources/Images/Icons/IntanIcon.png; sourceTree = "SOURCE_ROOT"; };
-		DA30BA6BF482A353393D5926 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RelativeRectangle.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeRectangle.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DAA04A0FD47097893712B241 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDisplayNode.cpp; path = ../../Source/Processors/SpikeDisplayNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		DAA4306D30617137463ED247 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativeRectangle.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeRectangle.h"; sourceTree = "SOURCE_ROOT"; };
-		DAC81FECCE54087394BE69F7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_WaitableEvent.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_WaitableEvent.h"; sourceTree = "SOURCE_ROOT"; };
-		DACD0879E139527D971D3AC4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileListComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileListComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		DB4F34DA0F04B40EB6A50FB1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_SystemStats.h"; path = "../../JuceLibraryCode/modules/juce_core/system/juce_SystemStats.h"; sourceTree = "SOURCE_ROOT"; };
-		DB4FB8EAFA1714529E527C3D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Messaging.cpp"; path = "../../JuceLibraryCode/modules/juce_events/native/juce_win32_Messaging.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DB4FF7675E5C98CF62DA8A2E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AccessClass.h; path = ../../Source/AccessClass.h; sourceTree = "SOURCE_ROOT"; };
-		DB550BAB034060FF4578BB64 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_audio_basics.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/juce_audio_basics.h"; sourceTree = "SOURCE_ROOT"; };
-		DB702F259EF24DAB9EC99D0A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FPGAOutput.h; path = ../../Source/Processors/FPGAOutput.h; sourceTree = "SOURCE_ROOT"; };
-		DB7866AFC8A4894810DBD05E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_InterProcessLock.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_InterProcessLock.h"; sourceTree = "SOURCE_ROOT"; };
-		DBB295F412798131D3F04045 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PulsePalOutput.cpp; path = ../../Source/Processors/PulsePalOutput.cpp; sourceTree = "SOURCE_ROOT"; };
-		DBB769DEBCD6468C13A3CD25 = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
-		DBB86AD59BA3F6EC09AF2C02 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpDisplayNode.h; path = ../../Source/Processors/LfpDisplayNode.h; sourceTree = "SOURCE_ROOT"; };
-		DBCA7E2FFCFD1354DD19DDD6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_data_structures.mm"; path = "../../JuceLibraryCode/modules/juce_data_structures/juce_data_structures.mm"; sourceTree = "SOURCE_ROOT"; };
-		DBED17FBB262C4DACEEDA9B0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiKeyboardState.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiKeyboardState.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DBF1FD9272546EE4C7DD517A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_mac_SystemTrayIcon.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_SystemTrayIcon.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DC17FC0E3B6E3B7C45079DE0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = OscilloscopeNode.cpp; path = ../../Source/Processors/OscilloscopeNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		DC200873B263C55E82B5384D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MultiTimer.h"; path = "../../JuceLibraryCode/modules/juce_events/timers/juce_MultiTimer.h"; sourceTree = "SOURCE_ROOT"; };
-		DD5695DE97CEF7BE76869232 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_FileOutputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_FileOutputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DDD2075B59AF7E38447BA84B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TrialCircularBuffer.cpp; path = ../../Source/Processors/TrialCircularBuffer.cpp; sourceTree = "SOURCE_ROOT"; };
-		DDE157BB06373ECDBB23469C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StretchableLayoutManager.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutManager.h"; sourceTree = "SOURCE_ROOT"; };
-		DDE89F0D5E01F079323CC89C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioProcessorPlayer.h"; path = "../../JuceLibraryCode/modules/juce_audio_utils/players/juce_AudioProcessorPlayer.h"; sourceTree = "SOURCE_ROOT"; };
-		DE4861552DB1976665B25DFD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_HighResolutionTimer.cpp"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_HighResolutionTimer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DEB9A630503639D42056236B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_UndoManager.h"; path = "../../JuceLibraryCode/modules/juce_data_structures/undomanager/juce_UndoManager.h"; sourceTree = "SOURCE_ROOT"; };
-		DEE2959DBBC84EA8448A0F77 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TimeSliceThread.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_TimeSliceThread.h"; sourceTree = "SOURCE_ROOT"; };
-		DEF465116BB906FD116DA5EB = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ofConstants.h; path = ../../Source/Processors/Serial/ofConstants.h; sourceTree = "SOURCE_ROOT"; };
-		DF3C9A1DD67E879E4E0A2727 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_audio_basics.mm"; path = "../../JuceLibraryCode/modules/juce_audio_basics/juce_audio_basics.mm"; sourceTree = "SOURCE_ROOT"; };
-		DFAA7B563CEFB94D9ADB5D6A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CPlusPlusCodeTokeniser.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CPlusPlusCodeTokeniser.h"; sourceTree = "SOURCE_ROOT"; };
-		DFFB7396DCE9DF1253217584 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioThumbnailCache.h"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnailCache.h"; sourceTree = "SOURCE_ROOT"; };
-		E040EA8B5BB61ABBBD14F12F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OggVorbisAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		E08E877C3A6283CF5C803957 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MainWindow.cpp; path = ../../Source/MainWindow.cpp; sourceTree = "SOURCE_ROOT"; };
-		E0ADC34D69113B79C2F4FF24 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CustomTypeface.h"; path = "../../JuceLibraryCode/modules/juce_graphics/fonts/juce_CustomTypeface.h"; sourceTree = "SOURCE_ROOT"; };
-		E0C264CF6345ABB4CAB98B92 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ScopedPointer.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_ScopedPointer.h"; sourceTree = "SOURCE_ROOT"; };
-		E20D5F2F75478DA4943CEDBD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ActionBroadcaster.h"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ActionBroadcaster.h"; sourceTree = "SOURCE_ROOT"; };
-		E216D095C98F850A5FB6FB0F = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChannelSelector.cpp; path = ../../Source/Processors/Editors/ChannelSelector.cpp; sourceTree = "SOURCE_ROOT"; };
-		E21CA41B44E191F1804F9662 = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_data_structures/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		E23FA5E940A1434B0305875D = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ResizableCornerComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableCornerComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		E2F46E110416D628C11392CA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Parameter.h; path = ../../Source/Processors/Parameter.h; sourceTree = "SOURCE_ROOT"; };
-		E31563D2E7DDD8315F369233 = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		E33F167E4AA1C44596A1EBED = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_mac_CoreGraphicsHelpers.h"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		E34E535DA9CBF248E32F7B45 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ReadWriteLock.cpp"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_ReadWriteLock.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E37140E9E8F7CFDDEEEF6148 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ToolbarItemFactory.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemFactory.h"; sourceTree = "SOURCE_ROOT"; };
-		E3C4B6B362320594789E1297 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PropertySet.cpp"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_PropertySet.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E3D9DABE0A9C1DCE6A6515CB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MixerAudioSource.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_MixerAudioSource.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E413F3262886677B4CBF3FA9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NotchFilterNode.cpp; path = ../../Source/Processors/NotchFilterNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		E419C9DA3202B8B6EC2DB723 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Reverb.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_Reverb.h"; sourceTree = "SOURCE_ROOT"; };
-		E42B745B4D2DCADE54F94757 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EventNode.h; path = ../../Source/Processors/EventNode.h; sourceTree = "SOURCE_ROOT"; };
-		E442E1FA7B58BFF6F1D8CBD8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelMappingEditor.h; path = ../../Source/Processors/Editors/ChannelMappingEditor.h; sourceTree = "SOURCE_ROOT"; };
-		E44B26F5D97CB483242DE05B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RBJ.h; path = ../../Source/Dsp/RBJ.h; sourceTree = "SOURCE_ROOT"; };
-		E48A7B152993BCF473725A19 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CameraDevice.h"; path = "../../JuceLibraryCode/modules/juce_video/capture/juce_CameraDevice.h"; sourceTree = "SOURCE_ROOT"; };
-		E4A2E203101AF37C169F1569 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BufferingAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_BufferingAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		E53FEAA3754E6B5D99516D56 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_KnownPluginList.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_KnownPluginList.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E58A18793D25A1D75811A052 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ImagePreviewComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_ImagePreviewComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		E594A85A291E0625E0410A85 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpDisplayEditor.h; path = ../../Source/Processors/Editors/LfpDisplayEditor.h; sourceTree = "SOURCE_ROOT"; };
-		E5B10AA248D400FDB2645084 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_WASAPI.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E5C1D021C0FD6FAD082C5D75 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = GraphViewer.cpp; path = ../../Source/UI/GraphViewer.cpp; sourceTree = "SOURCE_ROOT"; };
-		E666E60CC07666669FC77C7D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MemoryOutputStream.cpp"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryOutputStream.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E67C5ACDC8208CDE200EC8C6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_graphics.h"; path = "../../JuceLibraryCode/modules/juce_graphics/juce_graphics.h"; sourceTree = "SOURCE_ROOT"; };
-		E6D3A973D5CEF18CA2BAFF59 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TextButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_TextButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E7366E169158F5A2D1D7B55A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MidiFile.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiFile.h"; sourceTree = "SOURCE_ROOT"; };
-		E7460F066237871A704733E7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_InterprocessConnection.h"; path = "../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnection.h"; sourceTree = "SOURCE_ROOT"; };
-		E79259F2164D16553A69B458 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioComponent.h; path = ../../Source/Audio/AudioComponent.h; sourceTree = "SOURCE_ROOT"; };
-		E79B7DC03F81DA1F8CDE21CA = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ApplicationCommandManager.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandManager.h"; sourceTree = "SOURCE_ROOT"; };
-		E7ACE8C1456403A574236451 = { isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-bold-serialized"; path = "../../Resources/Fonts/cpmono-bold-serialized"; sourceTree = "SOURCE_ROOT"; };
-		E7EE416EF527C7506B499070 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BigInteger.h"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_BigInteger.h"; sourceTree = "SOURCE_ROOT"; };
-		E8174B3346AA69361BF73AE1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Cascade.h; path = ../../Source/Dsp/Cascade.h; sourceTree = "SOURCE_ROOT"; };
-		E817F0471AF514FD075B5DB7 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SerialInput.h; path = ../../Source/Processors/SerialInput.h; sourceTree = "SOURCE_ROOT"; };
-		E835BEB3C42E4B241804BE13 = { isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-light-serialized"; path = "../../Resources/Fonts/cpmono-light-serialized"; sourceTree = "SOURCE_ROOT"; };
-		E8480C4ED7F9579F6172F7B5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Common.h; path = ../../Source/Dsp/Common.h; sourceTree = "SOURCE_ROOT"; };
-		E8964C0BE264A55753BC6B7B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Midi.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_Midi.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E90FCB43DA2FF766597DA75E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Documentation.cpp; path = ../../Source/Dsp/Documentation.cpp; sourceTree = "SOURCE_ROOT"; };
-		E91923510CB2280C3A3B9E9C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LocalisedStrings.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_LocalisedStrings.h"; sourceTree = "SOURCE_ROOT"; };
-		E91A272EF06892937CB4B9CE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentDragger.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_ComponentDragger.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E93BE115650B1CB80EACB841 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EditorViewportButtons.h; path = ../../Source/UI/EditorViewportButtons.h; sourceTree = "SOURCE_ROOT"; };
-		E946426F95E0240683CB3337 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawablePath.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawablePath.h"; sourceTree = "SOURCE_ROOT"; };
-		E97684DCE824DEDA6683C6CD = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Synthesiser.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/synthesisers/juce_Synthesiser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EA2FC92CECD1EDA1F07DC59C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TooltipWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TooltipWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		EA354D7D8E48D461415D52D8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_JPEGLoader.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/image_formats/juce_JPEGLoader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EA535EA158451360B7B8AE52 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpDisplayNode.cpp; path = ../../Source/Processors/LfpDisplayNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		EA73332E3D5AEC04ADDFBB2A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioDataConverters.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioDataConverters.h"; sourceTree = "SOURCE_ROOT"; };
-		EA9518CDEA7049C21D5CE2D5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Process.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_Process.h"; sourceTree = "SOURCE_ROOT"; };
-		EAB2319C7AA57E06A2247CDF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BorderSize.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_BorderSize.h"; sourceTree = "SOURCE_ROOT"; };
-		EAB637B566FEBBDADA654262 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_VSTMidiEventList.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_VSTMidiEventList.h"; sourceTree = "SOURCE_ROOT"; };
-		EAB6A66678B122C578B16445 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_HighResolutionTimer.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_HighResolutionTimer.h"; sourceTree = "SOURCE_ROOT"; };
-		EAC262A83CD2BEA14542AE89 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StringPool.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_StringPool.h"; sourceTree = "SOURCE_ROOT"; };
-		EAC7A64301F0BF2C5E33A1F9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_InterprocessConnectionServer.cpp"; path = "../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnectionServer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EAEA49B9394D802B79CA8164 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StringPairArray.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_StringPairArray.h"; sourceTree = "SOURCE_ROOT"; };
-		EB5F9A50EB53A57D6AE303C2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "juce_mac_QuickTimeMovieComponent.mm"; path = "../../JuceLibraryCode/modules/juce_video/native/juce_mac_QuickTimeMovieComponent.mm"; sourceTree = "SOURCE_ROOT"; };
-		EC780F52ABBD7317A5CE2F33 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChebyshevI.h; path = ../../Source/Dsp/ChebyshevI.h; sourceTree = "SOURCE_ROOT"; };
-		ECA6FDB1366BE7EC30F1539B = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SourceNode.cpp; path = ../../Source/Processors/SourceNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		ECBEF88BBC974D96ED781C75 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_posix_SharedCode.h"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_posix_SharedCode.h"; sourceTree = "SOURCE_ROOT"; };
-		ECCE033FF2ACE42188FA4A7F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TemporaryFile.h"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_TemporaryFile.h"; sourceTree = "SOURCE_ROOT"; };
-		ECE3BE71EB6B9CF1CE869BBE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BubbleComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_BubbleComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		ED86166920362E9D2BE2CB26 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SVGParser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_SVGParser.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EDA209B0E7D124EA581023AD = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioFormatManager.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatManager.h"; sourceTree = "SOURCE_ROOT"; };
-		EDAC82BD742A54182E8DF2FE = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativeCoordinatePositioner.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinatePositioner.h"; sourceTree = "SOURCE_ROOT"; };
-		EE0336B43A39FD585DF638EE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ResizableEdgeComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableEdgeComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EE2C669B127D00C86B1B8CA8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Registry.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_win32_Registry.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EE4DD055D31F7D9DC718DBD8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_ComponentMovementWatcher.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentMovementWatcher.h"; sourceTree = "SOURCE_ROOT"; };
-		EEA51B7EF1CF19028C6672E0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DocumentWindow.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DocumentWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EF059B26886B32000BCF8CFF = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MouseInputSource.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseInputSource.h"; sourceTree = "SOURCE_ROOT"; };
-		EF3F9AA8D70E1D4D55F13182 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioThumbnail.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnail.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EF4A6E0E1232071252ACCD7B = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativeParallelogram.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeParallelogram.h"; sourceTree = "SOURCE_ROOT"; };
-		EF610B2A17D9B1C0D24DCE67 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_android_JNIHelpers.h"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_android_JNIHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		EF7B66764093D950724EFE70 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_OpenGLShaderProgram.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLShaderProgram.h"; sourceTree = "SOURCE_ROOT"; };
-		F09FD6D9CA4997216ADBF54F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataBuffer.h; path = ../../Source/Processors/DataThreads/DataBuffer.h; sourceTree = "SOURCE_ROOT"; };
-		F0F3834D46EA8FC8ADB206DB = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AbstractFifo.cpp"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_AbstractFifo.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F115ED75E977A54AAF036B2C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MatlabLikePlot.cpp; path = ../../Source/Processors/Visualization/MatlabLikePlot.cpp; sourceTree = "SOURCE_ROOT"; };
-		F17DF27524262A21A3EC932D = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_PluginListComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginListComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F1A3975235880CAC1D5757F4 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MP3AudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_MP3AudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F230A4C0186379F9EB0B0F74 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ReferenceNode.h; path = ../../Source/Processors/ReferenceNode.h; sourceTree = "SOURCE_ROOT"; };
-		F5A00ACFA3D76168F22F1205 = { isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
-		99E1BC08B886CFDD2CCFD462 = { isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "open-ephys.app"; sourceTree = "BUILT_PRODUCTS_DIR"; };
-		EBD8622EAEF10558809888B7 = { isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-01.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-01.png"; sourceTree = "SOURCE_ROOT"; };
-		EC95A2CF4B33EA37DA5FC1AC = { isa = PBXFileReference; lastKnownFileType = file.ttf; name = nordic.ttf; path = ../../Resources/Fonts/nordic.ttf; sourceTree = "SOURCE_ROOT"; };
-		ECB5A75A81B90327F58CBD9E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rhd2000datablock.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000datablock.cpp"; sourceTree = "SOURCE_ROOT"; };
-		ED887A521EEB8F3EBA7DDB31 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioIODeviceType.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.h"; sourceTree = "SOURCE_ROOT"; };
-		EEFC66D2DF5FD66B4D83B22F = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Component.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Component.h"; sourceTree = "SOURCE_ROOT"; };
-		EF8488936B3D3E9178C9099C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PulsePalOutput.h; path = ../../Source/Processors/PulsePalOutput.h; sourceTree = "SOURCE_ROOT"; };
-		EFC21F3CD0EB87D67E044E06 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MenuBarComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		F0CA3600E09054D7DB3B0067 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SmoothedFilter.h; path = ../../Source/Dsp/SmoothedFilter.h; sourceTree = "SOURCE_ROOT"; };
-		F0D9A28C206D7A8BA7089D29 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_KeyMappingEditorComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_KeyMappingEditorComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		F1099BFF0BC1656A23D62E84 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ScrollBar.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ScrollBar.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F10FB240E10A5742CE366A91 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TabbedButtonBar.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedButtonBar.h"; sourceTree = "SOURCE_ROOT"; };
-		F1DBAE92084D9D90234AC436 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioSourcePlayer.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioSourcePlayer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F28414731D9EE1F75D7B7043 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		F2A500BA3500C4A9D5792A54 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawableImage.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableImage.h"; sourceTree = "SOURCE_ROOT"; };
-		F2EDB88302B8A9356F43B834 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Primes.h"; path = "../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_Primes.h"; sourceTree = "SOURCE_ROOT"; };
-		F2F11D7C596DAE5579610CCC = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_AudioCDReader.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_AudioCDReader.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F3D0224E4247BCB06A9E4DDF = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_KeyPressMappingSet.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_KeyPressMappingSet.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F3F48717927A4E24F7373C09 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_NamedValueSet.h"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_NamedValueSet.h"; sourceTree = "SOURCE_ROOT"; };
-		F463A19E6EFEB2837582B117 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_audio_processors.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/juce_audio_processors.h"; sourceTree = "SOURCE_ROOT"; };
-		F46843B979D0385C733C797A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_BubbleMessageComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_BubbleMessageComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F4D2A03314AB1CF852CC4F2A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CPlusPlusCodeTokeniserFunctions.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CPlusPlusCodeTokeniserFunctions.h"; sourceTree = "SOURCE_ROOT"; };
-		F5642B98949DC0FA45EF904E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BufferedInputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/streams/juce_BufferedInputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		F6EBDA368C553C37BE703BE5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Vector3D.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Vector3D.h"; sourceTree = "SOURCE_ROOT"; };
-		F70B7D65EF56B8A0ED36478C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_WavAudioFormat.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WavAudioFormat.h"; sourceTree = "SOURCE_ROOT"; };
-		F796260525BD82FFC1D1732C = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Uuid.cpp"; path = "../../JuceLibraryCode/modules/juce_core/misc/juce_Uuid.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F7979AFD5780D9B2208736EE = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_TooltipWindow.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TooltipWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F7F374C05CDE0DB7712D18D1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Atomic.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_Atomic.h"; sourceTree = "SOURCE_ROOT"; };
-		F8322ED101601866FFB1698C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_FileOutputStream.h"; path = "../../JuceLibraryCode/modules/juce_core/files/juce_FileOutputStream.h"; sourceTree = "SOURCE_ROOT"; };
-		F88A99110564C87FBA281F2C = { isa = PBXFileReference; lastKnownFileType = file; name = "juce_module_info"; path = "../../JuceLibraryCode/modules/juce_video/juce_module_info"; sourceTree = "SOURCE_ROOT"; };
-		F8E202A1374401022F87F26E = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_CoreAudioFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F8EFE3709FDDC2D5F0843058 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Variant.cpp"; path = "../../JuceLibraryCode/modules/juce_core/containers/juce_Variant.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F94BFC6B5057806EEF8B59DA = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioIODevice.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODevice.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F94DD42C7BBF81C101D3F605 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EventNode.cpp; path = ../../Source/Processors/EventNode.cpp; sourceTree = "SOURCE_ROOT"; };
-		F9E2371F1A99B292F2947FF5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DragAndDropTarget.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_DragAndDropTarget.h"; sourceTree = "SOURCE_ROOT"; };
-		F9F37AD1C3E7CA932FF44E69 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_LagrangeInterpolator.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_LagrangeInterpolator.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FA1F1E9C7DEA48CAE6C247F4 = { isa = PBXFileReference; lastKnownFileType = image.png; name = OpenEphysBoardLogoGray.png; path = ../../Resources/Images/Icons/OpenEphysBoardLogoGray.png; sourceTree = "SOURCE_ROOT"; };
-		FA23A1334E4CFA77BC18A153 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FPGAThread.cpp; path = ../../Source/Processors/DataThreads/FPGAThread.cpp; sourceTree = "SOURCE_ROOT"; };
-		FA2F04BA4E146ABF649BBE89 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rhd2000evalboard.h; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000evalboard.h"; sourceTree = "SOURCE_ROOT"; };
-		FAC7E62CC15CA977A6FC72D1 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ChangeBroadcaster.cpp"; path = "../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ChangeBroadcaster.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FB071D0659E5F1CC630D765A = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileReader.h; path = ../../Source/Processors/FileReader.h; sourceTree = "SOURCE_ROOT"; };
-		FB1B880F24F376D1AC52F2A6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_DrawableButton.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_DrawableButton.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FB1EA9CB3C695925627B0AC6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_HeapBlock.h"; path = "../../JuceLibraryCode/modules/juce_core/memory/juce_HeapBlock.h"; sourceTree = "SOURCE_ROOT"; };
-		FB33617B5082CC0CDC189F2C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_KeyboardFocusTraverser.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyboardFocusTraverser.h"; sourceTree = "SOURCE_ROOT"; };
-		FB7E91937D3BBE00F64F0B72 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Colours.h"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colours.h"; sourceTree = "SOURCE_ROOT"; };
-		FC080F7DF94ABCB7EA09224A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Colour.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colour.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FC20BDD5357D39AC43DFC255 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_LADSPAPluginFormat.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FC85D30C66E7A4E4A6CA29AE = { isa = PBXFileReference; lastKnownFileType = file.otf; name = "cpmono_bold.otf"; path = "../../Resources/Fonts/cpmono_bold.otf"; sourceTree = "SOURCE_ROOT"; };
-		FC887C6CD74FE33F8BA784A6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MergerEditor.h; path = ../../Source/Processors/Editors/MergerEditor.h; sourceTree = "SOURCE_ROOT"; };
-		FD03E00D986C57096BA4EEF5 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OscilloscopeEditor.h; path = ../../Source/Processors/Editors/OscilloscopeEditor.h; sourceTree = "SOURCE_ROOT"; };
-		FD3A6BD3A8898E137DF257B9 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_RelativeParallelogram.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeParallelogram.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FD770E73FD462E9C9F6DBFB2 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_PositionableAudioSource.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_PositionableAudioSource.h"; sourceTree = "SOURCE_ROOT"; };
-		FD88DA941838FC91D222DF35 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RecentlyOpenedFilesList.h"; path = "../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_RecentlyOpenedFilesList.h"; sourceTree = "SOURCE_ROOT"; };
-		FDAAB4F0D2A15A6F0F71945A = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ResizableWindow.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ResizableWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FEB3730E084D7DD433D14A6C = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_MouseListener.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseListener.h"; sourceTree = "SOURCE_ROOT"; };
-		FEF0A4E3C8D22A830BCE2B67 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_JackAudio.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FF082466FC37DC44320B3B7E = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Draggable3DOrientation.h"; path = "../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Draggable3DOrientation.h"; sourceTree = "SOURCE_ROOT"; };
-		FF1B5858C942CA02EEC38E69 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ios_Audio.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_ios_Audio.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FF3E5A9F8B9250790C6DA089 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_URL.h"; path = "../../JuceLibraryCode/modules/juce_core/network/juce_URL.h"; sourceTree = "SOURCE_ROOT"; };
-		FF450FAFD49105CE7157DFC0 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Channel.h; path = ../../Source/Processors/Channel.h; sourceTree = "SOURCE_ROOT"; };
-		FFABF04684556C4A54A62439 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tictoc.cpp; path = ../../Source/Processors/tictoc.cpp; sourceTree = "SOURCE_ROOT"; };
-		FFBB9CE85A7C91FB11E4AEC8 = { isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ImageComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ImageComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		FFFBDB9A00240D797751FEE6 = { isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataWindow.h; path = ../../Source/Processors/Visualization/DataWindow.h; sourceTree = "SOURCE_ROOT"; };
-		9ADE9FD3E8A58C12B4B2D8B2 = { isa = PBXGroup; children = (
-				B081687E52C6A5157CFCCB17,
-				E7ACE8C1456403A574236451,
-				38A9627672C2562DBE257A05,
-				E835BEB3C42E4B241804BE13,
-				1719507D8A73EA71F1C3F306,
-				50DB7E5C152DDD03F2FA4C2D,
-				FC85D30C66E7A4E4A6CA29AE,
-				24D86195580EFB86AC084DCC,
-				AA7F6609B897B9E134377A62,
-				783D8922D5C687E170FA1A2C,
-				32B658D7A44849A6F640AF37,
-				847F6986DFA468BA8D80A531,
-				0A2AD4AB14F93364EFB9611E,
-				B13BDA434DEF56BB48B26896,
-				EC95A2CF4B33EA37DA5FC1AC,
-				9D050A509BEB9E3879DA35C6,
-				66F524552E8DE88CDC2E40FD,
-				D01254FA41688494C3CB0889,
-				61317B5191E05925F232E18C ); name = Fonts; sourceTree = "<group>"; };
-		048B10371EA2D5C7D883CC70 = { isa = PBXGroup; children = (
-				261B5AA82F2A86CC5500D8D2,
-				BE45C52599CD88A456166B49,
-				D46A0FAD95FD6DAC1877712B,
-				92E3405CB31ACFE3F80BBAD4,
-				FA1F1E9C7DEA48CAE6C247F4,
-				9F2BCD132F453B9D9EF09F15,
-				57941E5B2E1FF6028A68D4A7,
-				168823A9EBD85BFBFD2CE2EE,
-				7FDFE493862CE27EFCAC3F7F,
-				6D34DD9AB987A67BADE71C65,
-				D8AA3ED11D45FACF74B5FC05,
-				3A6FE617A781EEFFD39E1216,
-				CB2C4FD47184B2FE84408CAD,
-				93EFC1AA800FC5DA2F04A213,
-				D41ED9ADBE3B27E185B2E3F3,
-				D9CB4CEC2C07346BE69262A0,
-				A7FE538FF09AC8A58DE8F1BD,
-				AA3DAC9A4A3FF9E7D279FB23,
-				79BBD2F2F31D76CC4F5BD012,
-				32CEF6C84CD06B18035B035C,
-				EBD8622EAEF10558809888B7,
-				1A22BB28E65B6D6636CCEBF1,
-				1712916024EC787B6C231732,
-				47976F6BE2942EED64AEA4D2,
-				97C4F046D88561EEE245BE99,
-				BBF5345C0570D87C01A73FF9,
-				7C1D87A0C78F661FB459786B,
-				35AEAE0CC0B546625E163B9B,
-				BFF368651E3CEE5A900391A6,
-				5C5E4C396CD83C46F58644A2,
-				BEC4B69320BE492526794DFB,
-				6F9B89F7AD0E13887871D4FE,
-				B1887A7D2E27FF4DD03D16C1,
-				8AE2DDA47B2DFDEEEF69B12F,
-				DA0AE9F4A1DDC3555247216F ); name = Icons; sourceTree = "<group>"; };
-		5B916D6239703986EFCDB624 = { isa = PBXGroup; children = (
-				C5D9C53AE4AE414244E1E19A,
-				A764EF4F46F472715B250E41,
-				05C35036E964AAD6024E0766,
-				CD7E06ED47B243518F42DA49,
-				4F4E8E3B32DB7A91B41C9FFA,
-				3FFC2A3429D8B1D957D18CA7,
-				A3CAB6B56641ED68D9784348,
-				6B7252D3F574AE21BE464327,
-				381F5DC605AE69088004DF80,
-				5EA661C13CB7197A45F20028 ); name = Buttons; sourceTree = "<group>"; };
-		78AACAE5A74DDE52FE5848AF = { isa = PBXGroup; children = (
-				048B10371EA2D5C7D883CC70,
-				5B916D6239703986EFCDB624 ); name = Images; sourceTree = "<group>"; };
-		B9646290EA6B6995F8AEEAFB = { isa = PBXGroup; children = (
-				9ADE9FD3E8A58C12B4B2D8B2,
-				78AACAE5A74DDE52FE5848AF ); name = Resources; sourceTree = "<group>"; };
-		B016FBDF648372A23D7EAAD8 = { isa = PBXGroup; children = (
-				9F577889CB6C54A2F7B1CA80,
-				7B42B28FDB2E3AC67EF296F8 ); name = Network; sourceTree = "<group>"; };
-		BCD632E634E0F8A50827F9B6 = { isa = PBXGroup; children = (
-				1989E86F8DFDE34887AC0326,
-				29D7893C278FFE00782637B6,
-				22801F75289646F6A85E5583,
-				361D8C54B3E54766CBC48046,
-				B47B3368AA1A182B0CA1AB26,
-				6D59D5780ECD2CC9703CB499,
-				09BCBD414282A3AA4F66A3A5,
-				E8174B3346AA69361BF73AE1,
-				AC2CFF4DA5CE431FCC628BA3,
-				EC780F52ABBD7317A5CE2F33,
-				B767A249792EB15A87054409,
-				9CEDA04DB321755AF74D6FAF,
-				E8480C4ED7F9579F6172F7B5,
-				D8D895B3AD895C6E7FD446BF,
-				3063CF211ABB734A9FD452EC,
-				2B93450006102A0093F5EACB,
-				7ACB1CB66D69738904358F43,
-				E90FCB43DA2FF766597DA75E,
-				1086169B0EE86E04B64575C2,
-				392408C1943AC6234BAAC743,
-				A95D898F0998F4609E992B5F,
-				587FCA2485B9C89C2A99C23A,
-				C39772F796D85E8FE98474D5,
-				38313692308D501E4CADF1D5,
-				C4B0DF8094C90543A65E03E3,
-				4939A8B8300394AAD0926C0B,
-				A41C5A4CD5CF8EEFF993A8B1,
-				3F6C67E29CDEDF2EF61C054F,
-				C3BD84D9B090F98DD09F5958,
-				65312FAD0900119CDF6CF414,
-				5A8D46BEB81DDF24462E3D92,
-				9A21A229CFACC67E31F4F727,
-				E44B26F5D97CB483242DE05B,
-				3F69480D6145C77992FA59BA,
-				7EFF8622168303A4391D6CAE,
-				F0CA3600E09054D7DB3B0067,
-				C1CB526B75E406851FA918C6,
-				9428D7423971764AC0BA9CB7,
-				6340B1D2FECEABBBE6C0DE28,
-				CFB86C1F2A6076ADC36692AA ); name = Dsp; sourceTree = "<group>"; };
-		C451728043944D40C69166C1 = { isa = PBXGroup; children = (
-				B04D87ED6AA4897B6CD3CCF6,
-				E79259F2164D16553A69B458 ); name = Audio; sourceTree = "<group>"; };
-		3DE49DED45C5CDD8D184E248 = { isa = PBXGroup; children = (
-				48E12736F471C43C959AD15C,
-				79C32CA8069962F5DE48F633,
-				3753B3B311AE0A9F4CC5AD40,
-				758BC480F153DEA79304366B,
-				DEF465116BB906FD116DA5EB,
-				308F614D30DCB9AE3767C928,
-				92CB21BEE17D1DD03106AD87 ); name = Serial; sourceTree = "<group>"; };
-		4E3C60995CC567F1A839CAE3 = { isa = PBXGroup; children = (
-				258938780F93A7CF41366F26,
-				C5785E58E6F915165729EF16,
-				4867923F31CC3EDC9B1A5BE5,
-				6880C148A38A5C8D0092E358,
-				2C4730CAFED4F6292B575318,
-				B1082A8A306A1947F5B0E5FC ); name = Utilities; sourceTree = "<group>"; };
-		C4B85C0286AC2510730355E3 = { isa = PBXGroup; children = (
-				F115ED75E977A54AAF036B2C,
-				AE3D7946F13CE32AE41DD1B7,
-				08618BD1F5343B5E6457237F,
-				45C7B3A0676BC07190A2338B,
-				5894D40A0E8FA6E9B3EBF9D9,
-				ADCB42E4C5641007A4B78025,
-				A7D4C9E3ED3763847C087F46,
-				4E6EE225098D32E7D5DE60B2,
-				215E1BD79B5870D5356810F0,
-				66463AB11EA4D6341C32F27E,
-				FFFBDB9A00240D797751FEE6,
-				4A94E809624F99387E600399,
-				12B5DDCB6E5ECD93A4C55BB5 ); name = Visualization; sourceTree = "<group>"; };
-		9F16043BF599BCE0C02A00A5 = { isa = PBXGroup; children = (
-				3F45F344950087E1266A6445,
-				FD03E00D986C57096BA4EEF5,
-				7BF1DCDC30FDFBFAF03516C1,
-				4AF8FD4C7E567639A190D943,
-				A77E8538ED93AAADC9FE2646,
-				84BED3AADBD3FAB6EFEC323E,
-				42C88F6EE487194784FD1D6F,
-				2D27078AC6729A4B47C48099,
-				58BBDECD171E15D0768302A1,
-				12BE9C084DEC40230DA8E9A6,
-				7B7819A5759B54D91E334447,
-				2196ED9DD4262C60135E77F5,
-				8B8C25A8261F0A21369FB9D8,
-				78FB85191B054CDE7BD07DB7,
-				07BEF02C2B930DF7847C2921,
-				39D2C460FE587C5F564495A0,
-				28CCF04CCC028BAE0AEE5840,
-				15870472BA2B1779521A21BD,
-				B083B1375828610D55F12CF3,
-				E442E1FA7B58BFF6F1D8CBD8,
-				4B0097003751A59A11FA8C5B,
-				3067867C8C0F6CF6F086A6FC,
-				75B1E4EFCDA9A506CFEDB09F,
-				748AF0975561FFFE51DF5F58,
-				25A9484825F1B93ABC0E577F,
-				00A54510EFB9B0966D0B430C,
-				45D78C8EF660EECE64BAA33F,
-				BBCDE855BD0A58D3779D96A8,
-				1552007C6C6AF750278C5BE5,
-				0B2B7732073D56E484950C8D,
-				9C39C584DA6F507E773687EE,
-				1C93ECD2B04F39923E66B529,
-				C5ABE6BDCA91410BA92A7BD9,
-				0CCE619599DB39323E49FF3C,
-				169F1B20FC9FFE88C53D2735,
-				92528D6653802FACF658D8EA,
-				1AD76E8111A738A8F3717060,
-				8B9C0831BE4E09B7C0078B7E,
-				E216D095C98F850A5FB6FB0F,
-				70F06DBCA3948BCC1062E36F,
-				46E3A634686BFEF787229582,
-				8B745839B225E44C9EB5C6FA,
-				1EC95CD1D830F6D85ADB3B9D,
-				25ABEB43042E98C668A16432,
-				CAA3B9396EA62166234DAEF1,
-				B23E6EBB5F99CF7FC72FAC4E,
-				29FD7B383C5DDACAA7B8DFD3,
-				FC887C6CD74FE33F8BA784A6,
-				04C6B933E1603B4D0916570D,
-				C51CD15B311D0AAC08D0B908,
-				C79249376E3FDF10615E16EA,
-				BA2923571505AD47CA1EF878,
-				70151263C4CB8A4F79431E11,
-				985F2B5047476B272B1A4BD4,
-				9136BD46BE1E28A96FBBD440,
-				265EDA19C88E74249FD66609,
-				8A91849BE6B96EB8C0663469,
-				E594A85A291E0625E0410A85,
-				6328434A329C353DB8D9512C,
-				028D4D3C0862B4B1312E2395,
-				D51315B4241B019BE43EE4F1,
-				CCC20313AD0D0993F9EDD1B3,
-				A252FE4E6A360CBC4AF694B3,
-				83E5EA2AA0CB928889AC80AB,
-				10BE33089BA6F3468F36CD6C,
-				A0E3B98412D88921BB0AA58E,
-				D90290A0AA2C36CE757E46D5,
-				49FA151B1837E543D18858EB,
-				D3AE8303545E28D793312F46,
-				984BC60C0AFF3EDED692FA01 ); name = Editors; sourceTree = "<group>"; };
-		EBA825AF6FDB51EBA368CB8D = { isa = PBXGroup; children = (
-				235A8987D99A191D07208D2F,
-				14F594C425F332F455A16D35,
-				ECB5A75A81B90327F58CBD9E,
-				80EEDD40F49120ADBE9DCBDF,
-				2D2BAC4320470CF68743F58E,
-				FA2F04BA4E146ABF649BBE89,
-				5DB3B3197F8C1E5EE159D6FC,
-				8A989F74B1957BCB3B9BA398 ); name = "rhythm-api"; sourceTree = "<group>"; };
-		DEA24DC5AC8325310FB40395 = { isa = PBXGroup; children = (
-				EBA825AF6FDB51EBA368CB8D,
-				A3FB0EA0264580F6B00D993B,
-				23A6BA852B71DAAF3F709428,
-				1718EC50691D8421EC00F8B3,
-				95B57108E929DD11F898B7B1,
-				FA23A1334E4CFA77BC18A153,
-				8751DF970A9E3598683BACAF,
-				788F8B7719B70465762B634B,
-				F09FD6D9CA4997216ADBF54F,
-				92602D7166325C7232B85EDD,
-				0287B009511521BEAAE8A52C ); name = DataThreads; sourceTree = "<group>"; };
-		83A3E005DDFCC55F277EEDA5 = { isa = PBXGroup; children = (
-				FFABF04684556C4A54A62439,
-				900C10C1DB76331250A04557,
-				DC17FC0E3B6E3B7C45079DE0,
-				D627F12C36013C7EFE0B0B63,
-				E413F3262886677B4CBF3FA9,
-				5D23F70C117457FB8547A537,
-				B84E9C47FEE13D162CE9E5D7,
-				AF594F191BDCC1FFF2F31204,
-				96AED479B95D4EC31604D604,
-				4FC4EF4B38B28638B2F09260,
-				71C0C491E4BB214551D6EAD7,
-				BBCBB940B85B1695225C9A13,
-				C91ED2E43CF9CC0E83EB50A7,
-				3F3F8C49FB5AB1B91221845E,
-				DDD2075B59AF7E38447BA84B,
-				6E444E05271A0334FAE9DCA3,
-				7F4241B34F5F7245653B5196,
-				8E02668CAA496759B1F31468,
-				33EC8C48E03E5FB60DD9D4C5,
-				9E25AA6C671FB8DCA6E30A43,
-				86688D712937F3D08918C68B,
-				E817F0471AF514FD075B5DB7,
-				813CB9DFF788D612A0750FBF,
-				77D3770CCBB3EED01A854329,
-				9215DC26F511C58DEE009209,
-				FB071D0659E5F1CC630D765A,
-				5654BDD4FBFF01AC3F17FA0D,
-				A234B2D091071A1B710E884B,
-				DBB295F412798131D3F04045,
-				EF8488936B3D3E9178C9099C,
-				BBD9C2AED6F500D090069007,
-				F230A4C0186379F9EB0B0F74,
-				9FFD9560522567A033226BD7,
-				229989EC8A6F145C81348CA9,
-				76F569AE7B444D8F69EE0E86,
-				17CE6B2913E72ED8727ECD56,
-				9BC055494F9FEE3F90630541,
-				FF450FAFD49105CE7157DFC0,
-				3DE49DED45C5CDD8D184E248,
-				39464D2A22940DA2DDCCCFC6,
-				91D7B1F8B94AE9CFCC53771F,
-				9D78F50147005EDB0E89E2B4,
-				DB702F259EF24DAB9EC99D0A,
-				D38E60AC4854B6E1EDE488EB,
-				D128F31F18331117287F5EC5,
-				CD2370F8F4A44446558A08FB,
-				E2F46E110416D628C11392CA,
-				DAA04A0FD47097893712B241,
-				5EA61EDD64BE1E401DD0AA5E,
-				2D41C43686CDE35E86A389D7,
-				B917780A75945062761B6945,
-				EA535EA158451360B7B8AE52,
-				DBB86AD59BA3F6EC09AF2C02,
-				4E3C60995CC567F1A839CAE3,
-				C4B85C0286AC2510730355E3,
-				BC3B7E4E25505D9044BFACC7,
-				B70D836E0756C3D4EE8E20F2,
-				B27F558F42AC78F0E564B5AF,
-				5F64FDAFCA899A16C7FDDBCA,
-				F94DD42C7BBF81C101D3F605,
-				E42B745B4D2DCADE54F94757,
-				9F16043BF599BCE0C02A00A5,
-				DEA24DC5AC8325310FB40395,
-				A4E2CAAF556D557B24182414,
-				3EAE25787DBFBA8EFC42A277,
-				5522973FA48A13C6BED293FE,
-				23EAFAEA6457DB4E452F8715,
-				A98A22CF5F208ED6DBE08063,
-				C29BC68B2721471F32906FEB,
-				B0E8FAD5AC445F612E3468B9,
-				886E18520E8BD77234E1B686,
-				ECA6FDB1366BE7EC30F1539B,
-				154303EE3929F26B93792187,
-				3AE038CACE48AF85C4FB1ED5,
-				5B2A4DD7133CDE5AEC24CC07,
-				555D34D0CD8776EE5996CC3A,
-				0FDD7551AC98348D4A98ADC7 ); name = Processors; sourceTree = "<group>"; };
-		1D78FCCF430CD91FD1DBD95B = { isa = PBXGroup; children = (
-				E5C1D021C0FD6FAD082C5D75,
-				BA422CC894B825834A0C5479,
-				9F3B3184EC6D42CEA35D6ED8,
-				E93BE115650B1CB80EACB841,
-				0987F7E90136D0E08A606A22,
-				48F6281AB92B232E5187D00C,
-				7E875E681E18D693D5ADB2FB,
-				57FBA8BC3104D3AF41FBECD8,
-				79C91DDF3BC3F15D0338E504,
-				105B1452DF6CE1D80D69A9D1,
-				3774BBCA6CB133D9A854CF71,
-				19148DBA36B94FA639DF3A72,
-				17E13CCDA0C82F92EAB05BE6,
-				D2696B30CBEAD7CE72510AFA,
-				47A3942AC30A3212C01F1CAF,
-				7D9374931D760ADC65DCBFC6,
-				7BD2C39F13FDE202141C4B41,
-				9B9EDDFA0AE4991BC7FC7263,
-				94AED5D544719B438B3EE723,
-				C224FFE93AB9ACD2263F8877,
-				610E487E060C42B52FD5AAC9,
-				0FE8ACC50ED8E7FFC9E6B9B4,
-				D2A3B4CDD296B4CEC6902FD7,
-				3FC794735FA8DDA39A62224B ); name = UI; sourceTree = "<group>"; };
-		3564F28A16A2BDF3B1D5035E = { isa = PBXGroup; children = (
-				420B0E95F1300ABFDC125DBF,
-				DB4FF7675E5C98CF62DA8A2E,
-				B016FBDF648372A23D7EAAD8,
-				BCD632E634E0F8A50827F9B6,
-				C451728043944D40C69166C1,
-				83A3E005DDFCC55F277EEDA5,
-				1D78FCCF430CD91FD1DBD95B,
-				E08E877C3A6283CF5C803957,
-				BB26BA9CFAE8C836251E8EAF,
-				2C89EC72FF6A7118EF459DC3 ); name = Source; sourceTree = "<group>"; };
-		9D44948383EAABF451302146 = { isa = PBXGroup; children = (
-				B9646290EA6B6995F8AEEAFB,
-				3564F28A16A2BDF3B1D5035E ); name = "open-ephys"; sourceTree = "<group>"; };
-		C7E3612878FFD65D522A32A7 = { isa = PBXGroup; children = (
-				563F35B171FAF2540923CE45,
-				EA73332E3D5AEC04ADDFBB2A,
-				80E8C07F5807C65BCDFCCF94,
-				1CB0D7AC988EDEC838A1C546,
-				BE506F381B90833512348968,
-				42BF0530EADF336E58D39CD3 ); name = buffers; sourceTree = "<group>"; };
-		18CF6DB446071363AB4F1EC4 = { isa = PBXGroup; children = (
-				96E99CD031BD069997E387FE,
-				018F4E079EB12A78C4F8F773,
-				1307DAE32BA702565A67D127,
-				E7366E169158F5A2D1D7B55A,
-				DBED17FBB262C4DACEEDA9B0,
-				161E095C716133CB255B6CCD,
-				8B0C9D288C428BA5D956AE13,
-				927AE946A1371490D809876E,
-				560A28C1966B1817873CF764,
-				82EB2BDE7B9A4D5D945497B9 ); name = midi; sourceTree = "<group>"; };
-		553F5880E9CFE9C4A045C0C0 = { isa = PBXGroup; children = (
-				C2F9D279FCC5C4AD56A0C1DF,
-				3BEB59C6E8F833331C0783D5,
-				63F4150ABBA43B2215230034,
-				F9F37AD1C3E7CA932FF44E69,
-				65751E743D5EFD4066E50746,
-				E419C9DA3202B8B6EC2DB723 ); name = effects; sourceTree = "<group>"; };
-		860DF78DDC42F4C5093B46B0 = { isa = PBXGroup; children = (
-				605C7ACB09E7739EBE4F1539,
-				3F8DFB0DB8B82F0C2CFBCA05,
-				E4A2E203101AF37C169F1569,
-				5C1D2D28960C7957A15B3FE4,
-				3FA24B406E4A9F9F54421C6A,
-				4AD95B75DC581E32650FEDF6,
-				6D619C7A3A14981DC4EFF223,
-				E3D9DABE0A9C1DCE6A6515CB,
-				178AD28BF5BC92B58A3A3539,
-				FD770E73FD462E9C9F6DBFB2,
-				1B27BF1CF3F235A55CD5107D,
-				6535D85C084292220330EDD9,
-				9C5F99C38CC703FBB871401A,
-				1D1ABA743E533A4B7A50DBB0,
-				458A112D564ED066211FD482,
-				3B307527FC3241258EA68519 ); name = sources; sourceTree = "<group>"; };
-		14AA2721588E8A9253FFA98B = { isa = PBXGroup; children = (
-				E97684DCE824DEDA6683C6CD,
-				74DE857CEFA10BC49FF591DB ); name = synthesisers; sourceTree = "<group>"; };
-		9311E4762BC3218510204A0F = { isa = PBXGroup; children = (
-				C7E3612878FFD65D522A32A7,
-				18CF6DB446071363AB4F1EC4,
-				553F5880E9CFE9C4A045C0C0,
-				860DF78DDC42F4C5093B46B0,
-				14AA2721588E8A9253FFA98B,
-				786F6A40506C2094B812F4D5,
-				DB550BAB034060FF4578BB64 ); name = "juce_audio_basics"; sourceTree = "<group>"; };
-		6956236084207D7C136E5032 = { isa = PBXGroup; children = (
-				693E9C5C9A435F791921DAAE,
-				642C4CFA27846188E3D53688,
-				F94BFC6B5057806EEF8B59DA,
-				2D1BF69121265C83C7937EB6,
-				9BE34B4DECBF4EBFD27C9792,
-				ED887A521EEB8F3EBA7DDB31,
-				3E5E427D405905C53A37283D ); name = "audio_io"; sourceTree = "<group>"; };
-		42F1804D0EC2EB60625F783F = { isa = PBXGroup; children = (
-				26FF78F12CCB8725C0DAF9C2,
-				988F01B2B51B2AC7293D07DA,
-				A9A0BC63EB466C75D1B9326A,
-				B64193A23B69D4A88CDEDD0C,
-				0242AB5BCD8C002DC2E30BAC ); name = "midi_io"; sourceTree = "<group>"; };
-		2097A54F0DC05D433BEB7C81 = { isa = PBXGroup; children = (
-				F1DBAE92084D9D90234AC436,
-				D0D7CE266BD7CC5455926700,
-				7CD03E334269D693E1B84856,
-				402BC572EE3E8EC418946CE0 ); name = sources; sourceTree = "<group>"; };
-		2512062DBF7A12B895E6F6D9 = { isa = PBXGroup; children = (
-				19043050D1DADAEAB48FB803,
-				078625CF5C083AD538D23401,
-				1463D2DAB3A1D8CEE825056A ); name = "audio_cd"; sourceTree = "<group>"; };
-		FCD30A3CA425C3FDE6CEBAED = { isa = PBXGroup; children = (
-				0A42FFB89531588E51762D3E,
-				7D363D7B36A55EEB3198A827,
-				21D3C1095D2B5A834D998B74,
-				FF1B5858C942CA02EEC38E69,
-				601654292170CD2D60E912A6,
-				B7D848E4F85AE11FDE4D164D,
-				FEF0A4E3C8D22A830BCE2B67,
-				E8964C0BE264A55753BC6B7B,
-				9FC97A1CFD250F7215B4E397,
-				AEC2DABFC0517B4BE0CD704C,
-				AF3E3AE70160C3392B237316,
-				39422C7D01635DD9C00B5136,
-				17CACEC7EA0A4B55A06A0993,
-				B0A076D9536B6754F34E4606,
-				6CBD8647DB17F1B58B14A3BC,
-				F2F11D7C596DAE5579610CCC,
-				5B7EC53FD2232CA799D6C018,
-				25DCA4D0E86DFB51AF637D21,
-				E5B10AA248D400FDB2645084 ); name = native; sourceTree = "<group>"; };
-		83416B76189CFC2030936CCA = { isa = PBXGroup; children = (
-				6956236084207D7C136E5032,
-				42F1804D0EC2EB60625F783F,
-				2097A54F0DC05D433BEB7C81,
-				2512062DBF7A12B895E6F6D9,
-				FCD30A3CA425C3FDE6CEBAED,
-				6EF4EFD6D74D2573AC6B6A6F,
-				9069CE21141F5A4C5721BCF3 ); name = "juce_audio_devices"; sourceTree = "<group>"; };
-		8A5AC1CA1E8CB52621B64DA4 = { isa = PBXGroup; children = (
-				5C7EEDD80F88872A87FD561B,
-				F28414731D9EE1F75D7B7043,
-				B5B417E4196236A2CDE7F0CF,
-				EDA209B0E7D124EA581023AD,
-				4CCA36B2A6C4821E493E74D2,
-				789139D88F449BE488BF3CCB,
-				5CE99545433261F3B4A46252,
-				314955FB1E6DD74C71EB8907,
-				6B90F5150FA8E114E8AE98BF,
-				3BC3A723444252E177C1B1BD,
-				8551342E7D16FCA4F9A80BC5,
-				3A6E9EC3DA618EBA06B9DEEB,
-				86515FD9AD34D6FF96C0D8B6,
-				8D6A419A4678968762A59B28,
-				6B32691AA8B3D304B68CFA64 ); name = format; sourceTree = "<group>"; };
-		6DDA36A41852F78F61C4BA23 = { isa = PBXGroup; children = (
-				4AE1520FF569371665090B39,
-				822A504EE33F35F18A7F21AF,
-				F8E202A1374401022F87F26E,
-				2BC005B37A0FB3179C2F3AC7,
-				02DA588D3B873F1971ACD912,
-				266FC6DA3123E576811DD828,
-				2F2EDBE0623561191234AF21,
-				4CA9556E9C18029A47F34C7C,
-				F1A3975235880CAC1D5757F4,
-				72C33BA70B9EE82E39F1EC6C,
-				ACAE4A2D65AAC6A36DA9DBCF,
-				E040EA8B5BB61ABBBD14F12F,
-				BAE93A5EEC37D7B4C793BFA2,
-				BBC386B5A369262583AD4DDA,
-				0052A4FD257928E5D83927E6,
-				F70B7D65EF56B8A0ED36478C,
-				0C646E9950FB580B21E1F2BD,
-				8F0549459970F529587D6CDD ); name = codecs; sourceTree = "<group>"; };
-		147EC1A2CF770171DFB61105 = { isa = PBXGroup; children = (
-				BF647E1FAE73208AC29C14F7,
-				3EE92345839A4E5F608D82AC ); name = sampler; sourceTree = "<group>"; };
-		E2F864696FA2DDDAD60C7E83 = { isa = PBXGroup; children = (
-				8A5AC1CA1E8CB52621B64DA4,
-				6DDA36A41852F78F61C4BA23,
-				147EC1A2CF770171DFB61105,
-				D0E568AD5445AF061317E01D,
-				07FD5E530E9E6BFB2ACA4B8C ); name = "juce_audio_formats"; sourceTree = "<group>"; };
-		21BB3DD364DC0C39CC9594B9 = { isa = PBXGroup; children = (
-				5B2CDF3CF10A92F6CA45F3DE,
-				3DA70F9AAA904543B519874B,
-				06072EC6BCD3B7D8C17C2402,
-				C54760E4888674CF3CF022E6,
-				803D306CDAC2BD3BA04534EA,
-				256E22D98B16B09BD521C4A4,
-				7EA46209F07B2C8A83D0873A,
-				2F9BB379BCFCFE0D88CC0408,
-				D960588B732D973B82500E2D,
-				32A1325430309CF4114C9618,
-				C74399C81B1A0552CC52093E,
-				A17E8162EC7A0E513DDEB23C,
-				BA03776682290FF1AF4C0106 ); name = processors; sourceTree = "<group>"; };
-		14805A0D1A6C3ED796515AD6 = { isa = PBXGroup; children = (
-				18C2F9CA38393D106FB834E2,
-				B174EBEF82212C8624300F59,
-				0316B49B86725305C70783CA,
-				8E61792F6D6FC75CF18095CC ); name = format; sourceTree = "<group>"; };
-		208431C2D4A7C383FD247CE3 = { isa = PBXGroup; children = (
-				03D7B457E0915E43A6AFF4B4,
-				8515E367462BEF36233E2447,
-				FC20BDD5357D39AC43DFC255,
-				93F842958BCE6A9E09862CF7,
-				EAB637B566FEBBDADA654262,
-				B93B8666F8AF2E5D2E851B1C,
-				6589EAEF497ABA76A295B121 ); name = "format_types"; sourceTree = "<group>"; };
-		AF98861ADFF70900F6FD1833 = { isa = PBXGroup; children = (
-				E53FEAA3754E6B5D99516D56,
-				4D84A3A970FB67566A1E5B0B,
-				390EA3109658E8C51EFC8F61,
-				894C0CAC31D382477E7A122E,
-				F17DF27524262A21A3EC932D,
-				75E0C433EC27CFB712CD9F75 ); name = scanning; sourceTree = "<group>"; };
-		95530BD93D8ECFCC072C0850 = { isa = PBXGroup; children = (
-				21BB3DD364DC0C39CC9594B9,
-				14805A0D1A6C3ED796515AD6,
-				208431C2D4A7C383FD247CE3,
-				AF98861ADFF70900F6FD1833,
-				475824F60D47C28C392954A7,
-				F463A19E6EFEB2837582B117 ); name = "juce_audio_processors"; sourceTree = "<group>"; };
-		62693BDBB3A4F98A8A8B45F6 = { isa = PBXGroup; children = (
-				67BB47E709B643D4C01AB34C,
-				45A66E543B62A2C32AB3BA23,
-				EF3F9AA8D70E1D4D55F13182,
-				C1E1CCE5796B40E0A45FB021,
-				482A60A44EE6CB84FCB9DC88,
-				BD59A961F87AB628777894DC,
-				DFFB7396DCE9DF1253217584,
-				7C71195623459A6C2524D418,
-				784233150B26826701C09103 ); name = gui; sourceTree = "<group>"; };
-		09F214A405A08FDFC47244A5 = { isa = PBXGroup; children = (
-				57F66B4A911601169AF195E9,
-				DDE89F0D5E01F079323CC89C ); name = players; sourceTree = "<group>"; };
-		702A741EEADCBB982DDE18B0 = { isa = PBXGroup; children = (
-				62693BDBB3A4F98A8A8B45F6,
-				09F214A405A08FDFC47244A5,
-				80D57E78015C789503FE24B4,
-				8515A61F1E3BD62B9B95B495 ); name = "juce_audio_utils"; sourceTree = "<group>"; };
-		CDD260628D8AFE969895A610 = { isa = PBXGroup; children = (
-				AFE835E175F7159E1E7C6CC7,
-				2DA0032B6DF10345C4842BF5,
-				B64893F699A10B03AA4AFF6B,
-				9200FC900D22733AE716C364,
-				6596D69CCD1502DC6BBD15F1,
-				55F7467B96E236DD558228C9,
-				05BD169B8574607A6F6AD3B6,
-				6C8489C41782E3D391AF0C26,
-				1246C8A62803B7E115713705,
-				E91923510CB2280C3A3B9E9C,
-				1F12D1392E5DF34C3A3C445D,
-				0A413228C75C046CE683E0E6,
-				09A159213372995F3CCEB85B,
-				38B5A37F33AE3FB2014BF095,
-				2847E92BB432EEB9D5A59260,
-				B9E2607F1605D308CB331FCC,
-				EAEA49B9394D802B79CA8164,
-				C67AA7952D9EF7E248118B85,
-				EAC262A83CD2BEA14542AE89,
-				B7BEB7779860FE877E4D1BC8,
-				C98D4FF283E598244E89CD83 ); name = text; sourceTree = "<group>"; };
-		1E253D48AC292849CD3054CB = { isa = PBXGroup; children = (
-				0A8BC957DBEE226346C1EA25,
-				E7EE416EF527C7506B499070,
-				2B19F2DE42A91F56C2380F9A,
-				811C4D165AD7AABF4055059C,
-				90AD1B6A2293F625D786507A,
-				2B134713E91426120A994CB7,
-				90607327D7A1BB3C2C4E9264,
-				6A559D9595A54EF52BF0773A ); name = maths; sourceTree = "<group>"; };
-		85E7ADCD4C773A42B7F493E8 = { isa = PBXGroup; children = (
-				F7F374C05CDE0DB7712D18D1,
-				816EB8024DD50DE4B7E84CB8,
-				FB1EA9CB3C695925627B0AC6,
-				420843E39C285B620B220C1D,
-				C0C6335FEE0844872FDF4EE2,
-				D11BC618E53E6605B3A579E1,
-				8A026DB58E3555F7B070DA61,
-				3663C981D28BF165C1B601A7,
-				D5D6DAA3CFDD395096D2B072,
-				E0C264CF6345ABB4CAB98B92,
-				0D884C2CF25F23CE6B99B2A1,
-				8B49B07BC7534B247ADC756A ); name = memory; sourceTree = "<group>"; };
-		B49948DDB0E13018A81FFF94 = { isa = PBXGroup; children = (
-				F0F3834D46EA8FC8ADB206DB,
-				47BDFDD28759B342B1C50BC0,
-				7E40891072657FB5ADC2FAB7,
-				7D8100DC3A532980AEAAD909,
-				7291F19253205B1A5138908E,
-				0E98E81084F183B8426EDA7F,
-				193FED8339417E8E6264957A,
-				893E1A681FF162F6C9069F62,
-				66D3F831CE4F6AE89E4C869A,
-				35C0963BAB9A82F12CDC9F76,
-				F3F48717927A4E24F7373C09,
-				6C24163DC4ECD731489CC4F6,
-				E3C4B6B362320594789E1297,
-				66C663401829E0F7E787F708,
-				B5FBD4DBD2CFE0FFF457D7F6,
-				19AB6653E818B409554C5606,
-				76E89CBE70BF8F2476B7AA34,
-				49D837FD08100AF0DB797DB4,
-				F8EFE3709FDDC2D5F0843058,
-				172FA5C9EC4B16BC0C45F269 ); name = containers; sourceTree = "<group>"; };
-		E5D588C725B362D52B7F0801 = { isa = PBXGroup; children = (
-				47041E3794FA20F67F39AE63,
-				901DB6D5FE9134F2ADB9AE46,
-				4608E765A643BC0CB2C1BB02,
-				515213CC3271E8DEA8125D33,
-				DE4861552DB1976665B25DFD,
-				EAB6A66678B122C578B16445,
-				DB7866AFC8A4894810DBD05E,
-				EA9518CDEA7049C21D5CE2D5,
-				E34E535DA9CBF248E32F7B45,
-				113404D3FDE3745DF1E8D014,
-				ABA3FCD5D762336535D56D94,
-				7C6921FE817699C1B95AEBF6,
-				2D20F49E12A7D313049E0258,
-				36A9736F04AAA2F8E9D711BB,
-				222AC2E9BEFE12BE7FF88879,
-				8EB76CA261F62A89B3D25F81,
-				A6736FBDFBB0B82E22D2B1C0,
-				748E62D05C8FFF74DCA234C7,
-				0B382285EEDD8A3FDB45C074,
-				4133FE7830C52BBA035D82B8,
-				DEE2959DBBC84EA8448A0F77,
-				DAC81FECCE54087394BE69F7 ); name = threads; sourceTree = "<group>"; };
-		8C76D67898D8A6B0FB7F62D5 = { isa = PBXGroup; children = (
-				73ACB7A051EDE5F676E35FFD,
-				65DA1366481AB10AFB3AF344,
-				5DC1AF69A773401DB1E8FB32,
-				562E4A50364EEDC3AA2AACB8,
-				A769611E9CBFC127AF5AFB0D,
-				D8A40F2BFBEC65019C867786 ); name = time; sourceTree = "<group>"; };
-		FD67C32AD7A3D9BDC3CB7896 = { isa = PBXGroup; children = (
-				0DE9D2FE41553B4D4316DD55,
-				B2241E3C5C9F93389586F357,
-				B4C52FC94D6C680C33ED85C9,
-				108DF32ADFBA5CA48F928A92,
-				B2EF409A1F459E964756BA7C,
-				5E663D5A55F191AB92A1383F,
-				DD5695DE97CEF7BE76869232,
-				F8322ED101601866FFB1698C,
-				21A0260D2DB039B81DF4970C,
-				AE9359DBA841F88EF3DA9700,
-				AD960F561259904BA68DDA73,
-				6EA1CC7DACDDBA863179521A,
-				ECCE033FF2ACE42188FA4A7F ); name = files; sourceTree = "<group>"; };
-		1DF9A40DB990AEC6AD278C31 = { isa = PBXGroup; children = (
-				0BF3932F3EA1149C2F7E31F9,
-				3AFF1BE2EC512169120121CF,
-				4F31D61C0C2AB3472C6C1429,
-				BC953E395B22FB1D305E483E,
-				087FA26464FB283EC6FD4795,
-				C67C5EC0EE8DBC501C8AA395,
-				D9C9FCA6D705B72B80DB1142,
-				01D791730840EB0BA7FD61BA,
-				8F29CAC0059E3697A5A3652F,
-				FF3E5A9F8B9250790C6DA089 ); name = network; sourceTree = "<group>"; };
-		6415B8D280F206E770758A6A = { isa = PBXGroup; children = (
-				9B178E9015CF469CFD41BC79,
-				F5642B98949DC0FA45EF904E,
-				32976762B1DB850DB65B9504,
-				27548017AB2ABAF17E1D5DF5,
-				09160DF53438B400BFE85E07,
-				7555A13E69B99B1B6C7295FD,
-				D056D7F6C8EA8A6BBCC5C092,
-				66FE597910F6A68CBB6FA055,
-				8C077447B0DFC739C7D2E437,
-				E666E60CC07666669FC77C7D,
-				BF8B07C8BC86002C3DC94DEE,
-				D679982E05B9510FE239D690,
-				0B5B63E563EFA7E816DE3DCA,
-				0CCB1C4D687001E04DE1DD9C,
-				4978EF4C5F506F3289BC0D99 ); name = streams; sourceTree = "<group>"; };
-		3CAB707CFF748C665802E65E = { isa = PBXGroup; children = (
-				658D08592154525DA1C40826,
-				AB4C7059669AC385B02179C1,
-				7ECD5DB4BEBC44559D064E08,
-				0A351ED88CF00C0697701E73 ); name = logging; sourceTree = "<group>"; };
-		9D740F320C13F9B82EB64461 = { isa = PBXGroup; children = (
-				7F17077973FFDD70C4B78E7E,
-				A5E8E0CF6DA1AEAEE9D872DE,
-				9978BC2A359BC506F69E545F,
-				DB4F34DA0F04B40EB6A50FB1,
-				C446923C1950EB5BE5E67F15 ); name = system; sourceTree = "<group>"; };
-		17BAAA5A77781988BAA8CDEF = { isa = PBXGroup; children = (
-				B8D19858CC01BB5F7C35ED58,
-				8F7B13BF318C11900A2277DD,
-				C2746A86EC16D3EA9FAC2C1D,
-				83803D96768258DA20710764 ); name = xml; sourceTree = "<group>"; };
-		E4BC8B84B396D69A78DD829B = { isa = PBXGroup; children = (
-				8AA1009705E8A9531C707ED1,
-				4179FCF100DC52282D0F9753 ); name = json; sourceTree = "<group>"; };
-		7C859D548450DEE24AE009E4 = { isa = PBXGroup; children = (
-				D162391A46FF93093C328F9D,
-				23C7EA9C89CC98A5EFEC12FA,
-				A65F5AD9D0C532EBB3A2067D,
-				5343D594AA7D444A7C6AD924,
-				AD7311B9A37893CA0C4BC119,
-				D60F42AEB8551E83215691C3 ); name = zip; sourceTree = "<group>"; };
-		D72CD5E87BC67DDD61A82105 = { isa = PBXGroup; children = (
-				4D8F94CA49DB11E07918B4C9,
-				53130F5F47EB211416C028F6 ); name = "unit_tests"; sourceTree = "<group>"; };
-		DE30EC58A5AE1CD381356739 = { isa = PBXGroup; children = (
-				3FFD5E5D5C1D8B48DBBB9D18,
-				0BCAC20DAB10B957168B85D6,
-				F796260525BD82FFC1D1732C,
-				215B159836CE40810964B773,
-				349C9FCEDC32E73DCB7AE806 ); name = misc; sourceTree = "<group>"; };
-		572BB2781CE421A968F9D023 = { isa = PBXGroup; children = (
-				8882F8EBE55F52FA8E519249,
-				EF610B2A17D9B1C0D24DCE67,
-				9B5D838CB6224E82C9B36AA3,
-				982E1A954C316920557F029C,
-				23F048594D4C9AD8C3399877,
-				C7CA628FE3E1E3D16B24E059,
-				60B1BDA3E9E14F9515963082,
-				3FB80C5CFD953986778DCBA2,
-				5F6DCA68A982E930389644FD,
-				D22D3958949713747DAF59A3,
-				4D67518E9223C1C19BD4EF2E,
-				A950BD747F318BF6D555CB06,
-				63AF6BE7FE2A9E7882743B4F,
-				28847C807E6B05303FB8FB34,
-				BC06C1E8052799F4696101C3,
-				B87864B2D6A2E741D4B426A3,
-				8F08D5488CE147D693BA21E2,
-				28D5AEEEFC4FA8877419C829,
-				ECBEF88BBC974D96ED781C75,
-				86F4AAFCE3FEB34E325F3020,
-				BCB6A6D5A0C1417D74C29632,
-				698B0EC670DA47934444381B,
-				EE2C669B127D00C86B1B8CA8,
-				C0A718EA721772EA6B837F39,
-				77B3E84324445076F1F907E9 ); name = native; sourceTree = "<group>"; };
-		7333A0F468D3745057EB2368 = { isa = PBXGroup; children = (
-				CDD260628D8AFE969895A610,
-				1E253D48AC292849CD3054CB,
-				85E7ADCD4C773A42B7F493E8,
-				B49948DDB0E13018A81FFF94,
-				E5D588C725B362D52B7F0801,
-				8C76D67898D8A6B0FB7F62D5,
-				FD67C32AD7A3D9BDC3CB7896,
-				1DF9A40DB990AEC6AD278C31,
-				6415B8D280F206E770758A6A,
-				3CAB707CFF748C665802E65E,
-				9D740F320C13F9B82EB64461,
-				17BAAA5A77781988BAA8CDEF,
-				E4BC8B84B396D69A78DD829B,
-				7C859D548450DEE24AE009E4,
-				D72CD5E87BC67DDD61A82105,
-				DE30EC58A5AE1CD381356739,
-				572BB2781CE421A968F9D023,
-				CD492AC7B458FA6C321B9D0B,
-				97431963DB8D535DEDA9AD47 ); name = "juce_core"; sourceTree = "<group>"; };
-		7377EF4F37D5F898D74C4C2D = { isa = PBXGroup; children = (
-				0BB4380EDFEAAE0DAB255B90,
-				7719FB81DDF23CF0164B131D,
-				511C443A0A806706A772E981,
-				F2EDB88302B8A9356F43B834,
-				8D9DD6147EC0553B092FD367,
-				57C6DD2537116B30FB948A08 ); name = encryption; sourceTree = "<group>"; };
-		2A96C9BD7209F57EE8E19BBA = { isa = PBXGroup; children = (
-				B2017626F9A05C8C0EBE9B7E,
-				0FA84E49DB493BCC886A355F,
-				B17AA637E5C357FACC38EBB7,
-				8C38407151E149A7E2A15801 ); name = hashing; sourceTree = "<group>"; };
-		F196226BFBA15D76688C61C6 = { isa = PBXGroup; children = (
-				7377EF4F37D5F898D74C4C2D,
-				2A96C9BD7209F57EE8E19BBA,
-				01859D6E7D95E44BD8E17D91,
-				C16065CD5A8054262B81C1A3 ); name = "juce_cryptography"; sourceTree = "<group>"; };
-		94D3CC2AE4B67AAA936F9DEA = { isa = PBXGroup; children = (
-				967138FE8A086734ADC8CABB,
-				7CE1E34F6A0091E720854E75,
-				74A81014471CC0EB0D5E6571,
-				C5D0E0996D20BEEEDBFD64FA ); name = values; sourceTree = "<group>"; };
-		42DE5996B56B332A5B6C636D = { isa = PBXGroup; children = (
-				D71AD519382D547C958B0175,
-				11D619EEF63C1827EA91F593,
-				DEB9A630503639D42056236B ); name = undomanager; sourceTree = "<group>"; };
-		6783EE5E12C56ECE3D7FD1E2 = { isa = PBXGroup; children = (
-				31A3925602D128195100B74D,
-				5B6B25AA065FB6CDE7D6C507,
-				1CCC1D4213B17ABF6222EC82,
-				2AE12F85965B8BE4A0E12F67 ); name = "app_properties"; sourceTree = "<group>"; };
-		A7F7E551BA5A75737261BB4C = { isa = PBXGroup; children = (
-				94D3CC2AE4B67AAA936F9DEA,
-				42DE5996B56B332A5B6C636D,
-				6783EE5E12C56ECE3D7FD1E2,
-				E21CA41B44E191F1804F9662,
-				5962848AA3DD93A29EFF5B94 ); name = "juce_data_structures"; sourceTree = "<group>"; };
-		689A94018921FED3F037B194 = { isa = PBXGroup; children = (
-				D7807913367AD1B1FCBDEFAC,
-				9EC1C0A21FDCB81BE0EA60EA,
-				6CA98F8581CEAE2DC9AEBCE9,
-				7F49EA0CD3379397520AA6F1,
-				996E4EA6B532E4E436F50243,
-				7EBB3F8185EB597DEF77534D,
-				5A7D81B70480B40EEBC2FF54,
-				2924B990E35D3B51AA245978,
-				18A730DF335EEB3A4D13FDCA,
-				C844D1792A91BE2D8808CB14,
-				670987D88775D6B240C34820 ); name = messages; sourceTree = "<group>"; };
-		530413F49A2E29570D8A9761 = { isa = PBXGroup; children = (
-				B1A8C18C6E4B3572B8B750AD,
-				DC200873B263C55E82B5384D,
-				0A46EF94E558D5E19F96E646,
-				7EBEBC6DBA8DCA5A5D8C72E1 ); name = timers; sourceTree = "<group>"; };
-		259BB14332EF6F524455BF3C = { isa = PBXGroup; children = (
-				8CAEF601359DB6CB50E89D1A,
-				E20D5F2F75478DA4943CEDBD,
-				38711221C089A16CC29E93D2,
-				3A2C762575D9728B1F822ED3,
-				5379FC603780F30A2F05FE78,
-				FAC7E62CC15CA977A6FC72D1,
-				B8A9063181FEE1920095F824,
-				86E8E44A13F17083ED300BD5,
-				0DD0CBF9BBD4A503F2B7868D ); name = broadcasters; sourceTree = "<group>"; };
-		D70BE7E6ECFBD4AD6F29AA64 = { isa = PBXGroup; children = (
-				9360657FDE33FA37D80075D1,
-				E7460F066237871A704733E7,
-				EAC7A64301F0BF2C5E33A1F9,
-				946FDFCA107B3F4C74C471B4 ); name = interprocess; sourceTree = "<group>"; };
-		0A3CD1724922FB098543C013 = { isa = PBXGroup; children = (
-				1194EE0956A9645270582979,
-				BD1D02C70CCE095217581A5F,
-				19A8A8E1BF043B390E02C429,
-				B0DCDCB162FDBF972FA5B548,
-				4B5998D72503BD73D28E828A,
-				627956A7A1CB15251D02C8C5,
-				6DA8EC2F779DEBB701FE33CA,
-				DB4FB8EAFA1714529E527C3D ); name = native; sourceTree = "<group>"; };
-		F61CCB10A356CE4278F74478 = { isa = PBXGroup; children = (
-				689A94018921FED3F037B194,
-				530413F49A2E29570D8A9761,
-				259BB14332EF6F524455BF3C,
-				D70BE7E6ECFBD4AD6F29AA64,
-				0A3CD1724922FB098543C013,
-				31FDA03EF1B527B336FA6263,
-				CF758CB1E06DDA1AB7F5C9CC ); name = "juce_events"; sourceTree = "<group>"; };
-		D3C338AADE455AEA6C248E21 = { isa = PBXGroup; children = (
-				FC080F7DF94ABCB7EA09224A,
-				4C81E05B39376F54775A1027,
-				90F2939F533A26AC021E42B1,
-				A708E79EB9EB7CC44030F5D5,
-				6BBBC0907D7A62E2F3AB9BDF,
-				FB7E91937D3BBE00F64F0B72,
-				AFB684CE06F9256324EE0B4C,
-				B87C1BD13762817BE27DC2F7,
-				7A93BFD2180B5E00B124CB1A ); name = colour; sourceTree = "<group>"; };
-		1BF4F68D4169491DD79D0B01 = { isa = PBXGroup; children = (
-				793A4A777FEFA450F86C78EE,
-				891B132A0355007B4F37454C,
-				AF1F3010721A6B29062E4838,
-				B678CFC6B378A58834D2E41F,
-				B5E8A19FF91BEAD02C63E05B,
-				2F8252D3FF527D6559B12615,
-				301783FC4E3B19CA3C0AC85B ); name = contexts; sourceTree = "<group>"; };
-		328279397CFDFC5C31C08F49 = { isa = PBXGroup; children = (
-				9731D54410B06C1000370316,
-				217032322A2570ABAC47194C,
-				85928E2EF1C438EBC9EB07EA,
-				879B0383EF2A8B116903A500,
-				7F92025F0B8FD4FA725CC70B,
-				A540869F28EE158A0A348C28,
-				5AB3809F029824EE2DE0A798,
-				CC35C78D5B446ABF57DDDAE0 ); name = images; sourceTree = "<group>"; };
-		7E444D9FB4474A6546E9B779 = { isa = PBXGroup; children = (
-				D55137DE3404D7DF2A1F50D0,
-				EA354D7D8E48D461415D52D8,
-				98D2D452F48C86F47FB90BAD ); name = "image_formats"; sourceTree = "<group>"; };
-		91DA3CD69EAB03C727AA39C8 = { isa = PBXGroup; children = (
-				9F61AF101B43110732BB8814,
-				A5C9A0FBD818AEF57858FB31,
-				EAB2319C7AA57E06A2247CDF,
-				7B674BB1DA11A4E58EA71624,
-				B5ADA0C1BDBFAE2A2F8ECB48,
-				CD2E26CFD0DC7F6090E15A20,
-				2A3230DEAAC86A9090950703,
-				C660716FDD337EFB1A7C6C72,
-				04C474E0F2F7FDEC714A673C,
-				13D9DC48F19699485F9888A4,
-				4C3EA47E012B2D63ADE599DD,
-				6D77949E9C7C9B5A7795C0E0,
-				463A302B39C7815EB981CEBD,
-				9380932BED279F91B8C1C04B,
-				BDFF189EC742274DD2629196,
-				D88B0ADDC9BF206E3D2EE9F6 ); name = geometry; sourceTree = "<group>"; };
-		89F126369D1761C7A09E35C3 = { isa = PBXGroup; children = (
-				7F1E84C068D3E6AA13CDD699,
-				5DB6A07B827D62571BB51943,
-				18CFDBCD4A5B80E78DADCFEB,
-				5265AD5F97C9E813E14937A7 ); name = placement; sourceTree = "<group>"; };
-		6837ABCAE2AD67F0AD5F9AE3 = { isa = PBXGroup; children = (
-				C916444FD4BFB79D4DE9FCAF,
-				1AEEC114AFAB6E81205FBCD1,
-				C1435AB0105CDC29A3124E4F,
-				E0ADC34D69113B79C2F4FF24,
-				8822ADC9DB83FAF39B841E31,
-				1777330D3BDAE99A93F98943,
-				C209C7633D01E525231EE894,
-				14DD0220B41F74C01A9DC676,
-				4650B5724FE3C0608FB07A04,
-				8077C8D1C544F458947D693E,
-				AF8ADA74003E96998A5E4404,
-				9F845E950F19FEC4E6C88F91 ); name = fonts; sourceTree = "<group>"; };
-		D6EA061B97C039BF4BAAB444 = { isa = PBXGroup; children = (
-				1191BF3048664183033BFF89,
-				8B7EB54E1F773517A65D935C,
-				0AAFE3F4D106138401C190C5,
-				AADBA8C0AD524CE677428AFF,
-				B2FA9CC4754E136F22281176 ); name = effects; sourceTree = "<group>"; };
-		E30221BFC59C887A6337E8C8 = { isa = PBXGroup; children = (
-				89B0B267EF0A2A19A082EB86,
-				6DCDFF2618CFEECEACE87630,
-				AF7106E30ED950436CCEC712,
-				D48EB74E1B5AAC7846196B01,
-				3D100F6FDB04756402F3BCC9,
-				6832130272774CD542793762,
-				E33F167E4AA1C44596A1EBED,
-				CA09B0483969444C7CD106DC,
-				B021D393D0E2625741512320,
-				603764889DE750F8E87F6428,
-				7D36B006AE0B139D8A3D8641,
-				55EBFCA56B915C8CD043365C,
-				A0D768F1B92568344DAC9F0B ); name = native; sourceTree = "<group>"; };
-		448EFC87A2DEF32F9547F801 = { isa = PBXGroup; children = (
-				D3C338AADE455AEA6C248E21,
-				1BF4F68D4169491DD79D0B01,
-				328279397CFDFC5C31C08F49,
-				7E444D9FB4474A6546E9B779,
-				91DA3CD69EAB03C727AA39C8,
-				89F126369D1761C7A09E35C3,
-				6837ABCAE2AD67F0AD5F9AE3,
-				D6EA061B97C039BF4BAAB444,
-				E30221BFC59C887A6337E8C8,
-				25433DB6D2EAEBB307EFB960,
-				E67C5ACDC8208CDE200EC8C6 ); name = "juce_graphics"; sourceTree = "<group>"; };
-		DA98B2B8AD88362017D0133B = { isa = PBXGroup; children = (
-				085F51FEE5C5FDAA321090A0,
-				01C313C323E5CB995C939E0B,
-				EEFC66D2DF5FD66B4D83B22F,
-				4F4234DC14D3689C22655D0C,
-				50DD8D693741DD18106C0BA7,
-				A15596CDCC27B86FC070D7FA,
-				CD41C1D09F6D73FA33993F45,
-				1DF5FD417930A62110DF0419,
-				45883809F1335E6C745F8155 ); name = components; sourceTree = "<group>"; };
-		8EB93734459D15BBDF8EF722 = { isa = PBXGroup; children = (
-				E91A272EF06892937CB4B9CE,
-				9A29EBC10219D89919E12FCB,
-				8E78AAA58721DE609F6FFC61,
-				A54886FC74BE0DDC74094EF5,
-				F9E2371F1A99B292F2947FF5,
-				9C96B0CBFF3D34885BB8B020,
-				4EC254B133A7AAE377B9B3AE,
-				686FA8DDF2848517CBFB9E4A,
-				4E520E7960CC5098C2352E70,
-				565EEC8F429ABF5F9A867137,
-				11A5824E0239C86801BE2EB8,
-				3E22E947444B5849011B6C4E,
-				EF059B26886B32000BCF8CFF,
-				B00A9C0BAD3AF9F48E36A38F,
-				FEB3730E084D7DD433D14A6C,
-				8F3C158B4FB92CFC48324896,
-				05997833A4AA137FD64348AD,
-				AA3209223925B66A97AB4509 ); name = mouse; sourceTree = "<group>"; };
-		9A37C74D88FB91820F829E3C = { isa = PBXGroup; children = (
-				7BCE1C09508E1B9CFC79C185,
-				2FE6DAFB634FF3C20F1D6FD7,
-				D840E516B1DE9F3F730283D5,
-				FB33617B5082CC0CDC189F2C,
-				880CC7C325EFF665AC3006D2,
-				40C22F3CD61DDB9C7B3DCCA6,
-				33A69BDDCFCD4A4DC14A9961,
-				78CC9639B933CE2497264EF2,
-				8C268C3D0B8EC2BB8953E7F7,
-				C6E19D3864B40A52BCC49315,
-				6C36C3C304EB066B1DFCCD9C,
-				9C701D5A7298B83CE05ECEBB,
-				8689288B66B16EFB106CB2F4 ); name = keyboard; sourceTree = "<group>"; };
-		9627D3CCE9D6810CB06B5D77 = { isa = PBXGroup; children = (
-				9D2510B5E6180456C53A455E,
-				A7875D5F8D2A632C99791002,
-				FFBB9CE85A7C91FB11E4AEC8,
-				45D440B69BDB210B17CD424B,
-				8C3B6865F2053C80A6E692F1,
-				C7A76C0D1B3DC4A1F059E59B,
-				B3BAC48D01C49D8727D08097,
-				95EC6B1536DC65070D0ADCEE,
-				B123E2F4439DAD65196A2A9D,
-				6BA113C799640798D3F29A06,
-				53C8A2696FE4389E4AB4441C,
-				21C11A58CAA0F9E86AA204EC,
-				CD83E301AE42E6E3317D575D,
-				B60D02B5BF564ABC88841B1F,
-				D171071934C8F7F925B0D113,
-				3C1E0B87DA3E9AC60D2894F7,
-				921F5D04122F324502DA4E75,
-				9FDCF1E2B4651E58240400B9,
-				649F22404167E0D0EA244196,
-				AE6786E4659DAC92F52E9FA3,
-				6917A53BAA3CA2819E4C10BF,
-				17FB020EFEAED8493D3CB121,
-				E37140E9E8F7CFDDEEEF6148,
-				4BB38A2CD55BF23C7C3E3387,
-				7F93E4F0CC8B842AC1D3E560,
-				564380494D23DB70680FB0B5,
-				38E493BFC36AC80B1CDAAF35 ); name = widgets; sourceTree = "<group>"; };
-		3DA4EA9C737426FDAF1484AD = { isa = PBXGroup; children = (
-				7E581214A64A535E03EA759B,
-				71CF8F6995DF1BA2038C21D6,
-				CDC18ABAFEF000C720CE8622,
-				927FCF11005E78D499DAF197,
-				78BA978C614603B5E9ECFFF1,
-				483ABD5C1CF789943AB4AFB6,
-				2D577016FEEE23DD5703C924,
-				9B4EA34E8F90B7CC77694B7E,
-				EEA51B7EF1CF19028C6672E0,
-				581287A24510A9EACEE09CE4,
-				BA09F5CDB1C01E0FC153DB8E,
-				FDAAB4F0D2A15A6F0F71945A,
-				13D9868B08E941F6827E157C,
-				B6567CAE2B538E79E7DA814C,
-				027C1143CC66EA8F73C39A74,
-				F7979AFD5780D9B2208736EE,
-				EA2FC92CECD1EDA1F07DC59C,
-				55811E331B55E0547326CF22,
-				D51575B9AA7216CCE4B558E4 ); name = windows; sourceTree = "<group>"; };
-		23BCC80BAA5B674946A538A4 = { isa = PBXGroup; children = (
-				A19C4BB4BD69D4351B344A17,
-				EFC21F3CD0EB87D67E044E06,
-				D7E51310BD1B8EF6A2A77177,
-				4B3DBFE485F45E62C53A90B8,
-				0790CCE2FCFDFA6944DFC402,
-				361E3A46C9BFAD1530593487 ); name = menus; sourceTree = "<group>"; };
-		DAA118DDF10823819CE57BF1 = { isa = PBXGroup; children = (
-				B674DCA2C2A6AF6B58AA7820,
-				BABBEE3876B90C8A57C3074D,
-				17B29FF3D3EA14EF2BE149BB,
-				674FDCCEF6A1379A0F689004,
-				6DD526F86CBF2C3B3487FFE1,
-				2FF422D0633A28558D0227EC,
-				313970BBDAAA4EDC8B322F3A,
-				EE4DD055D31F7D9DC718DBD8,
-				570299171BCE863C54FBBA54,
-				4E71B355F2BABAF69CC4114D,
-				7D88F7083884A5ED2DBE7534,
-				5E0F8A60411A03461FD687CE,
-				C195559D311BAB51CFB545BA,
-				6E2F243D8F70CC92391204A4,
-				75FCE8908DD9055F90E93716,
-				5E1EFF4EEA5684FA00CAA353,
-				94BD861806F8EA598EC09370,
-				E23FA5E940A1434B0305875D,
-				EE0336B43A39FD585DF638EE,
-				CC42C4D4230BE4F1071CB2D3,
-				F1099BFF0BC1656A23D62E84,
-				5B411F4FCF0F69798C9E4A88,
-				43420911407CC35CE2A02B38,
-				DDE157BB06373ECDBB23469C,
-				918837CC0447C50774036664,
-				D06A8FDAD8B22537EA594383,
-				3E0942A2D72F50FDE27C14AE,
-				416B99B14B44CB16B725C4B2,
-				0D3C20D1F00B7B1381E6B987,
-				F10FB240E10A5742CE366A91,
-				4AE36D25675E32A897F97BFA,
-				510ACDAD798813D7FC110197,
-				AEF53FD0FBBFF5242EDD7032,
-				9F6664EB2C39D224C6BCC75E ); name = layout; sourceTree = "<group>"; };
-		444DE4CB4BD092CB31057DFC = { isa = PBXGroup; children = (
-				5FEBF3F722DB6191BF659816,
-				08DAD5894A480950C66F5873,
-				7CF939BD59D45EB41B5FE628,
-				390856DF83DAC70909D5B397,
-				FB1B880F24F376D1AC52F2A6,
-				D8AFDCC674A7514B7019EEA6,
-				7387114E34496F4606550863,
-				80A612858FA1177A262744C6,
-				B11E5B5E4483AF89E6DCBAB3,
-				393801D2B91773D376D874B0,
-				B1ECBE9C48227CBDB16E3702,
-				44E04E5F584A8BFAD062A09D,
-				E6D3A973D5CEF18CA2BAFF59,
-				83950E9D0D7C100B7DCA0E55,
-				31BE5E435604D33173940048,
-				92EC6BB8A8C4C5A61F43C233,
-				9C4342320D2DD65E2BD6351C,
-				98C81B13A0C34D8A4E93ADD1 ); name = buttons; sourceTree = "<group>"; };
-		DE87FCC919AE658D7931F3BA = { isa = PBXGroup; children = (
-				C454DFC77F19AB044372610E,
-				A93F302B8D91A997F54D231B,
-				BB0BB31575E1377F0C560D53,
-				B43C27BEC3AB681389FC5FC5,
-				75A4EEE127FAB86D65FF5F6E,
-				EDAC82BD742A54182E8DF2FE,
-				FD3A6BD3A8898E137DF257B9,
-				EF4A6E0E1232071252ACCD7B,
-				51926BEEA63BF141D93A5B36,
-				C41504F388D0B181B003B627,
-				08907A4BA0D5628476D19C48,
-				4A28A492852AEFBF508C1FC1,
-				DA30BA6BF482A353393D5926,
-				DAA4306D30617137463ED247 ); name = positioning; sourceTree = "<group>"; };
-		6101DBF4D993FE2CB50D4F90 = { isa = PBXGroup; children = (
-				13212C01A5E138553FAFBE9C,
-				9D13E0F774807670270F4790,
-				C5287F057A6A88BC33D5498A,
-				766923F74E30FF5D6B12E7CE,
-				9EAAE3C0BFF3D753C375A5FC,
-				F2A500BA3500C4A9D5792A54,
-				25F7BEADC001FA3D1EA9B32C,
-				E946426F95E0240683CB3337,
-				911CCC0A579792DC56807DEC,
-				617F5DFAAE97F48FA996A781,
-				4434939E139A45962C8CFB4C,
-				496180D5D96088CBB59035B1,
-				08A7A7FD7D77C0657270E9BF,
-				700597338DEC9AB65C4C8A5E,
-				ED86166920362E9D2BE2CB26 ); name = drawables; sourceTree = "<group>"; };
-		6DD8D8DBBBD09193A15803D0 = { isa = PBXGroup; children = (
-				D2CCDDF54D6D6F2BF4281F2D,
-				18B410DA5435C02C82BA13F8,
-				174842EA681FA29BE38A6272,
-				434E153E6C8337C1E4A2709A,
-				A9F5A8F835A1A734DF7F6775,
-				C10DC7C6E887B4EAAB8EDF38,
-				651E9B78A5139F7A5BCA4D90,
-				C7A68BAFB04A7D5FD81FA82B,
-				9070DC685E666BBFC2E19DA9,
-				0D8ECE32F7D0FE74185F6EF4,
-				6D4DFC260B2966E3EBFC0C79,
-				58958CC3F750D383261E2FBC,
-				414D8E6E4EE98E66C2583A50,
-				208DCD7025D0DF2740C01E4A ); name = properties; sourceTree = "<group>"; };
-		09C2000EFECCE35F3F793E55 = { isa = PBXGroup; children = (
-				5FEFF62D585CF777C950E569,
-				A4FC82A8339698B6C1AC5F18 ); name = lookandfeel; sourceTree = "<group>"; };
-		4CA0453E4C12495F1018A4E1 = { isa = PBXGroup; children = (
-				B83EBFAE6306941F79044523,
-				ACA28D2B1FECD2C57F0250A6,
-				6A63308EBE68478531604BA4,
-				7BE7EBBCC4DCF760A1AA697E,
-				353937A4E68C8C6916C6D1F9,
-				AD7D35FCD8CF66B6C393A7F7,
-				9C864C7DBAF37CD0719996A9,
-				3EAF57CE45DBACE2F88DA4C5,
-				945DC754F2EACDFFB7926DE8,
-				033AE5DE19F0EEDC47D41C80,
-				B4F0C0B262654C4782B5AC49,
-				284F3E94F0C96EA1DD89E606,
-				65A447DCF8A68BAABC20FC7D,
-				85C3F7CDF87409A56082DF67,
-				DACD0879E139527D971D3AC4,
-				52A8F84DCDDF0186B511B9CD,
-				499A12199A8A8C5AEDAA47E4,
-				1C474C73937D98E9D3FFEEC0,
-				6BA7D7A7E3E2E646E50D334A,
-				786A97B2B4E2BB6406546647,
-				696F2DC49934E6F01A2DF9FE,
-				405298E6CE1C80EC7CC43A87,
-				C2D1409D20E154E43569C725,
-				E58A18793D25A1D75811A052,
-				881237D5E366342B117C0ED7,
-				316FB94579DA666A388F429A ); name = filebrowser; sourceTree = "<group>"; };
-		45BA9E76F27503E30F331299 = { isa = PBXGroup; children = (
-				167524110873F9888CF1B9E8,
-				0DBB88B6BEC06FCECE4CBD28,
-				0B2502A656E77E00AF15A343,
-				70BF68C222D1E0A0368EB845,
-				E79B7DC03F81DA1F8CDE21CA,
-				4B74A7F0FDCE3E1706E5B320,
-				C6BDC4DAD5B40321DA67462A,
-				F3D0224E4247BCB06A9E4DDF,
-				1CFA355CD6811C253C72BDDA ); name = commands; sourceTree = "<group>"; };
-		BB094F61F6A8A5737BCC4CF6 = { isa = PBXGroup; children = (
-				04ED2387517934A84ACF9865,
-				ECE3BE71EB6B9CF1CE869BBE,
-				8D4FBD30E1C9EC0DA749BC83,
-				BCBBF8764A2101CD0E91DB5D ); name = misc; sourceTree = "<group>"; };
-		9519CC8E6EF00140A3B507BA = { isa = PBXGroup; children = (
-				2AB1CC4252DB09507ED31482,
-				753B81CCB5A6B6929679E7B7,
-				B24098EC4FD79D5EDC9383EC ); name = application; sourceTree = "<group>"; };
-		B324A7959C768520ED46A064 = { isa = PBXGroup; children = (
-				CF5BC8DB7D66C655DABA9129,
-				54339ADDCB6F8E9E7721A986,
-				47EE021D6C891095140ED7A9,
-				A8B4D80D55E48F50809DC5E4,
-				41AF61914A96159E9EA194B0,
-				48E4FA55FD4440AF44EEA437,
-				558E925DAC57ADF8810559AC,
-				6514FD7E6C5EC12735E49FBC,
-				1819C1C4DE5FEEDEA143E3D2,
-				14FE601229C9A40C6E182F28,
-				C17E85281A455245543930E5,
-				20EB4F22A76954F2986F364A,
-				45258533F9F65AC96D3080B3,
-				81D578AA5F277EB0946050E5,
-				159790C750B1F8B485DBB499,
-				1518D2BA7FCAF267EF1F02E6 ); name = native; sourceTree = "<group>"; };
-		83E1A8B708A967FC7D5B9FE4 = { isa = PBXGroup; children = (
-				DA98B2B8AD88362017D0133B,
-				8EB93734459D15BBDF8EF722,
-				9A37C74D88FB91820F829E3C,
-				9627D3CCE9D6810CB06B5D77,
-				3DA4EA9C737426FDAF1484AD,
-				23BCC80BAA5B674946A538A4,
-				DAA118DDF10823819CE57BF1,
-				444DE4CB4BD092CB31057DFC,
-				DE87FCC919AE658D7931F3BA,
-				6101DBF4D993FE2CB50D4F90,
-				6DD8D8DBBBD09193A15803D0,
-				09C2000EFECCE35F3F793E55,
-				4CA0453E4C12495F1018A4E1,
-				45BA9E76F27503E30F331299,
-				BB094F61F6A8A5737BCC4CF6,
-				9519CC8E6EF00140A3B507BA,
-				B324A7959C768520ED46A064,
-				BF9B6B0B73FF87595307D858,
-				3A9826A8C3B668BCC760BEB7 ); name = "juce_gui_basics"; sourceTree = "<group>"; };
-		9ADB0069D1F40FF3865041E3 = { isa = PBXGroup; children = (
-				1D7578F927EC030203A11978,
-				5BB1E90842FD8A212CC2D132,
-				586B1E0743FFBE9081A25F4F,
-				106E81B939C6B35E34DD71FE,
-				96F2A45DCB9BB53844B0ED4F,
-				081E86FE0B991469CFA8D7EA,
-				DFAA7B563CEFB94D9ADB5D6A,
-				F4D2A03314AB1CF852CC4F2A ); name = "code_editor"; sourceTree = "<group>"; };
-		E2198B85DAA7C61CCD912DD5 = { isa = PBXGroup; children = (
-				D1F9878B45ABC403F3749567,
-				C679AE9BBB9B1EE3BAB09E11 ); name = documents; sourceTree = "<group>"; };
-		4DD214F6A346B4C4F28B3C5A = { isa = PBXGroup; children = (
-				901C720965646841A94EB099,
-				32D568631762765C07D4BF0D,
-				0E4B0B8425DBA19B6F3FE4BF ); name = embedding; sourceTree = "<group>"; };
-		2A882D30C0E50E70FCD95554 = { isa = PBXGroup; children = (
-				76140C0485FDDA98C3D98E2A,
-				65BE7542749DCCAE33ACF40F ); name = lookandfeel; sourceTree = "<group>"; };
-		C8A65F145D072BB3DA28595B = { isa = PBXGroup; children = (
-				3F56A025C4D83EBDB66E3676,
-				F46843B979D0385C733C797A,
-				AD1950C0733B3470777BF861,
-				CE2BD40797A6E7647FDBE736,
-				23D82A4C165DD596474F30E4,
-				1E9FE44F0CCC6604B5469412,
-				F0D9A28C206D7A8BA7089D29,
-				88E5D0906646465409715828,
-				D4F94F0232F0CD426DFC44C5,
-				0AA8F001A50408977E76ED96,
-				FD88DA941838FC91D222DF35,
-				92E07CA13571893873565AC7,
-				6D4BA4399FDEB6D2195B257D,
-				7A9F37527280A470F201FB6E,
-				73C69D948D33899821536025,
-				8E696460A8A860B7A4044DFC ); name = misc; sourceTree = "<group>"; };
-		9924BF5224418D631DE02DA4 = { isa = PBXGroup; children = (
-				5E94E897783BEEFE61E61A2C,
-				6FE8B0DD6116E6A3456ECF09,
-				5284E69CC601457D5C7C1063,
-				D952A208CC8164F0B459EC9E,
-				5A746CDDE80FEA2E45B5BA66,
-				3A71F2C959CA7DD3C33DC411,
-				D357A886F6365DA33D639FF5,
-				DBF1FD9272546EE4C7DD517A,
-				3C92F249799E7CBF41FABEA0,
-				7C0F2759385C66CAC3EC362D,
-				1D7FEC587CFE464A21830C4D,
-				1BF01252E3A30560525CE057 ); name = native; sourceTree = "<group>"; };
-		E3229181F8CC2BD5E409AF00 = { isa = PBXGroup; children = (
-				9ADB0069D1F40FF3865041E3,
-				E2198B85DAA7C61CCD912DD5,
-				4DD214F6A346B4C4F28B3C5A,
-				2A882D30C0E50E70FCD95554,
-				C8A65F145D072BB3DA28595B,
-				9924BF5224418D631DE02DA4,
-				1C639F4C139C8D7753AA9BB6,
-				586448E180F8ACBF5A1565B0 ); name = "juce_gui_extra"; sourceTree = "<group>"; };
-		57F522311CAC2E8BF761B95A = { isa = PBXGroup; children = (
-				FF082466FC37DC44320B3B7E,
-				05DCAE8CA29532E2169D7AC1,
-				4CF403118BBAAD5B6763542A,
-				A3B6D091280930A016DF8FDA,
-				146C6A6E3C6B17F2AF475B50,
-				C5F9A0F8EB81AC15D9BDD61F,
-				B113BC1061788A9ECB1337C5,
-				A41AEA0D3ACB2B1E6713AE08,
-				D0247929128D618A2EB01D86,
-				4C4E2282C145D13C86CB23FA,
-				AC116E6590D49AB2EF19CB9E,
-				9F2853D1A12B686BE3BA2C61,
-				29381F22B8FDF48C3EAC3A9F,
-				455FFBB0C34B760D892D2D57,
-				5D9792840E8050DCC766B368,
-				61B0CBF705D5FC0431776286,
-				EF7B66764093D950724EFE70,
-				971E49A78543AADB8CA1D2B7,
-				D4B0BD47094D79AB6382228B,
-				12B5243A9435FABAFBE20165,
-				F6EBDA368C553C37BE703BE5 ); name = opengl; sourceTree = "<group>"; };
-		7C6BF9E0D166E4E5C3F2A005 = { isa = PBXGroup; children = (
-				917988BE74F2180BFC0583A3,
-				3AC9B61C10692BBA96D2F775,
-				3C18EC09535EA506FC0CBC62,
-				CC62E20B1189C697DD238810,
-				205E9A5C31827555F1CAC30D,
-				72FCE41894123FC5DB01566B,
-				61481DD4AAC7731CE984937D ); name = native; sourceTree = "<group>"; };
-		2D49786EE07B37713213F905 = { isa = PBXGroup; children = (
-				57F522311CAC2E8BF761B95A,
-				7C6BF9E0D166E4E5C3F2A005,
-				4540694F9744C9F4D29149CE,
-				AE1EA04666EAD34D0CA0373D ); name = "juce_opengl"; sourceTree = "<group>"; };
-		AADD3015266C1EF879776CBB = { isa = PBXGroup; children = (
-				59389DC8664617FD51740F36,
-				7C15112E5F287ACDD74480F5 ); name = playback; sourceTree = "<group>"; };
-		795DACC07989C186924B5DA3 = { isa = PBXGroup; children = (
-				E48A7B152993BCF473725A19 ); name = capture; sourceTree = "<group>"; };
-		C55C0342ACE444BC42092159 = { isa = PBXGroup; children = (
-				70ECB490BD59F59D003F3BEE,
-				6ABF91320A2EB6D307091AEE,
-				EB5F9A50EB53A57D6AE303C2,
-				D1D8F82F848413581B274A5D,
-				65980344D141B0008A94E2E4,
-				020205BB77179A9BE3FFF1E1 ); name = native; sourceTree = "<group>"; };
-		AD985677A45CD32AB58EECA5 = { isa = PBXGroup; children = (
-				AADD3015266C1EF879776CBB,
-				795DACC07989C186924B5DA3,
-				C55C0342ACE444BC42092159,
-				F88A99110564C87FBA281F2C,
-				C0B54E0803BA87C8BC353551 ); name = "juce_video"; sourceTree = "<group>"; };
-		328BE41789531FE4F91F7DA1 = { isa = PBXGroup; children = (
-				9311E4762BC3218510204A0F,
-				83416B76189CFC2030936CCA,
-				E2F864696FA2DDDAD60C7E83,
-				95530BD93D8ECFCC072C0850,
-				702A741EEADCBB982DDE18B0,
-				7333A0F468D3745057EB2368,
-				F196226BFBA15D76688C61C6,
-				A7F7E551BA5A75737261BB4C,
-				F61CCB10A356CE4278F74478,
-				448EFC87A2DEF32F9547F801,
-				83E1A8B708A967FC7D5B9FE4,
-				E3229181F8CC2BD5E409AF00,
-				2D49786EE07B37713213F905,
-				AD985677A45CD32AB58EECA5 ); name = "Juce Modules"; sourceTree = "<group>"; };
-		826D8EF5D0C6BF7B9F2AEAF0 = { isa = PBXGroup; children = (
-				D30880F1F9F514CEEDB9F48B,
-				A512C5B237A77EF6FB8E11A0,
-				837D266B3F62C3B05C2BC28C,
-				DF3C9A1DD67E879E4E0A2727,
-				65F4459CC1832883FFF6C166,
-				6B28CEAF75E22F2CCCACBCC7,
-				B20469D88488F0809126CC80,
-				56728EC77C65482B9C86FF4D,
-				A6A579E4E4AEA865BC71148C,
-				488D1B00C9E5FE4DAB035EDF,
-				DBCA7E2FFCFD1354DD19DDD6,
-				C29E664781AA2396C8D59543,
-				BBDFB328C3D5FC72A0446E6A,
-				23609D430A25F54723269E91,
-				27DC0E650D6D54DF29E6DB68,
-				5915DB02FB7CA8CEC1BF38A9,
-				4A7695E93CE32F4E95042FCB,
-				87B4BA68E49DD11197B7AFDB ); name = "Juce Library Code"; sourceTree = "<group>"; };
-		469F0AB7234589951A8F29FA = { isa = PBXGroup; children = (
-				46EF49B14DF7357A8287D9D8,
-				BBE1DB78E35135B41537DCB5,
-				61317B5191E05925F232E18C ); name = Resources; sourceTree = "<group>"; };
-		008433D940C09C1A15B916BA = { isa = PBXGroup; children = (
-				39F287BE4C0B4F3BD4A949FD,
-				C868329EBC1BBA606AB2EB88,
-				DBB769DEBCD6468C13A3CD25,
-				F5A00ACFA3D76168F22F1205,
-				27313EA12BC45638321922CA,
-				243817BA562AD7FA76C834C9,
-				D685CFEA6344360FBFC355B6,
-				E31563D2E7DDD8315F369233,
-				9C21DBFB38865E5AFE367C6F,
-				80C1B737D2C2CB519D1787D7,
-				C055D09224D84121A3EBB29F,
-				56169D835A3E3029D6E3904C,
-				4FD13AA663EEE7CC2F83033D ); name = Frameworks; sourceTree = "<group>"; };
-		FA0E0597ED415901958AD5AE = { isa = PBXGroup; children = (
-				99E1BC08B886CFDD2CCFD462 ); name = Products; sourceTree = "<group>"; };
-		A7589AF92E6E958E1F866761 = { isa = PBXGroup; children = (
-				9D44948383EAABF451302146,
-				328BE41789531FE4F91F7DA1,
-				826D8EF5D0C6BF7B9F2AEAF0,
-				469F0AB7234589951A8F29FA,
-				008433D940C09C1A15B916BA,
-				FA0E0597ED415901958AD5AE ); name = Source; sourceTree = "<group>"; };
-		95F63B27BAC6E72226C3E356 = { isa = XCBuildConfiguration; buildSettings = {
-				HEADER_SEARCH_PATHS = "../../JuceLibraryCode $(inherited)";
-				GCC_OPTIMIZATION_LEVEL = 3;
-				INFOPLIST_FILE = Info.plist;
-				INSTALL_PATH = "$(HOME)/Applications";
-				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
-				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
-				SDKROOT_ppc = macosx10.5;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+/* Begin PBXBuildFile section */
+		002427B013C43CE3E6D4E9B5 /* juce_opengl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5915DB02FB7CA8CEC1BF38A9 /* juce_opengl.mm */; };
+		004E78BC139419671A9EA137 /* MainWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E08E877C3A6283CF5C803957 /* MainWindow.cpp */; };
+		00A0D05390DB9F2B74DDAA78 /* Bessel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1989E86F8DFDE34887AC0326 /* Bessel.cpp */; };
+		029C3B11BE586DA100895A60 /* ElectrodeButtons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 28CCF04CCC028BAE0AEE5840 /* ElectrodeButtons.cpp */; };
+		03A83ACD14BB6A18AFA4C81A /* NetworkSinkProcotol.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 33EC8C48E03E5FB60DD9D4C5 /* NetworkSinkProcotol.pb.cc */; };
+		04E6370E518D4C41CAC82003 /* OscilloscopeNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC17FC0E3B6E3B7C45079DE0 /* OscilloscopeNode.cpp */; };
+		06BCB79AE267E5841F641E38 /* juce_cryptography.mm in Sources */ = {isa = PBXBuildFile; fileRef = 488D1B00C9E5FE4DAB035EDF /* juce_cryptography.mm */; };
+		0836C50051EF59BF91D7B12D /* LfpDisplayEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8A91849BE6B96EB8C0663469 /* LfpDisplayEditor.cpp */; };
+		09673DA3B4D6EA61DEFC0C46 /* DataViewport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47A3942AC30A3212C01F1CAF /* DataViewport.cpp */; };
+		0987D2A72DD60B4A7D719707 /* LogWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94AED5D544719B438B3EE723 /* LogWindow.cpp */; };
+		0AE243437B40602D35435C32 /* AudioComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B04D87ED6AA4897B6CD3CCF6 /* AudioComponent.cpp */; };
+		0CEFF81CD8861F959DB13362 /* RecordControlEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1552007C6C6AF750278C5BE5 /* RecordControlEditor.cpp */; };
+		0D3DFADD627629AD52668186 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39F287BE4C0B4F3BD4A949FD /* Accelerate.framework */; };
+		0DAD0EFDC8B36F1D9BBB00BC /* PeriStimulusTimeHistogramNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96AED479B95D4EC31604D604 /* PeriStimulusTimeHistogramNode.cpp */; };
+		11D82BA398E9433440B76F66 /* PhaseDetector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9FFD9560522567A033226BD7 /* PhaseDetector.cpp */; };
+		129ADFA8B25DE091AFA2D9E3 /* Custom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D8D895B3AD895C6E7FD446BF /* Custom.cpp */; };
+		13F1111511DD01E843E631CA /* ProcessorList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79C91DDF3BC3F15D0338E504 /* ProcessorList.cpp */; };
+		14BDAEA656AAFA60334CC55C /* AccessClass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 420B0E95F1300ABFDC125DBF /* AccessClass.cpp */; };
+		155C4E1F4B91745239F99C8A /* OscilloscopeEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F45F344950087E1266A6445 /* OscilloscopeEditor.cpp */; };
+		1691EC0AC4C7083D65B925E2 /* FPGAOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9D78F50147005EDB0E89E2B4 /* FPGAOutput.cpp */; };
+		171DBC82575004F0DAF60A80 /* tictoc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFABF04684556C4A54A62439 /* tictoc.cpp */; };
+		19BB86C918F89D1377F8A0E1 /* SpikeObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5894D40A0E8FA6E9B3EBF9D9 /* SpikeObject.cpp */; };
+		1B620FC17AAECA4C5DE741E2 /* DataWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66463AB11EA4D6341C32F27E /* DataWindow.cpp */; };
+		21539690A9A5DD20AFAF41D3 /* SignalGeneratorEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9136BD46BE1E28A96FBBD440 /* SignalGeneratorEditor.cpp */; };
+		24CC7E9A7E87F762D4AB0467 /* DataThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 92602D7166325C7232B85EDD /* DataThread.cpp */; };
+		285FF16149C85F2793EBCBAE /* Design.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B93450006102A0093F5EACB /* Design.cpp */; };
+		2B29D90B985E9EB788472EFE /* SplitterEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D51315B4241B019BE43EE4F1 /* SplitterEditor.cpp */; };
+		2B4A80DCF867DC025C21966B /* Merger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4867923F31CC3EDC9B1A5BE5 /* Merger.cpp */; };
+		2D2BDB63CBD0BED07FF9E44B /* RecentFilesMenuTemplate.nib in Resources */ = {isa = PBXBuildFile; fileRef = BBE1DB78E35135B41537DCB5 /* RecentFilesMenuTemplate.nib */; };
+		30530D3307A5202B71B3D751 /* SpikeDetectCanvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 08618BD1F5343B5E6457237F /* SpikeDetectCanvas.cpp */; };
+		3130878C465F3294A89CA142 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E31563D2E7DDD8315F369233 /* IOKit.framework */; };
+		3162B66BC8118715AAA527D7 /* UIComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D2A3B4CDD296B4CEC6902FD7 /* UIComponent.cpp */; };
+		352F3875222B1D233013AAF9 /* ReferenceNodeEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C39C584DA6F507E773687EE /* ReferenceNodeEditor.cpp */; };
+		38568B2E6C61E2F07173B568 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C868329EBC1BBA606AB2EB88 /* AudioToolbox.framework */; };
+		3933895CA488855A23943F61 /* ParameterEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E3A634686BFEF787229582 /* ParameterEditor.cpp */; };
+		3A2E957EB8D117C535F119E9 /* ArduinoOutputEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AD76E8111A738A8F3717060 /* ArduinoOutputEditor.cpp */; };
+		3D0C7CA4AD9E3963D52E89BD /* DiscRecording.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D685CFEA6344360FBFC355B6 /* DiscRecording.framework */; };
+		3FF289281D3318A7BA8BB44D /* juce_audio_processors.mm in Sources */ = {isa = PBXBuildFile; fileRef = B20469D88488F0809126CC80 /* juce_audio_processors.mm */; };
+		4996C99F2CF9C13880F8C5D8 /* NotchFilterNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E413F3262886677B4CBF3FA9 /* NotchFilterNode.cpp */; };
+		4AD3281B0CCF122A25E33667 /* Biquad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 22801F75289646F6A85E5583 /* Biquad.cpp */; };
+		4FA2949D3023FC2E377AFFB6 /* unibody-8.otf in Resources */ = {isa = PBXBuildFile; fileRef = 61317B5191E05925F232E18C /* unibody-8.otf */; };
+		4FEC4EC2796E37A3B11B50B9 /* Filter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 587FCA2485B9C89C2A99C23A /* Filter.cpp */; };
+		512D7D16D0A95BDD0D6D6E45 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FD13AA663EEE7CC2F83033D /* WebKit.framework */; };
+		52AE3F7AEED81BA9ED5C4830 /* ChannelSelector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E216D095C98F850A5FB6FB0F /* ChannelSelector.cpp */; };
+		52E0D9DC7F5C4703257D8BEB /* ChannelMappingEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B083B1375828610D55F12CF3 /* ChannelMappingEditor.cpp */; };
+		5570682BF1A39FB3E3FAC182 /* LfpDisplayCanvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A94E809624F99387E600399 /* LfpDisplayCanvas.cpp */; };
+		55CD2E9F373B69C3E8363B78 /* SourceNodeEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6328434A329C353DB8D9512C /* SourceNodeEditor.cpp */; };
+		582C224AA50C9395810C8E27 /* ofSerial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 308F614D30DCB9AE3767C928 /* ofSerial.cpp */; };
+		58D3FF3B1F462634167BDFB5 /* ControlPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 610E487E060C42B52FD5AAC9 /* ControlPanel.cpp */; };
+		58E0EC510F2A88E14AE55439 /* juce_gui_extra.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27DC0E650D6D54DF29E6DB68 /* juce_gui_extra.mm */; };
+		591CED1277A8C945EF60841C /* MessageCenter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BD2C39F13FDE202141C4B41 /* MessageCenter.cpp */; };
+		5AE42EF7A713B1EC0ACF9EDE /* FilterNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B0E8FAD5AC445F612E3468B9 /* FilterNode.cpp */; };
+		5E296916472899325DFFC828 /* NotchFilterEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF1DCDC30FDFBFAF03516C1 /* NotchFilterEditor.cpp */; };
+		6029B20DF2BD523AC0F78896 /* FilterEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D90290A0AA2C36CE757E46D5 /* FilterEditor.cpp */; };
+		6272253EB0051C1F215CD4D9 /* PulsePalOutputEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25A9484825F1B93ABC0E577F /* PulsePalOutputEditor.cpp */; };
+		627C7B84F5FD275FAF43663A /* WiFiOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2D41C43686CDE35E86A389D7 /* WiFiOutput.cpp */; };
+		6306AA945375749C4FE834E6 /* Main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2C89EC72FF6A7118EF459DC3 /* Main.cpp */; };
+		6510492BAE00C95DC620F493 /* juce_core.mm in Sources */ = {isa = PBXBuildFile; fileRef = A6A579E4E4AEA865BC71148C /* juce_core.mm */; };
+		65C47CAEC038F5C9FAC6811D /* ISCANeditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 58BBDECD171E15D0768302A1 /* ISCANeditor.cpp */; };
+		66F3B79BDF9BFB631D7E3584 /* RecordNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A4E2CAAF556D557B24182414 /* RecordNode.cpp */; };
+		6702EEA4E99D503C0EE933C4 /* GenericEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D3AE8303545E28D793312F46 /* GenericEditor.cpp */; };
+		685151FF4FB872983524A5C3 /* SpikeDisplayNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DAA04A0FD47097893712B241 /* SpikeDisplayNode.cpp */; };
+		69630D3ECA4D6014EE3734CD /* State.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C1CB526B75E406851FA918C6 /* State.cpp */; };
+		6A13D8F42A330E2C410B43E3 /* EditorViewport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E875E681E18D693D5ADB2FB /* EditorViewport.cpp */; };
+		6B67D7B6301182C7621294B6 /* FPGAThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA23A1334E4CFA77BC18A153 /* FPGAThread.cpp */; };
+		7015D104F55D5B128341CEA8 /* juce_graphics.mm in Sources */ = {isa = PBXBuildFile; fileRef = BBDFB328C3D5FC72A0446E6A /* juce_graphics.mm */; };
+		702C9BFCE865CB6C6B8BFB0D /* rhd2000registers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DB3B3197F8C1E5EE159D6FC /* rhd2000registers.cpp */; };
+		704484388E63CDE33491E1AB /* EventDetector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39464D2A22940DA2DDCCCFC6 /* EventDetector.cpp */; };
+		7077270005BA819E3D5654B5 /* PulsePalOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DBB295F412798131D3F04045 /* PulsePalOutput.cpp */; };
+		71111DE81104B1536ECB6DFB /* SourceNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECA6FDB1366BE7EC30F1539B /* SourceNode.cpp */; };
+		739573501D1D440A72C5C2E5 /* RHD2000Thread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3FB0EA0264580F6B00D993B /* RHD2000Thread.cpp */; };
+		73DAB4DC87D7333E490F2D7E /* AdvancerNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71C0C491E4BB214551D6EAD7 /* AdvancerNode.cpp */; };
+		784125612E2B7AC6CD89D835 /* EventNodeEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70151263C4CB8A4F79431E11 /* EventNodeEditor.cpp */; };
+		790911EDF00A4BF77327D99A /* PulsePal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 48E12736F471C43C959AD15C /* PulsePal.cpp */; };
+		7F188166D38DA7FB23311413 /* ImageIcon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04C6B933E1603B4D0916570D /* ImageIcon.cpp */; };
+		80E5365461A5A7A32C48C563 /* EventNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F94DD42C7BBF81C101D3F605 /* EventNode.cpp */; };
+		85A60568B3DC342C76B4E679 /* GenericProcessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AE038CACE48AF85C4FB1ED5 /* GenericProcessor.cpp */; };
+		88B896EB9793E0C44410D981 /* PhaseDetectorEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 75B1E4EFCDA9A506CFEDB09F /* PhaseDetectorEditor.cpp */; };
+		89223664B6CB2A912E36B091 /* MatlabLikePlot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F115ED75E977A54AAF036B2C /* MatlabLikePlot.cpp */; };
+		89FCE8890946693CD5FC4A70 /* okFrontPanelDLL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 235A8987D99A191D07208D2F /* okFrontPanelDLL.cpp */; };
+		8A5BACA019DA9B0EFAD5CE93 /* ProcessorGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 555D34D0CD8776EE5996CC3A /* ProcessorGraph.cpp */; };
+		8EF485897B3A20D8E6AC3B40 /* PeriStimulusTimeHistogramEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C25A8261F0A21369FB9D8 /* PeriStimulusTimeHistogramEditor.cpp */; };
+		9212DC2AEE118398CC970DDF /* CoreMIDI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 243817BA562AD7FA76C834C9 /* CoreMIDI.framework */; };
+		9227961C07C0EE73E89C90B5 /* juce_audio_devices.mm in Sources */ = {isa = PBXBuildFile; fileRef = 65F4459CC1832883FFF6C166 /* juce_audio_devices.mm */; };
+		94FAD0B2F2538EE8918F9E67 /* NetworkEvents.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C91ED2E43CF9CC0E83EB50A7 /* NetworkEvents.cpp */; };
+		955561F4FF4484648FDB9F73 /* FileReaderThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1718EC50691D8421EC00F8B3 /* FileReaderThread.cpp */; };
+		95AE939ADE096394CCD2526F /* EditorViewportButtons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9F3B3184EC6D42CEA35D6ED8 /* EditorViewportButtons.cpp */; };
+		992137E90F9D41522FD56875 /* MergerEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29FD7B383C5DDACAA7B8DFD3 /* MergerEditor.cpp */; };
+		996F9E4989EB47941D8100DA /* SignalGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5522973FA48A13C6BED293FE /* SignalGenerator.cpp */; };
+		9A80E3D1D1758A31D2169497 /* CustomLookAndFeel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3774BBCA6CB133D9A854CF71 /* CustomLookAndFeel.cpp */; };
+		9BF1FBB0A93003FE8EC94C72 /* NetworkSink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7F4241B34F5F7245653B5196 /* NetworkSink.cpp */; };
+		9D17609E468FC65EB70ED7F4 /* RBJ.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9A21A229CFACC67E31F4F727 /* RBJ.cpp */; };
+		9E30156DBCE4EAF9EFAF0AC4 /* juce_audio_utils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 56728EC77C65482B9C86FF4D /* juce_audio_utils.mm */; };
+		9E8544C3983B3203530B5A49 /* Parameter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD2370F8F4A44446558A08FB /* Parameter.cpp */; };
+		A0DAD4E5F7583349DC9275F2 /* juce_data_structures.mm in Sources */ = {isa = PBXBuildFile; fileRef = DBCA7E2FFCFD1354DD19DDD6 /* juce_data_structures.mm */; };
+		A269A876BDF3B7011FA4C681 /* juce_gui_basics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 23609D430A25F54723269E91 /* juce_gui_basics.mm */; };
+		A2EE65335FB2810C04ECBFAF /* juce_audio_formats.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B28CEAF75E22F2CCCACBCC7 /* juce_audio_formats.mm */; };
+		A33C92B3D445EBC6C35E7ABA /* SpikeSortBoxes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 813CB9DFF788D612A0750FBF /* SpikeSortBoxes.cpp */; };
+		A3CF90DE56808A47519FC101 /* SerialInputEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07BEF02C2B930DF7847C2921 /* SerialInputEditor.cpp */; };
+		A44FEA7117CFE2F06B9889B4 /* Legendre.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C4B0DF8094C90543A65E03E3 /* Legendre.cpp */; };
+		A454D138EC507C01D299AB0F /* WiFiOutputEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C79249376E3FDF10615E16EA /* WiFiOutputEditor.cpp */; };
+		A94130738A9973148544664A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5A00ACFA3D76168F22F1205 /* Cocoa.framework */; };
+		AA16BE5A6BBD024C8FCFCDA8 /* VisualizerEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CAA3B9396EA62166234DAEF1 /* VisualizerEditor.cpp */; };
+		AD032CEA5DBE4D4C76D3D2D1 /* ArduinoOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D38E60AC4854B6E1EDE488EB /* ArduinoOutput.cpp */; };
+		AD7D05519200FB0EE1C7617A /* BinaryData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A512C5B237A77EF6FB8E11A0 /* BinaryData.cpp */; };
+		AE06672D2CBF8F64465B2126 /* RootFinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F69480D6145C77992FA59BA /* RootFinder.cpp */; };
+		AF26E388BF6536803E762CB1 /* RHD2000Editor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45D78C8EF660EECE64BAA33F /* RHD2000Editor.cpp */; };
+		AF67C81811F18FCE6AA9C895 /* SpikeDisplayEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1EC95CD1D830F6D85ADB3B9D /* SpikeDisplayEditor.cpp */; };
+		B226387EB0FCE3BE6773FF61 /* Cascade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 09BCBD414282A3AA4F66A3A5 /* Cascade.cpp */; };
+		B3B08037F49EC7540586828F /* ChebyshevI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC2CFF4DA5CE431FCC628BA3 /* ChebyshevI.cpp */; };
+		B6C73582C501D8C3C03A4860 /* ChebyshevII.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B767A249792EB15A87054409 /* ChebyshevII.cpp */; };
+		B89453078EB0A8107F39EDF3 /* SerialInput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86688D712937F3D08918C68B /* SerialInput.cpp */; };
+		B8EB3B8A25F7D8BA4F697399 /* TrialCircularBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD2075B59AF7E38447BA84B /* TrialCircularBuffer.cpp */; };
+		BBE886EA79C50D0D68A5A753 /* PoleFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65312FAD0900119CDF6CF414 /* PoleFilter.cpp */; };
+		BE54C019A73BBAE05BFD7D17 /* ResamplingNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A98A22CF5F208ED6DBE08063 /* ResamplingNode.cpp */; };
+		BEACD5086C04D68470944B72 /* NetworkEventsEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77E8538ED93AAADC9FE2646 /* NetworkEventsEditor.cpp */; };
+		BEC09BF7DFCBD272B5471696 /* ISCAN.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B84E9C47FEE13D162CE9E5D7 /* ISCAN.cpp */; };
+		BECDDBEE5F3E0B715BC91F39 /* AdvancerEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42C88F6EE487194784FD1D6F /* AdvancerEditor.cpp */; };
+		BF3254F07C15D467D6DB3FEF /* AudioEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 10BE33089BA6F3468F36CD6C /* AudioEditor.cpp */; };
+		C0E966234C8AF91C19CF6EA4 /* Param.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C67E29CDEDF2EF61C054F /* Param.cpp */; };
+		C2475E008FEB33B3EA7B6C7F /* juce_audio_basics.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF3C9A1DD67E879E4E0A2727 /* juce_audio_basics.mm */; };
+		C3406F00595AEFF068EDB162 /* FPGAOutputEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 169F1B20FC9FFE88C53D2735 /* FPGAOutputEditor.cpp */; };
+		C59764685E62E7C4D323F84B /* LfpDisplayNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EA535EA158451360B7B8AE52 /* LfpDisplayNode.cpp */; };
+		C6F08BF3EF53274A42BB88EB /* Channel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BC055494F9FEE3F90630541 /* Channel.cpp */; };
+		C853FCE2F6C91B3643322CF0 /* PracticalSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9F577889CB6C54A2F7B1CA80 /* PracticalSocket.cpp */; };
+		C8D7AC0B88A9A2C182B2B752 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB769DEBCD6468C13A3CD25 /* Carbon.framework */; };
+		C9AC286A46B3A1318F298DEF /* rhd2000datablock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECB5A75A81B90327F58CBD9E /* rhd2000datablock.cpp */; };
+		CA4DCF67B48352BE633A616D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C055D09224D84121A3EBB29F /* QuartzCore.framework */; };
+		CAB9D9DEF279F93132B45F90 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80C1B737D2C2CB519D1787D7 /* QTKit.framework */; };
+		CB470032BC92A30906C96258 /* Elliptic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 392408C1943AC6234BAAC743 /* Elliptic.cpp */; };
+		D0873C347977633B4421B94D /* SpikeDetectorEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A252FE4E6A360CBC4AF694B3 /* SpikeDetectorEditor.cpp */; };
+		D0E9E20F9D8FDA700BB6D820 /* Splitter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2C4730CAFED4F6292B575318 /* Splitter.cpp */; };
+		D19775DC99C67AD20F98EF17 /* Documentation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90FCB43DA2FF766597DA75E /* Documentation.cpp */; };
+		D499273B65D901D0A101CAAA /* GraphViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5C1D021C0FD6FAD082C5D75 /* GraphViewer.cpp */; };
+		DA836EC803E4FF4EDEBE6386 /* rhd2000evalboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2D2BAC4320470CF68743F58E /* rhd2000evalboard.cpp */; };
+		DD77A0AB68C932F294B753C2 /* LfpTriggeredAverageEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B7819A5759B54D91E334447 /* LfpTriggeredAverageEditor.cpp */; };
+		DDDFAE2042D8AD20CC78CE3C /* ofArduino.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3753B3B311AE0A9F4CC5AD40 /* ofArduino.cpp */; };
+		DE758AF46844DF951655966C /* AudioNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B27F558F42AC78F0E564B5AF /* AudioNode.cpp */; };
+		E100912B2FCE36A30D097C95 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C21DBFB38865E5AFE367C6F /* OpenGL.framework */; };
+		E4DA638CDD4DD574A6CD843E /* RecordControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 258938780F93A7CF41366F26 /* RecordControl.cpp */; };
+		E5CBEA12D7AD7788C9BF5737 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27313EA12BC45638321922CA /* CoreAudio.framework */; };
+		E85DA5FC9A162F129ABA7113 /* SignalChainManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0987F7E90136D0E08A606A22 /* SignalChainManager.cpp */; };
+		EA46BA3970E958013FF85690 /* FileReaderEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0097003751A59A11FA8C5B /* FileReaderEditor.cpp */; };
+		EA6A1BDDF81818D516B93DD6 /* ChannelMappingNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5654BDD4FBFF01AC3F17FA0D /* ChannelMappingNode.cpp */; };
+		ED8CB527B27C67E9E4DA027C /* SpikeDetector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC3B7E4E25505D9044BFACC7 /* SpikeDetector.cpp */; };
+		EDEE5E21F0C9BDB7DB796083 /* AudioResamplingNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 76F569AE7B444D8F69EE0E86 /* AudioResamplingNode.cpp */; };
+		EE56A6BBBFA4A27A4BCF7279 /* SpikeDisplayCanvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D4C9E3ED3763847C087F46 /* SpikeDisplayCanvas.cpp */; };
+		F0EC60AEFAFF3D289F8110BE /* ResamplingNodeEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C5ABE6BDCA91410BA92A7BD9 /* ResamplingNodeEditor.cpp */; };
+		F25EC78DCCC9CCEE805AE011 /* FileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9215DC26F511C58DEE009209 /* FileReader.cpp */; };
+		F4397EAE00E0B9F96C8B6C07 /* InfoLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17E13CCDA0C82F92EAB05BE6 /* InfoLabel.cpp */; };
+		F505DF3C2BA492B5A2F28D05 /* Butterworth.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B47B3368AA1A182B0CA1AB26 /* Butterworth.cpp */; };
+		FA2A052548AAD146F3F5AD83 /* juce_video.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4A7695E93CE32F4E95042FCB /* juce_video.mm */; };
+		FAE745870674A07A65690433 /* DataBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 788F8B7719B70465762B634B /* DataBuffer.cpp */; };
+		FCB767F14565886C9D823916 /* juce_events.mm in Sources */ = {isa = PBXBuildFile; fileRef = C29E664781AA2396C8D59543 /* juce_events.mm */; };
+		FD4865450F4C47FF3C6327FE /* QuickTime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 56169D835A3E3029D6E3904C /* QuickTime.framework */; };
+		FDCFDC9CC6D7A82131190FB0 /* ReferenceNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BBD9C2AED6F500D090069007 /* ReferenceNode.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0052A4FD257928E5D83927E6 /* juce_WavAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_WavAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		00A54510EFB9B0966D0B430C /* PulsePalOutputEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PulsePalOutputEditor.h; path = ../../Source/Processors/Editors/PulsePalOutputEditor.h; sourceTree = SOURCE_ROOT; };
+		01859D6E7D95E44BD8E17D91 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_cryptography/juce_module_info; sourceTree = SOURCE_ROOT; };
+		018F4E079EB12A78C4F8F773 /* juce_MidiBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiBuffer.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiBuffer.h; sourceTree = SOURCE_ROOT; };
+		01C313C323E5CB995C939E0B /* juce_Component.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Component.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Component.cpp; sourceTree = SOURCE_ROOT; };
+		01D791730840EB0BA7FD61BA /* juce_Socket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Socket.h; path = ../../JuceLibraryCode/modules/juce_core/network/juce_Socket.h; sourceTree = SOURCE_ROOT; };
+		020205BB77179A9BE3FFF1E1 /* juce_win32_QuickTimeMovieComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_QuickTimeMovieComponent.cpp; path = ../../JuceLibraryCode/modules/juce_video/native/juce_win32_QuickTimeMovieComponent.cpp; sourceTree = SOURCE_ROOT; };
+		0242AB5BCD8C002DC2E30BAC /* juce_MidiOutput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiOutput.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiOutput.h; sourceTree = SOURCE_ROOT; };
+		027C1143CC66EA8F73C39A74 /* juce_ThreadWithProgressWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ThreadWithProgressWindow.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ThreadWithProgressWindow.h; sourceTree = SOURCE_ROOT; };
+		0287B009511521BEAAE8A52C /* DataThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataThread.h; path = ../../Source/Processors/DataThreads/DataThread.h; sourceTree = SOURCE_ROOT; };
+		028D4D3C0862B4B1312E2395 /* SourceNodeEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SourceNodeEditor.h; path = ../../Source/Processors/Editors/SourceNodeEditor.h; sourceTree = SOURCE_ROOT; };
+		02DA588D3B873F1971ACD912 /* juce_FlacAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FlacAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		0316B49B86725305C70783CA /* juce_AudioPluginFormatManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioPluginFormatManager.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.cpp; sourceTree = SOURCE_ROOT; };
+		033AE5DE19F0EEDC47D41C80 /* juce_FileChooserDialogBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileChooserDialogBox.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooserDialogBox.cpp; sourceTree = SOURCE_ROOT; };
+		03D7B457E0915E43A6AFF4B4 /* juce_AudioUnitPluginFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioUnitPluginFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.h; sourceTree = SOURCE_ROOT; };
+		04C474E0F2F7FDEC714A673C /* juce_PathIterator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PathIterator.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathIterator.cpp; sourceTree = SOURCE_ROOT; };
+		04C6B933E1603B4D0916570D /* ImageIcon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ImageIcon.cpp; path = ../../Source/Processors/Editors/ImageIcon.cpp; sourceTree = SOURCE_ROOT; };
+		04ED2387517934A84ACF9865 /* juce_BubbleComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BubbleComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_BubbleComponent.cpp; sourceTree = SOURCE_ROOT; };
+		05997833A4AA137FD64348AD /* juce_TextDragAndDropTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextDragAndDropTarget.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_TextDragAndDropTarget.h; sourceTree = SOURCE_ROOT; };
+		05BD169B8574607A6F6AD3B6 /* juce_Identifier.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Identifier.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_Identifier.cpp; sourceTree = SOURCE_ROOT; };
+		05C35036E964AAD6024E0766 /* MergerA-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerA-01.png"; path = "../../Resources/Images/Buttons/MergerA-01.png"; sourceTree = SOURCE_ROOT; };
+		05DCAE8CA29532E2169D7AC1 /* juce_Matrix3D.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Matrix3D.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Matrix3D.h; sourceTree = SOURCE_ROOT; };
+		06072EC6BCD3B7D8C17C2402 /* juce_AudioProcessor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioProcessor.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp; sourceTree = SOURCE_ROOT; };
+		078625CF5C083AD538D23401 /* juce_AudioCDReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioCDReader.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_cd/juce_AudioCDReader.cpp; sourceTree = SOURCE_ROOT; };
+		0790CCE2FCFDFA6944DFC402 /* juce_PopupMenu.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PopupMenu.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_PopupMenu.cpp; sourceTree = SOURCE_ROOT; };
+		07BEF02C2B930DF7847C2921 /* SerialInputEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SerialInputEditor.cpp; path = ../../Source/Processors/Editors/SerialInputEditor.cpp; sourceTree = SOURCE_ROOT; };
+		07FD5E530E9E6BFB2ACA4B8C /* juce_audio_formats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_audio_formats.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/juce_audio_formats.h; sourceTree = SOURCE_ROOT; };
+		081E86FE0B991469CFA8D7EA /* juce_CPlusPlusCodeTokeniser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CPlusPlusCodeTokeniser.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CPlusPlusCodeTokeniser.cpp; sourceTree = SOURCE_ROOT; };
+		085F51FEE5C5FDAA321090A0 /* juce_CachedComponentImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CachedComponentImage.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_CachedComponentImage.h; sourceTree = SOURCE_ROOT; };
+		08618BD1F5343B5E6457237F /* SpikeDetectCanvas.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDetectCanvas.cpp; path = ../../Source/Processors/Visualization/SpikeDetectCanvas.cpp; sourceTree = SOURCE_ROOT; };
+		087FA26464FB283EC6FD4795 /* juce_NamedPipe.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_NamedPipe.cpp; path = ../../JuceLibraryCode/modules/juce_core/network/juce_NamedPipe.cpp; sourceTree = SOURCE_ROOT; };
+		08907A4BA0D5628476D19C48 /* juce_RelativePointPath.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RelativePointPath.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePointPath.cpp; sourceTree = SOURCE_ROOT; };
+		08A7A7FD7D77C0657270E9BF /* juce_DrawableText.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DrawableText.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableText.cpp; sourceTree = SOURCE_ROOT; };
+		08DAD5894A480950C66F5873 /* juce_ArrowButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ArrowButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ArrowButton.h; sourceTree = SOURCE_ROOT; };
+		09160DF53438B400BFE85E07 /* juce_InputSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_InputSource.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_InputSource.h; sourceTree = SOURCE_ROOT; };
+		0987F7E90136D0E08A606A22 /* SignalChainManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SignalChainManager.cpp; path = ../../Source/UI/SignalChainManager.cpp; sourceTree = SOURCE_ROOT; };
+		09A159213372995F3CCEB85B /* juce_String.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_String.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_String.h; sourceTree = SOURCE_ROOT; };
+		09BCBD414282A3AA4F66A3A5 /* Cascade.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Cascade.cpp; path = ../../Source/Dsp/Cascade.cpp; sourceTree = SOURCE_ROOT; };
+		0A2AD4AB14F93364EFB9611E /* miso-regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file.ttf; name = "miso-regular.ttf"; path = "../../Resources/Fonts/miso-regular.ttf"; sourceTree = SOURCE_ROOT; };
+		0A351ED88CF00C0697701E73 /* juce_Logger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Logger.h; path = ../../JuceLibraryCode/modules/juce_core/logging/juce_Logger.h; sourceTree = SOURCE_ROOT; };
+		0A413228C75C046CE683E0E6 /* juce_String.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_String.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_String.cpp; sourceTree = SOURCE_ROOT; };
+		0A42FFB89531588E51762D3E /* juce_android_Audio.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Audio.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_android_Audio.cpp; sourceTree = SOURCE_ROOT; };
+		0A46EF94E558D5E19F96E646 /* juce_Timer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Timer.cpp; path = ../../JuceLibraryCode/modules/juce_events/timers/juce_Timer.cpp; sourceTree = SOURCE_ROOT; };
+		0A8BC957DBEE226346C1EA25 /* juce_BigInteger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BigInteger.cpp; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_BigInteger.cpp; sourceTree = SOURCE_ROOT; };
+		0AA8F001A50408977E76ED96 /* juce_RecentlyOpenedFilesList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RecentlyOpenedFilesList.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_RecentlyOpenedFilesList.cpp; sourceTree = SOURCE_ROOT; };
+		0AAFE3F4D106138401C190C5 /* juce_GlowEffect.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GlowEffect.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/effects/juce_GlowEffect.cpp; sourceTree = SOURCE_ROOT; };
+		0B2502A656E77E00AF15A343 /* juce_ApplicationCommandInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ApplicationCommandInfo.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandInfo.h; sourceTree = SOURCE_ROOT; };
+		0B2B7732073D56E484950C8D /* RecordControlEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RecordControlEditor.h; path = ../../Source/Processors/Editors/RecordControlEditor.h; sourceTree = SOURCE_ROOT; };
+		0B382285EEDD8A3FDB45C074 /* juce_ThreadPool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ThreadPool.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ThreadPool.h; sourceTree = SOURCE_ROOT; };
+		0B5B63E563EFA7E816DE3DCA /* juce_OutputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OutputStream.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_OutputStream.h; sourceTree = SOURCE_ROOT; };
+		0BB4380EDFEAAE0DAB255B90 /* juce_BlowFish.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BlowFish.cpp; path = ../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_BlowFish.cpp; sourceTree = SOURCE_ROOT; };
+		0BCAC20DAB10B957168B85D6 /* juce_Result.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Result.h; path = ../../JuceLibraryCode/modules/juce_core/misc/juce_Result.h; sourceTree = SOURCE_ROOT; };
+		0BF3932F3EA1149C2F7E31F9 /* juce_IPAddress.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_IPAddress.cpp; path = ../../JuceLibraryCode/modules/juce_core/network/juce_IPAddress.cpp; sourceTree = SOURCE_ROOT; };
+		0C646E9950FB580B21E1F2BD /* juce_WindowsMediaAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_WindowsMediaAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WindowsMediaAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		0CCB1C4D687001E04DE1DD9C /* juce_SubregionStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_SubregionStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_SubregionStream.cpp; sourceTree = SOURCE_ROOT; };
+		0CCE619599DB39323E49FF3C /* ResamplingNodeEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ResamplingNodeEditor.h; path = ../../Source/Processors/Editors/ResamplingNodeEditor.h; sourceTree = SOURCE_ROOT; };
+		0D3C20D1F00B7B1381E6B987 /* juce_TabbedButtonBar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TabbedButtonBar.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedButtonBar.cpp; sourceTree = SOURCE_ROOT; };
+		0D884C2CF25F23CE6B99B2A1 /* juce_Singleton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Singleton.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_Singleton.h; sourceTree = SOURCE_ROOT; };
+		0D8ECE32F7D0FE74185F6EF4 /* juce_PropertyPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PropertyPanel.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyPanel.h; sourceTree = SOURCE_ROOT; };
+		0DBB88B6BEC06FCECE4CBD28 /* juce_ApplicationCommandInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ApplicationCommandInfo.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandInfo.cpp; sourceTree = SOURCE_ROOT; };
+		0DD0CBF9BBD4A503F2B7868D /* juce_ListenerList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ListenerList.h; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ListenerList.h; sourceTree = SOURCE_ROOT; };
+		0DE9D2FE41553B4D4316DD55 /* juce_DirectoryIterator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DirectoryIterator.cpp; path = ../../JuceLibraryCode/modules/juce_core/files/juce_DirectoryIterator.cpp; sourceTree = SOURCE_ROOT; };
+		0E4B0B8425DBA19B6F3FE4BF /* juce_UIViewComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_UIViewComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/embedding/juce_UIViewComponent.h; sourceTree = SOURCE_ROOT; };
+		0E98E81084F183B8426EDA7F /* juce_DynamicObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DynamicObject.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_DynamicObject.h; sourceTree = SOURCE_ROOT; };
+		0FA84E49DB493BCC886A355F /* juce_MD5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MD5.h; path = ../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_MD5.h; sourceTree = SOURCE_ROOT; };
+		0FDD7551AC98348D4A98ADC7 /* ProcessorGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ProcessorGraph.h; path = ../../Source/Processors/ProcessorGraph.h; sourceTree = SOURCE_ROOT; };
+		0FE8ACC50ED8E7FFC9E6B9B4 /* ControlPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ControlPanel.h; path = ../../Source/UI/ControlPanel.h; sourceTree = SOURCE_ROOT; };
+		105B1452DF6CE1D80D69A9D1 /* ProcessorList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ProcessorList.h; path = ../../Source/UI/ProcessorList.h; sourceTree = SOURCE_ROOT; };
+		106E81B939C6B35E34DD71FE /* juce_CodeEditorComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CodeEditorComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.h; sourceTree = SOURCE_ROOT; };
+		1086169B0EE86E04B64575C2 /* Dsp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Dsp.h; path = ../../Source/Dsp/Dsp.h; sourceTree = SOURCE_ROOT; };
+		108DF32ADFBA5CA48F928A92 /* juce_File.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_File.h; path = ../../JuceLibraryCode/modules/juce_core/files/juce_File.h; sourceTree = SOURCE_ROOT; };
+		10BE33089BA6F3468F36CD6C /* AudioEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioEditor.cpp; path = ../../Source/Processors/Editors/AudioEditor.cpp; sourceTree = SOURCE_ROOT; };
+		113404D3FDE3745DF1E8D014 /* juce_ReadWriteLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ReadWriteLock.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ReadWriteLock.h; sourceTree = SOURCE_ROOT; };
+		1191BF3048664183033BFF89 /* juce_DropShadowEffect.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DropShadowEffect.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/effects/juce_DropShadowEffect.cpp; sourceTree = SOURCE_ROOT; };
+		1194EE0956A9645270582979 /* juce_android_Messaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Messaging.cpp; path = ../../JuceLibraryCode/modules/juce_events/native/juce_android_Messaging.cpp; sourceTree = SOURCE_ROOT; };
+		11A5824E0239C86801BE2EB8 /* juce_MouseEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MouseEvent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseEvent.h; sourceTree = SOURCE_ROOT; };
+		11D619EEF63C1827EA91F593 /* juce_UndoManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_UndoManager.cpp; path = ../../JuceLibraryCode/modules/juce_data_structures/undomanager/juce_UndoManager.cpp; sourceTree = SOURCE_ROOT; };
+		1246C8A62803B7E115713705 /* juce_LocalisedStrings.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_LocalisedStrings.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_LocalisedStrings.cpp; sourceTree = SOURCE_ROOT; };
+		12B5243A9435FABAFBE20165 /* juce_Quaternion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Quaternion.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Quaternion.h; sourceTree = SOURCE_ROOT; };
+		12B5DDCB6E5ECD93A4C55BB5 /* LfpDisplayCanvas.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpDisplayCanvas.h; path = ../../Source/Processors/Visualization/LfpDisplayCanvas.h; sourceTree = SOURCE_ROOT; };
+		12BE9C084DEC40230DA8E9A6 /* ISCANeditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ISCANeditor.h; path = ../../Source/Processors/Editors/ISCANeditor.h; sourceTree = SOURCE_ROOT; };
+		1307DAE32BA702565A67D127 /* juce_MidiFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiFile.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiFile.cpp; sourceTree = SOURCE_ROOT; };
+		13212C01A5E138553FAFBE9C /* juce_Drawable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Drawable.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_Drawable.cpp; sourceTree = SOURCE_ROOT; };
+		13D9868B08E941F6827E157C /* juce_ResizableWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ResizableWindow.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ResizableWindow.h; sourceTree = SOURCE_ROOT; };
+		13D9DC48F19699485F9888A4 /* juce_PathIterator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PathIterator.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathIterator.h; sourceTree = SOURCE_ROOT; };
+		1463D2DAB3A1D8CEE825056A /* juce_AudioCDReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioCDReader.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_cd/juce_AudioCDReader.h; sourceTree = SOURCE_ROOT; };
+		146C6A6E3C6B17F2AF475B50 /* juce_OpenGLFrameBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLFrameBuffer.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLFrameBuffer.cpp; sourceTree = SOURCE_ROOT; };
+		14DD0220B41F74C01A9DC676 /* juce_GlyphArrangement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_GlyphArrangement.h; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_GlyphArrangement.h; sourceTree = SOURCE_ROOT; };
+		14F594C425F332F455A16D35 /* okFrontPanelDLL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = okFrontPanelDLL.h; path = "../../Source/Processors/DataThreads/rhythm-api/okFrontPanelDLL.h"; sourceTree = SOURCE_ROOT; };
+		14FE601229C9A40C6E182F28 /* juce_mac_MouseCursor.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_MouseCursor.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_MouseCursor.mm; sourceTree = SOURCE_ROOT; };
+		1518D2BA7FCAF267EF1F02E6 /* juce_win32_Windowing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Windowing.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_win32_Windowing.cpp; sourceTree = SOURCE_ROOT; };
+		154303EE3929F26B93792187 /* SourceNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SourceNode.h; path = ../../Source/Processors/SourceNode.h; sourceTree = SOURCE_ROOT; };
+		1552007C6C6AF750278C5BE5 /* RecordControlEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordControlEditor.cpp; path = ../../Source/Processors/Editors/RecordControlEditor.cpp; sourceTree = SOURCE_ROOT; };
+		15870472BA2B1779521A21BD /* ElectrodeButtons.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ElectrodeButtons.h; path = ../../Source/Processors/Editors/ElectrodeButtons.h; sourceTree = SOURCE_ROOT; };
+		159790C750B1F8B485DBB499 /* juce_win32_FileChooser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_FileChooser.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_win32_FileChooser.cpp; sourceTree = SOURCE_ROOT; };
+		161E095C716133CB255B6CCD /* juce_MidiKeyboardState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiKeyboardState.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiKeyboardState.h; sourceTree = SOURCE_ROOT; };
+		167524110873F9888CF1B9E8 /* juce_ApplicationCommandID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ApplicationCommandID.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandID.h; sourceTree = SOURCE_ROOT; };
+		168823A9EBD85BFBFD2CE2EE /* RadioButtons-03.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-03.png"; path = "../../Resources/Images/Icons/RadioButtons-03.png"; sourceTree = SOURCE_ROOT; };
+		169F1B20FC9FFE88C53D2735 /* FPGAOutputEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FPGAOutputEditor.cpp; path = ../../Source/Processors/Editors/FPGAOutputEditor.cpp; sourceTree = SOURCE_ROOT; };
+		1712916024EC787B6C231732 /* RadioButtons_selected_over-03.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-03.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-03.png"; sourceTree = SOURCE_ROOT; };
+		1718EC50691D8421EC00F8B3 /* FileReaderThread.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileReaderThread.cpp; path = ../../Source/Processors/DataThreads/FileReaderThread.cpp; sourceTree = SOURCE_ROOT; };
+		1719507D8A73EA71F1C3F306 /* cpmono-plain-serialized */ = {isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-plain-serialized"; path = "../../Resources/Fonts/cpmono-plain-serialized"; sourceTree = SOURCE_ROOT; };
+		172FA5C9EC4B16BC0C45F269 /* juce_Variant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Variant.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_Variant.h; sourceTree = SOURCE_ROOT; };
+		174842EA681FA29BE38A6272 /* juce_ButtonPropertyComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ButtonPropertyComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ButtonPropertyComponent.cpp; sourceTree = SOURCE_ROOT; };
+		1777330D3BDAE99A93F98943 /* juce_Font.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Font.h; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Font.h; sourceTree = SOURCE_ROOT; };
+		178AD28BF5BC92B58A3A3539 /* juce_MixerAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MixerAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_MixerAudioSource.h; sourceTree = SOURCE_ROOT; };
+		17B29FF3D3EA14EF2BE149BB /* juce_ComponentBoundsConstrainer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComponentBoundsConstrainer.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBoundsConstrainer.cpp; sourceTree = SOURCE_ROOT; };
+		17CACEC7EA0A4B55A06A0993 /* juce_MidiDataConcatenator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiDataConcatenator.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_MidiDataConcatenator.h; sourceTree = SOURCE_ROOT; };
+		17CE6B2913E72ED8727ECD56 /* AudioResamplingNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioResamplingNode.h; path = ../../Source/Processors/AudioResamplingNode.h; sourceTree = SOURCE_ROOT; };
+		17E13CCDA0C82F92EAB05BE6 /* InfoLabel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = InfoLabel.cpp; path = ../../Source/UI/InfoLabel.cpp; sourceTree = SOURCE_ROOT; };
+		17FB020EFEAED8493D3CB121 /* juce_ToolbarItemComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ToolbarItemComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemComponent.h; sourceTree = SOURCE_ROOT; };
+		1819C1C4DE5FEEDEA143E3D2 /* juce_mac_MainMenu.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_MainMenu.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_MainMenu.mm; sourceTree = SOURCE_ROOT; };
+		18A730DF335EEB3A4D13FDCA /* juce_MessageManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MessageManager.cpp; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_MessageManager.cpp; sourceTree = SOURCE_ROOT; };
+		18B410DA5435C02C82BA13F8 /* juce_BooleanPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BooleanPropertyComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_BooleanPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		18C2F9CA38393D106FB834E2 /* juce_AudioPluginFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioPluginFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormat.cpp; sourceTree = SOURCE_ROOT; };
+		18CFDBCD4A5B80E78DADCFEB /* juce_RectanglePlacement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RectanglePlacement.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/placement/juce_RectanglePlacement.cpp; sourceTree = SOURCE_ROOT; };
+		19043050D1DADAEAB48FB803 /* juce_AudioCDBurner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioCDBurner.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_cd/juce_AudioCDBurner.h; sourceTree = SOURCE_ROOT; };
+		19148DBA36B94FA639DF3A72 /* CustomLookAndFeel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CustomLookAndFeel.h; path = ../../Source/UI/CustomLookAndFeel.h; sourceTree = SOURCE_ROOT; };
+		193FED8339417E8E6264957A /* juce_ElementComparator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ElementComparator.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_ElementComparator.h; sourceTree = SOURCE_ROOT; };
+		1989E86F8DFDE34887AC0326 /* Bessel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Bessel.cpp; path = ../../Source/Dsp/Bessel.cpp; sourceTree = SOURCE_ROOT; };
+		19A8A8E1BF043B390E02C429 /* juce_linux_Messaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Messaging.cpp; path = ../../JuceLibraryCode/modules/juce_events/native/juce_linux_Messaging.cpp; sourceTree = SOURCE_ROOT; };
+		19AB6653E818B409554C5606 /* juce_ScopedValueSetter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ScopedValueSetter.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_ScopedValueSetter.h; sourceTree = SOURCE_ROOT; };
+		1A22BB28E65B6D6636CCEBF1 /* RadioButtons_selected_over-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-02.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-02.png"; sourceTree = SOURCE_ROOT; };
+		1AD76E8111A738A8F3717060 /* ArduinoOutputEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ArduinoOutputEditor.cpp; path = ../../Source/Processors/Editors/ArduinoOutputEditor.cpp; sourceTree = SOURCE_ROOT; };
+		1AEEC114AFAB6E81205FBCD1 /* juce_AttributedString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AttributedString.h; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_AttributedString.h; sourceTree = SOURCE_ROOT; };
+		1B27BF1CF3F235A55CD5107D /* juce_ResamplingAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ResamplingAudioSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ResamplingAudioSource.cpp; sourceTree = SOURCE_ROOT; };
+		1BF01252E3A30560525CE057 /* juce_win32_WebBrowserComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_WebBrowserComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_win32_WebBrowserComponent.cpp; sourceTree = SOURCE_ROOT; };
+		1C474C73937D98E9D3FFEEC0 /* juce_FilePreviewComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FilePreviewComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FilePreviewComponent.h; sourceTree = SOURCE_ROOT; };
+		1C639F4C139C8D7753AA9BB6 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_gui_extra/juce_module_info; sourceTree = SOURCE_ROOT; };
+		1C93ECD2B04F39923E66B529 /* ReferenceNodeEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ReferenceNodeEditor.h; path = ../../Source/Processors/Editors/ReferenceNodeEditor.h; sourceTree = SOURCE_ROOT; };
+		1CB0D7AC988EDEC838A1C546 /* juce_AudioSampleBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioSampleBuffer.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioSampleBuffer.h; sourceTree = SOURCE_ROOT; };
+		1CCC1D4213B17ABF6222EC82 /* juce_PropertiesFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PropertiesFile.cpp; path = ../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_PropertiesFile.cpp; sourceTree = SOURCE_ROOT; };
+		1CFA355CD6811C253C72BDDA /* juce_KeyPressMappingSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_KeyPressMappingSet.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_KeyPressMappingSet.h; sourceTree = SOURCE_ROOT; };
+		1D1ABA743E533A4B7A50DBB0 /* juce_ReverbAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ReverbAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ReverbAudioSource.h; sourceTree = SOURCE_ROOT; };
+		1D7578F927EC030203A11978 /* juce_CodeDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CodeDocument.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeDocument.cpp; sourceTree = SOURCE_ROOT; };
+		1D7FEC587CFE464A21830C4D /* juce_win32_SystemTrayIcon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_SystemTrayIcon.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_win32_SystemTrayIcon.cpp; sourceTree = SOURCE_ROOT; };
+		1DF5FD417930A62110DF0419 /* juce_ModalComponentManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ModalComponentManager.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ModalComponentManager.cpp; sourceTree = SOURCE_ROOT; };
+		1E9FE44F0CCC6604B5469412 /* juce_KeyMappingEditorComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_KeyMappingEditorComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_KeyMappingEditorComponent.cpp; sourceTree = SOURCE_ROOT; };
+		1EC95CD1D830F6D85ADB3B9D /* SpikeDisplayEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDisplayEditor.cpp; path = ../../Source/Processors/Editors/SpikeDisplayEditor.cpp; sourceTree = SOURCE_ROOT; };
+		1F12D1392E5DF34C3A3C445D /* juce_NewLine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_NewLine.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_NewLine.h; sourceTree = SOURCE_ROOT; };
+		205E9A5C31827555F1CAC30D /* juce_OpenGL_osx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGL_osx.h; path = ../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_osx.h; sourceTree = SOURCE_ROOT; };
+		208DCD7025D0DF2740C01E4A /* juce_TextPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextPropertyComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_TextPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		20EB4F22A76954F2986F364A /* juce_mac_Windowing.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_Windowing.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_Windowing.mm; sourceTree = SOURCE_ROOT; };
+		215B159836CE40810964B773 /* juce_Uuid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Uuid.h; path = ../../JuceLibraryCode/modules/juce_core/misc/juce_Uuid.h; sourceTree = SOURCE_ROOT; };
+		215E1BD79B5870D5356810F0 /* Visualizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Visualizer.h; path = ../../Source/Processors/Visualization/Visualizer.h; sourceTree = SOURCE_ROOT; };
+		217032322A2570ABAC47194C /* juce_Image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Image.h; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_Image.h; sourceTree = SOURCE_ROOT; };
+		2196ED9DD4262C60135E77F5 /* LfpTriggeredAverageEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpTriggeredAverageEditor.h; path = ../../Source/Processors/Editors/LfpTriggeredAverageEditor.h; sourceTree = SOURCE_ROOT; };
+		21A0260D2DB039B81DF4970C /* juce_FileSearchPath.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileSearchPath.cpp; path = ../../JuceLibraryCode/modules/juce_core/files/juce_FileSearchPath.cpp; sourceTree = SOURCE_ROOT; };
+		21C11A58CAA0F9E86AA204EC /* juce_Slider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Slider.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Slider.h; sourceTree = SOURCE_ROOT; };
+		21D3C1095D2B5A834D998B74 /* juce_android_OpenSL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_OpenSL.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_android_OpenSL.cpp; sourceTree = SOURCE_ROOT; };
+		222AC2E9BEFE12BE7FF88879 /* juce_Thread.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Thread.cpp; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_Thread.cpp; sourceTree = SOURCE_ROOT; };
+		22801F75289646F6A85E5583 /* Biquad.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Biquad.cpp; path = ../../Source/Dsp/Biquad.cpp; sourceTree = SOURCE_ROOT; };
+		229989EC8A6F145C81348CA9 /* PhaseDetector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PhaseDetector.h; path = ../../Source/Processors/PhaseDetector.h; sourceTree = SOURCE_ROOT; };
+		235A8987D99A191D07208D2F /* okFrontPanelDLL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = okFrontPanelDLL.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/okFrontPanelDLL.cpp"; sourceTree = SOURCE_ROOT; };
+		23609D430A25F54723269E91 /* juce_gui_basics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_gui_basics.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/juce_gui_basics.mm; sourceTree = SOURCE_ROOT; };
+		23A6BA852B71DAAF3F709428 /* RHD2000Thread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RHD2000Thread.h; path = ../../Source/Processors/DataThreads/RHD2000Thread.h; sourceTree = SOURCE_ROOT; };
+		23C7EA9C89CC98A5EFEC12FA /* juce_GZIPCompressorOutputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_GZIPCompressorOutputStream.h; path = ../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPCompressorOutputStream.h; sourceTree = SOURCE_ROOT; };
+		23D82A4C165DD596474F30E4 /* juce_ColourSelector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ColourSelector.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_ColourSelector.h; sourceTree = SOURCE_ROOT; };
+		23EAFAEA6457DB4E452F8715 /* SignalGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SignalGenerator.h; path = ../../Source/Processors/SignalGenerator.h; sourceTree = SOURCE_ROOT; };
+		23F048594D4C9AD8C3399877 /* juce_android_SystemStats.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_SystemStats.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_android_SystemStats.cpp; sourceTree = SOURCE_ROOT; };
+		243817BA562AD7FA76C834C9 /* CoreMIDI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMIDI.framework; path = System/Library/Frameworks/CoreMIDI.framework; sourceTree = SDKROOT; };
+		24D86195580EFB86AC084DCC /* cpmono_extra_light.otf */ = {isa = PBXFileReference; lastKnownFileType = file.otf; name = cpmono_extra_light.otf; path = ../../Resources/Fonts/cpmono_extra_light.otf; sourceTree = SOURCE_ROOT; };
+		25433DB6D2EAEBB307EFB960 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_graphics/juce_module_info; sourceTree = SOURCE_ROOT; };
+		256E22D98B16B09BD521C4A4 /* juce_AudioProcessorEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioProcessorEditor.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h; sourceTree = SOURCE_ROOT; };
+		258938780F93A7CF41366F26 /* RecordControl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordControl.cpp; path = ../../Source/Processors/Utilities/RecordControl.cpp; sourceTree = SOURCE_ROOT; };
+		25A9484825F1B93ABC0E577F /* PulsePalOutputEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PulsePalOutputEditor.cpp; path = ../../Source/Processors/Editors/PulsePalOutputEditor.cpp; sourceTree = SOURCE_ROOT; };
+		25ABEB43042E98C668A16432 /* SpikeDisplayEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDisplayEditor.h; path = ../../Source/Processors/Editors/SpikeDisplayEditor.h; sourceTree = SOURCE_ROOT; };
+		25DCA4D0E86DFB51AF637D21 /* juce_win32_Midi.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Midi.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_Midi.cpp; sourceTree = SOURCE_ROOT; };
+		25F7BEADC001FA3D1EA9B32C /* juce_DrawablePath.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DrawablePath.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawablePath.cpp; sourceTree = SOURCE_ROOT; };
+		261B5AA82F2A86CC5500D8D2 /* ArduinoIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = ArduinoIcon.png; path = ../../Resources/Images/Icons/ArduinoIcon.png; sourceTree = SOURCE_ROOT; };
+		265EDA19C88E74249FD66609 /* SignalGeneratorEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SignalGeneratorEditor.h; path = ../../Source/Processors/Editors/SignalGeneratorEditor.h; sourceTree = SOURCE_ROOT; };
+		266FC6DA3123E576811DD828 /* juce_FlacAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FlacAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		26FF78F12CCB8725C0DAF9C2 /* juce_MidiInput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiInput.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiInput.h; sourceTree = SOURCE_ROOT; };
+		27313EA12BC45638321922CA /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		27548017AB2ABAF17E1D5DF5 /* juce_FileInputSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileInputSource.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_FileInputSource.h; sourceTree = SOURCE_ROOT; };
+		27DC0E650D6D54DF29E6DB68 /* juce_gui_extra.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_gui_extra.mm; path = ../../JuceLibraryCode/modules/juce_gui_extra/juce_gui_extra.mm; sourceTree = SOURCE_ROOT; };
+		2847E92BB432EEB9D5A59260 /* juce_StringArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_StringArray.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_StringArray.h; sourceTree = SOURCE_ROOT; };
+		284F3E94F0C96EA1DD89E606 /* juce_FileFilter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileFilter.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileFilter.cpp; sourceTree = SOURCE_ROOT; };
+		28847C807E6B05303FB8FB34 /* juce_mac_Strings.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_Strings.mm; path = ../../JuceLibraryCode/modules/juce_core/native/juce_mac_Strings.mm; sourceTree = SOURCE_ROOT; };
+		28CCF04CCC028BAE0AEE5840 /* ElectrodeButtons.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ElectrodeButtons.cpp; path = ../../Source/Processors/Editors/ElectrodeButtons.cpp; sourceTree = SOURCE_ROOT; };
+		28D5AEEEFC4FA8877419C829 /* juce_posix_NamedPipe.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_posix_NamedPipe.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_posix_NamedPipe.cpp; sourceTree = SOURCE_ROOT; };
+		2924B990E35D3B51AA245978 /* juce_MessageListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MessageListener.h; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_MessageListener.h; sourceTree = SOURCE_ROOT; };
+		29381F22B8FDF48C3EAC3A9F /* juce_OpenGLPixelFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLPixelFormat.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLPixelFormat.cpp; sourceTree = SOURCE_ROOT; };
+		29D7893C278FFE00782637B6 /* Bessel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Bessel.h; path = ../../Source/Dsp/Bessel.h; sourceTree = SOURCE_ROOT; };
+		29FD7B383C5DDACAA7B8DFD3 /* MergerEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MergerEditor.cpp; path = ../../Source/Processors/Editors/MergerEditor.cpp; sourceTree = SOURCE_ROOT; };
+		2A3230DEAAC86A9090950703 /* juce_Path.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Path.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Path.cpp; sourceTree = SOURCE_ROOT; };
+		2AB1CC4252DB09507ED31482 /* juce_Application.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Application.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/application/juce_Application.cpp; sourceTree = SOURCE_ROOT; };
+		2AE12F85965B8BE4A0E12F67 /* juce_PropertiesFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PropertiesFile.h; path = ../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_PropertiesFile.h; sourceTree = SOURCE_ROOT; };
+		2B134713E91426120A994CB7 /* juce_Random.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Random.cpp; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_Random.cpp; sourceTree = SOURCE_ROOT; };
+		2B19F2DE42A91F56C2380F9A /* juce_Expression.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Expression.cpp; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_Expression.cpp; sourceTree = SOURCE_ROOT; };
+		2B93450006102A0093F5EACB /* Design.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Design.cpp; path = ../../Source/Dsp/Design.cpp; sourceTree = SOURCE_ROOT; };
+		2BC005B37A0FB3179C2F3AC7 /* juce_CoreAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CoreAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		2C4730CAFED4F6292B575318 /* Splitter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Splitter.cpp; path = ../../Source/Processors/Utilities/Splitter.cpp; sourceTree = SOURCE_ROOT; };
+		2C89EC72FF6A7118EF459DC3 /* Main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Main.cpp; path = ../../Source/Main.cpp; sourceTree = SOURCE_ROOT; };
+		2D1BF69121265C83C7937EB6 /* juce_AudioIODevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioIODevice.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h; sourceTree = SOURCE_ROOT; };
+		2D20F49E12A7D313049E0258 /* juce_ScopedWriteLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ScopedWriteLock.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ScopedWriteLock.h; sourceTree = SOURCE_ROOT; };
+		2D27078AC6729A4B47C48099 /* AdvancerEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AdvancerEditor.h; path = ../../Source/Processors/Editors/AdvancerEditor.h; sourceTree = SOURCE_ROOT; };
+		2D2BAC4320470CF68743F58E /* rhd2000evalboard.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rhd2000evalboard.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000evalboard.cpp"; sourceTree = SOURCE_ROOT; };
+		2D41C43686CDE35E86A389D7 /* WiFiOutput.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WiFiOutput.cpp; path = ../../Source/Processors/WiFiOutput.cpp; sourceTree = SOURCE_ROOT; };
+		2D577016FEEE23DD5703C924 /* juce_DialogWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DialogWindow.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DialogWindow.cpp; sourceTree = SOURCE_ROOT; };
+		2DA0032B6DF10345C4842BF5 /* juce_CharacterFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CharacterFunctions.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_CharacterFunctions.h; sourceTree = SOURCE_ROOT; };
+		2F2EDBE0623561191234AF21 /* juce_LAMEEncoderAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_LAMEEncoderAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_LAMEEncoderAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		2F8252D3FF527D6559B12615 /* juce_LowLevelGraphicsSoftwareRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_LowLevelGraphicsSoftwareRenderer.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsSoftwareRenderer.cpp; sourceTree = SOURCE_ROOT; };
+		2F9BB379BCFCFE0D88CC0408 /* juce_AudioProcessorGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioProcessorGraph.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h; sourceTree = SOURCE_ROOT; };
+		2FE6DAFB634FF3C20F1D6FD7 /* juce_CaretComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CaretComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_CaretComponent.h; sourceTree = SOURCE_ROOT; };
+		2FF422D0633A28558D0227EC /* juce_ComponentBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComponentBuilder.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBuilder.h; sourceTree = SOURCE_ROOT; };
+		301783FC4E3B19CA3C0AC85B /* juce_LowLevelGraphicsSoftwareRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LowLevelGraphicsSoftwareRenderer.h; path = ../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsSoftwareRenderer.h; sourceTree = SOURCE_ROOT; };
+		3063CF211ABB734A9FD452EC /* Custom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Custom.h; path = ../../Source/Dsp/Custom.h; sourceTree = SOURCE_ROOT; };
+		3067867C8C0F6CF6F086A6FC /* FileReaderEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileReaderEditor.h; path = ../../Source/Processors/Editors/FileReaderEditor.h; sourceTree = SOURCE_ROOT; };
+		308F614D30DCB9AE3767C928 /* ofSerial.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ofSerial.cpp; path = ../../Source/Processors/Serial/ofSerial.cpp; sourceTree = SOURCE_ROOT; };
+		313970BBDAAA4EDC8B322F3A /* juce_ComponentMovementWatcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComponentMovementWatcher.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentMovementWatcher.cpp; sourceTree = SOURCE_ROOT; };
+		314955FB1E6DD74C71EB8907 /* juce_AudioFormatReaderSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioFormatReaderSource.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReaderSource.h; sourceTree = SOURCE_ROOT; };
+		316FB94579DA666A388F429A /* juce_WildcardFileFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_WildcardFileFilter.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_WildcardFileFilter.h; sourceTree = SOURCE_ROOT; };
+		31A3925602D128195100B74D /* juce_ApplicationProperties.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ApplicationProperties.cpp; path = ../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_ApplicationProperties.cpp; sourceTree = SOURCE_ROOT; };
+		31BE5E435604D33173940048 /* juce_ToggleButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ToggleButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToggleButton.cpp; sourceTree = SOURCE_ROOT; };
+		31FDA03EF1B527B336FA6263 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_events/juce_module_info; sourceTree = SOURCE_ROOT; };
+		32976762B1DB850DB65B9504 /* juce_FileInputSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileInputSource.cpp; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_FileInputSource.cpp; sourceTree = SOURCE_ROOT; };
+		32A1325430309CF4114C9618 /* juce_GenericAudioProcessorEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GenericAudioProcessorEditor.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp; sourceTree = SOURCE_ROOT; };
+		32B658D7A44849A6F640AF37 /* miso-bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file.ttf; name = "miso-bold.ttf"; path = "../../Resources/Fonts/miso-bold.ttf"; sourceTree = SOURCE_ROOT; };
+		32CEF6C84CD06B18035B035C /* RadioButtons_selected-05.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-05.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-05.png"; sourceTree = SOURCE_ROOT; };
+		32D568631762765C07D4BF0D /* juce_NSViewComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_NSViewComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/embedding/juce_NSViewComponent.h; sourceTree = SOURCE_ROOT; };
+		33A69BDDCFCD4A4DC14A9961 /* juce_KeyPress.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_KeyPress.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyPress.cpp; sourceTree = SOURCE_ROOT; };
+		33EC8C48E03E5FB60DD9D4C5 /* NetworkSinkProcotol.pb.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkSinkProcotol.pb.cc; path = ../../Source/Processors/NetworkSinkProcotol.pb.cc; sourceTree = SOURCE_ROOT; };
+		349C9FCEDC32E73DCB7AE806 /* juce_WindowsRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_WindowsRegistry.h; path = ../../JuceLibraryCode/modules/juce_core/misc/juce_WindowsRegistry.h; sourceTree = SOURCE_ROOT; };
+		353937A4E68C8C6916C6D1F9 /* juce_FileBrowserComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileBrowserComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.cpp; sourceTree = SOURCE_ROOT; };
+		35AEAE0CC0B546625E163B9B /* sine_wave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = sine_wave.png; path = ../../Resources/Images/Icons/sine_wave.png; sourceTree = SOURCE_ROOT; };
+		35C0963BAB9A82F12CDC9F76 /* juce_NamedValueSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_NamedValueSet.cpp; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_NamedValueSet.cpp; sourceTree = SOURCE_ROOT; };
+		361D8C54B3E54766CBC48046 /* Biquad.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Biquad.h; path = ../../Source/Dsp/Biquad.h; sourceTree = SOURCE_ROOT; };
+		361E3A46C9BFAD1530593487 /* juce_PopupMenu.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PopupMenu.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_PopupMenu.h; sourceTree = SOURCE_ROOT; };
+		3663C981D28BF165C1B601A7 /* juce_OptionalScopedPointer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OptionalScopedPointer.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_OptionalScopedPointer.h; sourceTree = SOURCE_ROOT; };
+		36A9736F04AAA2F8E9D711BB /* juce_SpinLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SpinLock.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_SpinLock.h; sourceTree = SOURCE_ROOT; };
+		3753B3B311AE0A9F4CC5AD40 /* ofArduino.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ofArduino.cpp; path = ../../Source/Processors/Serial/ofArduino.cpp; sourceTree = SOURCE_ROOT; };
+		3774BBCA6CB133D9A854CF71 /* CustomLookAndFeel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CustomLookAndFeel.cpp; path = ../../Source/UI/CustomLookAndFeel.cpp; sourceTree = SOURCE_ROOT; };
+		381F5DC605AE69088004DF80 /* PipelineB-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineB-01.png"; path = "../../Resources/Images/Buttons/PipelineB-01.png"; sourceTree = SOURCE_ROOT; };
+		38313692308D501E4CADF1D5 /* Layout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Layout.h; path = ../../Source/Dsp/Layout.h; sourceTree = SOURCE_ROOT; };
+		38711221C089A16CC29E93D2 /* juce_ActionListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ActionListener.h; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ActionListener.h; sourceTree = SOURCE_ROOT; };
+		38A9627672C2562DBE257A05 /* cpmono-extralight-serialized */ = {isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-extralight-serialized"; path = "../../Resources/Fonts/cpmono-extralight-serialized"; sourceTree = SOURCE_ROOT; };
+		38B5A37F33AE3FB2014BF095 /* juce_StringArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_StringArray.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_StringArray.cpp; sourceTree = SOURCE_ROOT; };
+		38E493BFC36AC80B1CDAAF35 /* juce_TreeView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TreeView.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TreeView.h; sourceTree = SOURCE_ROOT; };
+		390856DF83DAC70909D5B397 /* juce_Button.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Button.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_Button.h; sourceTree = SOURCE_ROOT; };
+		390EA3109658E8C51EFC8F61 /* juce_PluginDirectoryScanner.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PluginDirectoryScanner.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginDirectoryScanner.cpp; sourceTree = SOURCE_ROOT; };
+		392408C1943AC6234BAAC743 /* Elliptic.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Elliptic.cpp; path = ../../Source/Dsp/Elliptic.cpp; sourceTree = SOURCE_ROOT; };
+		393801D2B91773D376D874B0 /* juce_ImageButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ImageButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ImageButton.h; sourceTree = SOURCE_ROOT; };
+		39422C7D01635DD9C00B5136 /* juce_mac_CoreMidi.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_mac_CoreMidi.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_CoreMidi.cpp; sourceTree = SOURCE_ROOT; };
+		39464D2A22940DA2DDCCCFC6 /* EventDetector.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EventDetector.cpp; path = ../../Source/Processors/EventDetector.cpp; sourceTree = SOURCE_ROOT; };
+		39D2C460FE587C5F564495A0 /* SerialInputEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SerialInputEditor.h; path = ../../Source/Processors/Editors/SerialInputEditor.h; sourceTree = SOURCE_ROOT; };
+		39F287BE4C0B4F3BD4A949FD /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		3A2C762575D9728B1F822ED3 /* juce_AsyncUpdater.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AsyncUpdater.cpp; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_AsyncUpdater.cpp; sourceTree = SOURCE_ROOT; };
+		3A6E9EC3DA618EBA06B9DEEB /* juce_AudioSubsectionReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioSubsectionReader.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioSubsectionReader.h; sourceTree = SOURCE_ROOT; };
+		3A6FE617A781EEFFD39E1216 /* RadioButtons_neutral-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-02.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-02.png"; sourceTree = SOURCE_ROOT; };
+		3A71F2C959CA7DD3C33DC411 /* juce_mac_CarbonViewWrapperComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_mac_CarbonViewWrapperComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_CarbonViewWrapperComponent.h; sourceTree = SOURCE_ROOT; };
+		3A9826A8C3B668BCC760BEB7 /* juce_gui_basics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_gui_basics.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/juce_gui_basics.h; sourceTree = SOURCE_ROOT; };
+		3AC9B61C10692BBA96D2F775 /* juce_OpenGL_android.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGL_android.h; path = ../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_android.h; sourceTree = SOURCE_ROOT; };
+		3AE038CACE48AF85C4FB1ED5 /* GenericProcessor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = GenericProcessor.cpp; path = ../../Source/Processors/GenericProcessor.cpp; sourceTree = SOURCE_ROOT; };
+		3AFF1BE2EC512169120121CF /* juce_IPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_IPAddress.h; path = ../../JuceLibraryCode/modules/juce_core/network/juce_IPAddress.h; sourceTree = SOURCE_ROOT; };
+		3B307527FC3241258EA68519 /* juce_ToneGeneratorAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ToneGeneratorAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ToneGeneratorAudioSource.h; sourceTree = SOURCE_ROOT; };
+		3BC3A723444252E177C1B1BD /* juce_AudioFormatWriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioFormatWriter.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatWriter.h; sourceTree = SOURCE_ROOT; };
+		3BEB59C6E8F833331C0783D5 /* juce_IIRFilter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_IIRFilter.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_IIRFilter.cpp; sourceTree = SOURCE_ROOT; };
+		3C18EC09535EA506FC0CBC62 /* juce_OpenGL_ios.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGL_ios.h; path = ../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_ios.h; sourceTree = SOURCE_ROOT; };
+		3C1E0B87DA3E9AC60D2894F7 /* juce_TableListBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TableListBox.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableListBox.h; sourceTree = SOURCE_ROOT; };
+		3C92F249799E7CBF41FABEA0 /* juce_mac_WebBrowserComponent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_WebBrowserComponent.mm; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_WebBrowserComponent.mm; sourceTree = SOURCE_ROOT; };
+		3D100F6FDB04756402F3BCC9 /* juce_mac_CoreGraphicsContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_mac_CoreGraphicsContext.h; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsContext.h; sourceTree = SOURCE_ROOT; };
+		3DA70F9AAA904543B519874B /* juce_AudioPluginInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioPluginInstance.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioPluginInstance.h; sourceTree = SOURCE_ROOT; };
+		3E0942A2D72F50FDE27C14AE /* juce_StretchableObjectResizer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_StretchableObjectResizer.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableObjectResizer.cpp; sourceTree = SOURCE_ROOT; };
+		3E22E947444B5849011B6C4E /* juce_MouseInputSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MouseInputSource.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseInputSource.cpp; sourceTree = SOURCE_ROOT; };
+		3E5E427D405905C53A37283D /* juce_SystemAudioVolume.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SystemAudioVolume.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_SystemAudioVolume.h; sourceTree = SOURCE_ROOT; };
+		3EAE25787DBFBA8EFC42A277 /* RecordNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RecordNode.h; path = ../../Source/Processors/RecordNode.h; sourceTree = SOURCE_ROOT; };
+		3EAF57CE45DBACE2F88DA4C5 /* juce_FileChooser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileChooser.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooser.cpp; sourceTree = SOURCE_ROOT; };
+		3EE92345839A4E5F608D82AC /* juce_Sampler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Sampler.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/sampler/juce_Sampler.h; sourceTree = SOURCE_ROOT; };
+		3F3F8C49FB5AB1B91221845E /* NetworkEvents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkEvents.h; path = ../../Source/Processors/NetworkEvents.h; sourceTree = SOURCE_ROOT; };
+		3F45F344950087E1266A6445 /* OscilloscopeEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = OscilloscopeEditor.cpp; path = ../../Source/Processors/Editors/OscilloscopeEditor.cpp; sourceTree = SOURCE_ROOT; };
+		3F56A025C4D83EBDB66E3676 /* juce_AppleRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AppleRemote.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_AppleRemote.h; sourceTree = SOURCE_ROOT; };
+		3F69480D6145C77992FA59BA /* RootFinder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RootFinder.cpp; path = ../../Source/Dsp/RootFinder.cpp; sourceTree = SOURCE_ROOT; };
+		3F6C67E29CDEDF2EF61C054F /* Param.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Param.cpp; path = ../../Source/Dsp/Param.cpp; sourceTree = SOURCE_ROOT; };
+		3F8DFB0DB8B82F0C2CFBCA05 /* juce_BufferingAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BufferingAudioSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_BufferingAudioSource.cpp; sourceTree = SOURCE_ROOT; };
+		3FA24B406E4A9F9F54421C6A /* juce_ChannelRemappingAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ChannelRemappingAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ChannelRemappingAudioSource.h; sourceTree = SOURCE_ROOT; };
+		3FB80C5CFD953986778DCBA2 /* juce_linux_Files.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Files.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_linux_Files.cpp; sourceTree = SOURCE_ROOT; };
+		3FC794735FA8DDA39A62224B /* UIComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UIComponent.h; path = ../../Source/UI/UIComponent.h; sourceTree = SOURCE_ROOT; };
+		3FFC2A3429D8B1D957D18CA7 /* MergerB-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerB-02.png"; path = "../../Resources/Images/Buttons/MergerB-02.png"; sourceTree = SOURCE_ROOT; };
+		3FFD5E5D5C1D8B48DBBB9D18 /* juce_Result.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Result.cpp; path = ../../JuceLibraryCode/modules/juce_core/misc/juce_Result.cpp; sourceTree = SOURCE_ROOT; };
+		402BC572EE3E8EC418946CE0 /* juce_AudioTransportSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioTransportSource.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioTransportSource.h; sourceTree = SOURCE_ROOT; };
+		405298E6CE1C80EC7CC43A87 /* juce_FileTreeComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileTreeComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileTreeComponent.h; sourceTree = SOURCE_ROOT; };
+		40C22F3CD61DDB9C7B3DCCA6 /* juce_KeyListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_KeyListener.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyListener.h; sourceTree = SOURCE_ROOT; };
+		4133FE7830C52BBA035D82B8 /* juce_TimeSliceThread.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TimeSliceThread.cpp; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_TimeSliceThread.cpp; sourceTree = SOURCE_ROOT; };
+		414D8E6E4EE98E66C2583A50 /* juce_TextPropertyComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TextPropertyComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_TextPropertyComponent.cpp; sourceTree = SOURCE_ROOT; };
+		416B99B14B44CB16B725C4B2 /* juce_StretchableObjectResizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_StretchableObjectResizer.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableObjectResizer.h; sourceTree = SOURCE_ROOT; };
+		4179FCF100DC52282D0F9753 /* juce_JSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_JSON.h; path = ../../JuceLibraryCode/modules/juce_core/json/juce_JSON.h; sourceTree = SOURCE_ROOT; };
+		41AF61914A96159E9EA194B0 /* juce_linux_Clipboard.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Clipboard.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_linux_Clipboard.cpp; sourceTree = SOURCE_ROOT; };
+		420843E39C285B620B220C1D /* juce_LeakedObjectDetector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LeakedObjectDetector.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_LeakedObjectDetector.h; sourceTree = SOURCE_ROOT; };
+		420B0E95F1300ABFDC125DBF /* AccessClass.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AccessClass.cpp; path = ../../Source/AccessClass.cpp; sourceTree = SOURCE_ROOT; };
+		42BF0530EADF336E58D39CD3 /* juce_FloatVectorOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FloatVectorOperations.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.h; sourceTree = SOURCE_ROOT; };
+		42C88F6EE487194784FD1D6F /* AdvancerEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AdvancerEditor.cpp; path = ../../Source/Processors/Editors/AdvancerEditor.cpp; sourceTree = SOURCE_ROOT; };
+		43420911407CC35CE2A02B38 /* juce_StretchableLayoutManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_StretchableLayoutManager.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutManager.cpp; sourceTree = SOURCE_ROOT; };
+		434E153E6C8337C1E4A2709A /* juce_ButtonPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ButtonPropertyComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ButtonPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		4434939E139A45962C8CFB4C /* juce_DrawableShape.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DrawableShape.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableShape.cpp; sourceTree = SOURCE_ROOT; };
+		44E04E5F584A8BFAD062A09D /* juce_ShapeButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ShapeButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ShapeButton.h; sourceTree = SOURCE_ROOT; };
+		45258533F9F65AC96D3080B3 /* juce_MultiTouchMapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MultiTouchMapper.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_MultiTouchMapper.h; sourceTree = SOURCE_ROOT; };
+		4540694F9744C9F4D29149CE /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_opengl/juce_module_info; sourceTree = SOURCE_ROOT; };
+		455FFBB0C34B760D892D2D57 /* juce_OpenGLPixelFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLPixelFormat.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLPixelFormat.h; sourceTree = SOURCE_ROOT; };
+		45883809F1335E6C745F8155 /* juce_ModalComponentManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ModalComponentManager.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ModalComponentManager.h; sourceTree = SOURCE_ROOT; };
+		458A112D564ED066211FD482 /* juce_ToneGeneratorAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ToneGeneratorAudioSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ToneGeneratorAudioSource.cpp; sourceTree = SOURCE_ROOT; };
+		45A66E543B62A2C32AB3BA23 /* juce_AudioDeviceSelectorComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioDeviceSelectorComponent.h; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioDeviceSelectorComponent.h; sourceTree = SOURCE_ROOT; };
+		45C7B3A0676BC07190A2338B /* SpikeDetectCanvas.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDetectCanvas.h; path = ../../Source/Processors/Visualization/SpikeDetectCanvas.h; sourceTree = SOURCE_ROOT; };
+		45D440B69BDB210B17CD424B /* juce_ImageComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ImageComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ImageComponent.h; sourceTree = SOURCE_ROOT; };
+		45D78C8EF660EECE64BAA33F /* RHD2000Editor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RHD2000Editor.cpp; path = ../../Source/Processors/Editors/RHD2000Editor.cpp; sourceTree = SOURCE_ROOT; };
+		4608E765A643BC0CB2C1BB02 /* juce_CriticalSection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CriticalSection.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_CriticalSection.h; sourceTree = SOURCE_ROOT; };
+		463A302B39C7815EB981CEBD /* juce_Point.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Point.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Point.h; sourceTree = SOURCE_ROOT; };
+		4650B5724FE3C0608FB07A04 /* juce_TextLayout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TextLayout.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_TextLayout.cpp; sourceTree = SOURCE_ROOT; };
+		46E3A634686BFEF787229582 /* ParameterEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ParameterEditor.cpp; path = ../../Source/Processors/Editors/ParameterEditor.cpp; sourceTree = SOURCE_ROOT; };
+		46EF49B14DF7357A8287D9D8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
+		47041E3794FA20F67F39AE63 /* juce_ChildProcess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ChildProcess.cpp; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ChildProcess.cpp; sourceTree = SOURCE_ROOT; };
+		475824F60D47C28C392954A7 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_audio_processors/juce_module_info; sourceTree = SOURCE_ROOT; };
+		47976F6BE2942EED64AEA4D2 /* RadioButtons_selected_over-04.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-04.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-04.png"; sourceTree = SOURCE_ROOT; };
+		47A3942AC30A3212C01F1CAF /* DataViewport.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataViewport.cpp; path = ../../Source/UI/DataViewport.cpp; sourceTree = SOURCE_ROOT; };
+		47BDFDD28759B342B1C50BC0 /* juce_AbstractFifo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AbstractFifo.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_AbstractFifo.h; sourceTree = SOURCE_ROOT; };
+		47EE021D6C891095140ED7A9 /* juce_ios_UIViewComponentPeer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_ios_UIViewComponentPeer.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm; sourceTree = SOURCE_ROOT; };
+		482A60A44EE6CB84FCB9DC88 /* juce_AudioThumbnailBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioThumbnailBase.h; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnailBase.h; sourceTree = SOURCE_ROOT; };
+		483ABD5C1CF789943AB4AFB6 /* juce_ComponentPeer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComponentPeer.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ComponentPeer.h; sourceTree = SOURCE_ROOT; };
+		4867923F31CC3EDC9B1A5BE5 /* Merger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Merger.cpp; path = ../../Source/Processors/Utilities/Merger.cpp; sourceTree = SOURCE_ROOT; };
+		488D1B00C9E5FE4DAB035EDF /* juce_cryptography.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_cryptography.mm; path = ../../JuceLibraryCode/modules/juce_cryptography/juce_cryptography.mm; sourceTree = SOURCE_ROOT; };
+		48E12736F471C43C959AD15C /* PulsePal.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PulsePal.cpp; path = ../../Source/Processors/Serial/PulsePal.cpp; sourceTree = SOURCE_ROOT; };
+		48E4FA55FD4440AF44EEA437 /* juce_linux_FileChooser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_FileChooser.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_linux_FileChooser.cpp; sourceTree = SOURCE_ROOT; };
+		48F6281AB92B232E5187D00C /* SignalChainManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SignalChainManager.h; path = ../../Source/UI/SignalChainManager.h; sourceTree = SOURCE_ROOT; };
+		4939A8B8300394AAD0926C0B /* Legendre.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Legendre.h; path = ../../Source/Dsp/Legendre.h; sourceTree = SOURCE_ROOT; };
+		496180D5D96088CBB59035B1 /* juce_DrawableShape.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DrawableShape.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableShape.h; sourceTree = SOURCE_ROOT; };
+		4978EF4C5F506F3289BC0D99 /* juce_SubregionStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SubregionStream.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_SubregionStream.h; sourceTree = SOURCE_ROOT; };
+		499A12199A8A8C5AEDAA47E4 /* juce_FilenameComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FilenameComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FilenameComponent.h; sourceTree = SOURCE_ROOT; };
+		49D837FD08100AF0DB797DB4 /* juce_SparseSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SparseSet.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_SparseSet.h; sourceTree = SOURCE_ROOT; };
+		49FA151B1837E543D18858EB /* FilterEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FilterEditor.h; path = ../../Source/Processors/Editors/FilterEditor.h; sourceTree = SOURCE_ROOT; };
+		4A28A492852AEFBF508C1FC1 /* juce_RelativePointPath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RelativePointPath.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePointPath.h; sourceTree = SOURCE_ROOT; };
+		4A7695E93CE32F4E95042FCB /* juce_video.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_video.mm; path = ../../JuceLibraryCode/modules/juce_video/juce_video.mm; sourceTree = SOURCE_ROOT; };
+		4A94E809624F99387E600399 /* LfpDisplayCanvas.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpDisplayCanvas.cpp; path = ../../Source/Processors/Visualization/LfpDisplayCanvas.cpp; sourceTree = SOURCE_ROOT; };
+		4AD95B75DC581E32650FEDF6 /* juce_IIRFilterAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_IIRFilterAudioSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_IIRFilterAudioSource.cpp; sourceTree = SOURCE_ROOT; };
+		4AE1520FF569371665090B39 /* juce_AiffAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AiffAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		4AE36D25675E32A897F97BFA /* juce_TabbedComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TabbedComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedComponent.cpp; sourceTree = SOURCE_ROOT; };
+		4AF8FD4C7E567639A190D943 /* NotchFilterEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NotchFilterEditor.h; path = ../../Source/Processors/Editors/NotchFilterEditor.h; sourceTree = SOURCE_ROOT; };
+		4B0097003751A59A11FA8C5B /* FileReaderEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileReaderEditor.cpp; path = ../../Source/Processors/Editors/FileReaderEditor.cpp; sourceTree = SOURCE_ROOT; };
+		4B3DBFE485F45E62C53A90B8 /* juce_MenuBarModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MenuBarModel.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarModel.h; sourceTree = SOURCE_ROOT; };
+		4B5998D72503BD73D28E828A /* juce_osx_MessageQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_osx_MessageQueue.h; path = ../../JuceLibraryCode/modules/juce_events/native/juce_osx_MessageQueue.h; sourceTree = SOURCE_ROOT; };
+		4B74A7F0FDCE3E1706E5B320 /* juce_ApplicationCommandTarget.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ApplicationCommandTarget.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandTarget.cpp; sourceTree = SOURCE_ROOT; };
+		4BB38A2CD55BF23C7C3E3387 /* juce_ToolbarItemPalette.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ToolbarItemPalette.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemPalette.cpp; sourceTree = SOURCE_ROOT; };
+		4C3EA47E012B2D63ADE599DD /* juce_PathStrokeType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PathStrokeType.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathStrokeType.cpp; sourceTree = SOURCE_ROOT; };
+		4C4E2282C145D13C86CB23FA /* juce_OpenGLHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLHelpers.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLHelpers.h; sourceTree = SOURCE_ROOT; };
+		4C81E05B39376F54775A1027 /* juce_Colour.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Colour.h; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colour.h; sourceTree = SOURCE_ROOT; };
+		4CA9556E9C18029A47F34C7C /* juce_LAMEEncoderAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LAMEEncoderAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_LAMEEncoderAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		4CCA36B2A6C4821E493E74D2 /* juce_AudioFormatReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioFormatReader.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReader.cpp; sourceTree = SOURCE_ROOT; };
+		4CF403118BBAAD5B6763542A /* juce_OpenGLContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLContext.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLContext.cpp; sourceTree = SOURCE_ROOT; };
+		4D67518E9223C1C19BD4EF2E /* juce_linux_Threads.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Threads.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_linux_Threads.cpp; sourceTree = SOURCE_ROOT; };
+		4D84A3A970FB67566A1E5B0B /* juce_KnownPluginList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_KnownPluginList.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_KnownPluginList.h; sourceTree = SOURCE_ROOT; };
+		4D8F94CA49DB11E07918B4C9 /* juce_UnitTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_UnitTest.cpp; path = ../../JuceLibraryCode/modules/juce_core/unit_tests/juce_UnitTest.cpp; sourceTree = SOURCE_ROOT; };
+		4E520E7960CC5098C2352E70 /* juce_MouseCursor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MouseCursor.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseCursor.h; sourceTree = SOURCE_ROOT; };
+		4E6EE225098D32E7D5DE60B2 /* SpikeDisplayCanvas.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDisplayCanvas.h; path = ../../Source/Processors/Visualization/SpikeDisplayCanvas.h; sourceTree = SOURCE_ROOT; };
+		4E71B355F2BABAF69CC4114D /* juce_ConcertinaPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ConcertinaPanel.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ConcertinaPanel.h; sourceTree = SOURCE_ROOT; };
+		4EC254B133A7AAE377B9B3AE /* juce_LassoComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LassoComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_LassoComponent.h; sourceTree = SOURCE_ROOT; };
+		4F31D61C0C2AB3472C6C1429 /* juce_MACAddress.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MACAddress.cpp; path = ../../JuceLibraryCode/modules/juce_core/network/juce_MACAddress.cpp; sourceTree = SOURCE_ROOT; };
+		4F4234DC14D3689C22655D0C /* juce_ComponentListener.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComponentListener.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ComponentListener.cpp; sourceTree = SOURCE_ROOT; };
+		4F4E8E3B32DB7A91B41C9FFA /* MergerB-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerB-01.png"; path = "../../Resources/Images/Buttons/MergerB-01.png"; sourceTree = SOURCE_ROOT; };
+		4FC4EF4B38B28638B2F09260 /* PeriStimulusTimeHistogramNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PeriStimulusTimeHistogramNode.h; path = ../../Source/Processors/PeriStimulusTimeHistogramNode.h; sourceTree = SOURCE_ROOT; };
+		4FD13AA663EEE7CC2F83033D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		50DB7E5C152DDD03F2FA4C2D /* BebasNeue.otf */ = {isa = PBXFileReference; lastKnownFileType = file.otf; name = BebasNeue.otf; path = ../../Resources/Fonts/BebasNeue.otf; sourceTree = SOURCE_ROOT; };
+		50DD8D693741DD18106C0BA7 /* juce_ComponentListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComponentListener.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_ComponentListener.h; sourceTree = SOURCE_ROOT; };
+		510ACDAD798813D7FC110197 /* juce_TabbedComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TabbedComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedComponent.h; sourceTree = SOURCE_ROOT; };
+		511C443A0A806706A772E981 /* juce_Primes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Primes.cpp; path = ../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_Primes.cpp; sourceTree = SOURCE_ROOT; };
+		515213CC3271E8DEA8125D33 /* juce_DynamicLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DynamicLibrary.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_DynamicLibrary.h; sourceTree = SOURCE_ROOT; };
+		51926BEEA63BF141D93A5B36 /* juce_RelativePoint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RelativePoint.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePoint.cpp; sourceTree = SOURCE_ROOT; };
+		5265AD5F97C9E813E14937A7 /* juce_RectanglePlacement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RectanglePlacement.h; path = ../../JuceLibraryCode/modules/juce_graphics/placement/juce_RectanglePlacement.h; sourceTree = SOURCE_ROOT; };
+		5284E69CC601457D5C7C1063 /* juce_linux_SystemTrayIcon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_SystemTrayIcon.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_linux_SystemTrayIcon.cpp; sourceTree = SOURCE_ROOT; };
+		52A8F84DCDDF0186B511B9CD /* juce_FilenameComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FilenameComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FilenameComponent.cpp; sourceTree = SOURCE_ROOT; };
+		53130F5F47EB211416C028F6 /* juce_UnitTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_UnitTest.h; path = ../../JuceLibraryCode/modules/juce_core/unit_tests/juce_UnitTest.h; sourceTree = SOURCE_ROOT; };
+		5343D594AA7D444A7C6AD924 /* juce_GZIPDecompressorInputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_GZIPDecompressorInputStream.h; path = ../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPDecompressorInputStream.h; sourceTree = SOURCE_ROOT; };
+		5379FC603780F30A2F05FE78 /* juce_AsyncUpdater.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AsyncUpdater.h; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_AsyncUpdater.h; sourceTree = SOURCE_ROOT; };
+		53C8A2696FE4389E4AB4441C /* juce_Slider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Slider.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Slider.cpp; sourceTree = SOURCE_ROOT; };
+		54339ADDCB6F8E9E7721A986 /* juce_android_Windowing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Windowing.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_android_Windowing.cpp; sourceTree = SOURCE_ROOT; };
+		5522973FA48A13C6BED293FE /* SignalGenerator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SignalGenerator.cpp; path = ../../Source/Processors/SignalGenerator.cpp; sourceTree = SOURCE_ROOT; };
+		555D34D0CD8776EE5996CC3A /* ProcessorGraph.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ProcessorGraph.cpp; path = ../../Source/Processors/ProcessorGraph.cpp; sourceTree = SOURCE_ROOT; };
+		55811E331B55E0547326CF22 /* juce_TopLevelWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TopLevelWindow.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TopLevelWindow.cpp; sourceTree = SOURCE_ROOT; };
+		558E925DAC57ADF8810559AC /* juce_linux_Windowing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Windowing.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_linux_Windowing.cpp; sourceTree = SOURCE_ROOT; };
+		55EBFCA56B915C8CD043365C /* juce_win32_DirectWriteTypeLayout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_DirectWriteTypeLayout.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_DirectWriteTypeLayout.cpp; sourceTree = SOURCE_ROOT; };
+		55F7467B96E236DD558228C9 /* juce_CharPointer_UTF8.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CharPointer_UTF8.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_UTF8.h; sourceTree = SOURCE_ROOT; };
+		560A28C1966B1817873CF764 /* juce_MidiMessageSequence.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiMessageSequence.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessageSequence.cpp; sourceTree = SOURCE_ROOT; };
+		56169D835A3E3029D6E3904C /* QuickTime.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickTime.framework; path = System/Library/Frameworks/QuickTime.framework; sourceTree = SDKROOT; };
+		562E4A50364EEDC3AA2AACB8 /* juce_RelativeTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RelativeTime.h; path = ../../JuceLibraryCode/modules/juce_core/time/juce_RelativeTime.h; sourceTree = SOURCE_ROOT; };
+		563F35B171FAF2540923CE45 /* juce_AudioDataConverters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioDataConverters.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioDataConverters.cpp; sourceTree = SOURCE_ROOT; };
+		564380494D23DB70680FB0B5 /* juce_TreeView.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TreeView.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TreeView.cpp; sourceTree = SOURCE_ROOT; };
+		5654BDD4FBFF01AC3F17FA0D /* ChannelMappingNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChannelMappingNode.cpp; path = ../../Source/Processors/ChannelMappingNode.cpp; sourceTree = SOURCE_ROOT; };
+		565EEC8F429ABF5F9A867137 /* juce_MouseEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MouseEvent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseEvent.cpp; sourceTree = SOURCE_ROOT; };
+		56728EC77C65482B9C86FF4D /* juce_audio_utils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_audio_utils.mm; path = ../../JuceLibraryCode/modules/juce_audio_utils/juce_audio_utils.mm; sourceTree = SOURCE_ROOT; };
+		570299171BCE863C54FBBA54 /* juce_ConcertinaPanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ConcertinaPanel.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ConcertinaPanel.cpp; sourceTree = SOURCE_ROOT; };
+		57941E5B2E1FF6028A68D4A7 /* RadioButtons-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-02.png"; path = "../../Resources/Images/Icons/RadioButtons-02.png"; sourceTree = SOURCE_ROOT; };
+		57C6DD2537116B30FB948A08 /* juce_RSAKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RSAKey.h; path = ../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_RSAKey.h; sourceTree = SOURCE_ROOT; };
+		57F66B4A911601169AF195E9 /* juce_AudioProcessorPlayer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioProcessorPlayer.cpp; path = ../../JuceLibraryCode/modules/juce_audio_utils/players/juce_AudioProcessorPlayer.cpp; sourceTree = SOURCE_ROOT; };
+		57FBA8BC3104D3AF41FBECD8 /* EditorViewport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EditorViewport.h; path = ../../Source/UI/EditorViewport.h; sourceTree = SOURCE_ROOT; };
+		581287A24510A9EACEE09CE4 /* juce_DocumentWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DocumentWindow.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DocumentWindow.h; sourceTree = SOURCE_ROOT; };
+		586448E180F8ACBF5A1565B0 /* juce_gui_extra.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_gui_extra.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/juce_gui_extra.h; sourceTree = SOURCE_ROOT; };
+		586B1E0743FFBE9081A25F4F /* juce_CodeEditorComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CodeEditorComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.cpp; sourceTree = SOURCE_ROOT; };
+		587FCA2485B9C89C2A99C23A /* Filter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Filter.cpp; path = ../../Source/Dsp/Filter.cpp; sourceTree = SOURCE_ROOT; };
+		5894D40A0E8FA6E9B3EBF9D9 /* SpikeObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeObject.cpp; path = ../../Source/Processors/Visualization/SpikeObject.cpp; sourceTree = SOURCE_ROOT; };
+		58958CC3F750D383261E2FBC /* juce_SliderPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SliderPropertyComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_SliderPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		58BBDECD171E15D0768302A1 /* ISCANeditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ISCANeditor.cpp; path = ../../Source/Processors/Editors/ISCANeditor.cpp; sourceTree = SOURCE_ROOT; };
+		5915DB02FB7CA8CEC1BF38A9 /* juce_opengl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_opengl.mm; path = ../../JuceLibraryCode/modules/juce_opengl/juce_opengl.mm; sourceTree = SOURCE_ROOT; };
+		59389DC8664617FD51740F36 /* juce_DirectShowComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DirectShowComponent.h; path = ../../JuceLibraryCode/modules/juce_video/playback/juce_DirectShowComponent.h; sourceTree = SOURCE_ROOT; };
+		5962848AA3DD93A29EFF5B94 /* juce_data_structures.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_data_structures.h; path = ../../JuceLibraryCode/modules/juce_data_structures/juce_data_structures.h; sourceTree = SOURCE_ROOT; };
+		5A746CDDE80FEA2E45B5BA66 /* juce_mac_AppleRemote.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_AppleRemote.mm; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_AppleRemote.mm; sourceTree = SOURCE_ROOT; };
+		5A7D81B70480B40EEBC2FF54 /* juce_MessageListener.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MessageListener.cpp; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_MessageListener.cpp; sourceTree = SOURCE_ROOT; };
+		5A8D46BEB81DDF24462E3D92 /* PoleFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PoleFilter.h; path = ../../Source/Dsp/PoleFilter.h; sourceTree = SOURCE_ROOT; };
+		5AB3809F029824EE2DE0A798 /* juce_ImageFileFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ImageFileFormat.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageFileFormat.cpp; sourceTree = SOURCE_ROOT; };
+		5B2A4DD7133CDE5AEC24CC07 /* GenericProcessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GenericProcessor.h; path = ../../Source/Processors/GenericProcessor.h; sourceTree = SOURCE_ROOT; };
+		5B2CDF3CF10A92F6CA45F3DE /* juce_AudioPlayHead.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioPlayHead.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioPlayHead.h; sourceTree = SOURCE_ROOT; };
+		5B411F4FCF0F69798C9E4A88 /* juce_ScrollBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ScrollBar.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ScrollBar.h; sourceTree = SOURCE_ROOT; };
+		5B6B25AA065FB6CDE7D6C507 /* juce_ApplicationProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ApplicationProperties.h; path = ../../JuceLibraryCode/modules/juce_data_structures/app_properties/juce_ApplicationProperties.h; sourceTree = SOURCE_ROOT; };
+		5B7EC53FD2232CA799D6C018 /* juce_win32_DirectSound.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_DirectSound.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_DirectSound.cpp; sourceTree = SOURCE_ROOT; };
+		5BB1E90842FD8A212CC2D132 /* juce_CodeDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CodeDocument.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeDocument.h; sourceTree = SOURCE_ROOT; };
+		5C1D2D28960C7957A15B3FE4 /* juce_ChannelRemappingAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ChannelRemappingAudioSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ChannelRemappingAudioSource.cpp; sourceTree = SOURCE_ROOT; };
+		5C5E4C396CD83C46F58644A2 /* triangle_wave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = triangle_wave.png; path = ../../Resources/Images/Icons/triangle_wave.png; sourceTree = SOURCE_ROOT; };
+		5C7EEDD80F88872A87FD561B /* juce_AudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		5CE99545433261F3B4A46252 /* juce_AudioFormatReaderSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioFormatReaderSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReaderSource.cpp; sourceTree = SOURCE_ROOT; };
+		5D23F70C117457FB8547A537 /* NotchFilterNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NotchFilterNode.h; path = ../../Source/Processors/NotchFilterNode.h; sourceTree = SOURCE_ROOT; };
+		5D9792840E8050DCC766B368 /* juce_OpenGLRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLRenderer.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLRenderer.h; sourceTree = SOURCE_ROOT; };
+		5DB3B3197F8C1E5EE159D6FC /* rhd2000registers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rhd2000registers.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000registers.cpp"; sourceTree = SOURCE_ROOT; };
+		5DB6A07B827D62571BB51943 /* juce_Justification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Justification.h; path = ../../JuceLibraryCode/modules/juce_graphics/placement/juce_Justification.h; sourceTree = SOURCE_ROOT; };
+		5DC1AF69A773401DB1E8FB32 /* juce_RelativeTime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RelativeTime.cpp; path = ../../JuceLibraryCode/modules/juce_core/time/juce_RelativeTime.cpp; sourceTree = SOURCE_ROOT; };
+		5E0F8A60411A03461FD687CE /* juce_GroupComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_GroupComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_GroupComponent.h; sourceTree = SOURCE_ROOT; };
+		5E1EFF4EEA5684FA00CAA353 /* juce_ResizableBorderComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ResizableBorderComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableBorderComponent.h; sourceTree = SOURCE_ROOT; };
+		5E663D5A55F191AB92A1383F /* juce_FileInputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileInputStream.h; path = ../../JuceLibraryCode/modules/juce_core/files/juce_FileInputStream.h; sourceTree = SOURCE_ROOT; };
+		5E94E897783BEEFE61E61A2C /* juce_android_WebBrowserComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_WebBrowserComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_android_WebBrowserComponent.cpp; sourceTree = SOURCE_ROOT; };
+		5EA61EDD64BE1E401DD0AA5E /* SpikeDisplayNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDisplayNode.h; path = ../../Source/Processors/SpikeDisplayNode.h; sourceTree = SOURCE_ROOT; };
+		5EA661C13CB7197A45F20028 /* PipelineB-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineB-02.png"; path = "../../Resources/Images/Buttons/PipelineB-02.png"; sourceTree = SOURCE_ROOT; };
+		5F64FDAFCA899A16C7FDDBCA /* AudioNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioNode.h; path = ../../Source/Processors/AudioNode.h; sourceTree = SOURCE_ROOT; };
+		5F6DCA68A982E930389644FD /* juce_linux_Network.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Network.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_linux_Network.cpp; sourceTree = SOURCE_ROOT; };
+		5FEBF3F722DB6191BF659816 /* juce_ArrowButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ArrowButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ArrowButton.cpp; sourceTree = SOURCE_ROOT; };
+		5FEFF62D585CF777C950E569 /* juce_LookAndFeel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_LookAndFeel.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.cpp; sourceTree = SOURCE_ROOT; };
+		601654292170CD2D60E912A6 /* juce_linux_ALSA.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_ALSA.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_ALSA.cpp; sourceTree = SOURCE_ROOT; };
+		603764889DE750F8E87F6428 /* juce_win32_Direct2DGraphicsContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Direct2DGraphicsContext.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_Direct2DGraphicsContext.cpp; sourceTree = SOURCE_ROOT; };
+		605C7ACB09E7739EBE4F1539 /* juce_AudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_AudioSource.h; sourceTree = SOURCE_ROOT; };
+		60B1BDA3E9E14F9515963082 /* juce_BasicNativeHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BasicNativeHeaders.h; path = ../../JuceLibraryCode/modules/juce_core/native/juce_BasicNativeHeaders.h; sourceTree = SOURCE_ROOT; };
+		610E487E060C42B52FD5AAC9 /* ControlPanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ControlPanel.cpp; path = ../../Source/UI/ControlPanel.cpp; sourceTree = SOURCE_ROOT; };
+		61317B5191E05925F232E18C /* unibody-8.otf */ = {isa = PBXFileReference; lastKnownFileType = file.otf; name = "unibody-8.otf"; path = "../../Resources/Fonts/unibody-8.otf"; sourceTree = SOURCE_ROOT; };
+		61481DD4AAC7731CE984937D /* juce_OpenGLExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLExtensions.h; path = ../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGLExtensions.h; sourceTree = SOURCE_ROOT; };
+		617F5DFAAE97F48FA996A781 /* juce_DrawableRectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DrawableRectangle.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableRectangle.h; sourceTree = SOURCE_ROOT; };
+		61B0CBF705D5FC0431776286 /* juce_OpenGLShaderProgram.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLShaderProgram.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLShaderProgram.cpp; sourceTree = SOURCE_ROOT; };
+		627956A7A1CB15251D02C8C5 /* juce_ScopedXLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ScopedXLock.h; path = ../../JuceLibraryCode/modules/juce_events/native/juce_ScopedXLock.h; sourceTree = SOURCE_ROOT; };
+		6328434A329C353DB8D9512C /* SourceNodeEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SourceNodeEditor.cpp; path = ../../Source/Processors/Editors/SourceNodeEditor.cpp; sourceTree = SOURCE_ROOT; };
+		6340B1D2FECEABBBE6C0DE28 /* Types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Types.h; path = ../../Source/Dsp/Types.h; sourceTree = SOURCE_ROOT; };
+		63AF6BE7FE2A9E7882743B4F /* juce_mac_Network.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_Network.mm; path = ../../JuceLibraryCode/modules/juce_core/native/juce_mac_Network.mm; sourceTree = SOURCE_ROOT; };
+		63F4150ABBA43B2215230034 /* juce_IIRFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_IIRFilter.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_IIRFilter.h; sourceTree = SOURCE_ROOT; };
+		642C4CFA27846188E3D53688 /* juce_AudioDeviceManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioDeviceManager.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.h; sourceTree = SOURCE_ROOT; };
+		649F22404167E0D0EA244196 /* juce_Toolbar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Toolbar.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Toolbar.cpp; sourceTree = SOURCE_ROOT; };
+		6514FD7E6C5EC12735E49FBC /* juce_mac_FileChooser.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_FileChooser.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_FileChooser.mm; sourceTree = SOURCE_ROOT; };
+		651E9B78A5139F7A5BCA4D90 /* juce_PropertyComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PropertyComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyComponent.cpp; sourceTree = SOURCE_ROOT; };
+		65312FAD0900119CDF6CF414 /* PoleFilter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PoleFilter.cpp; path = ../../Source/Dsp/PoleFilter.cpp; sourceTree = SOURCE_ROOT; };
+		6535D85C084292220330EDD9 /* juce_ResamplingAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ResamplingAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ResamplingAudioSource.h; sourceTree = SOURCE_ROOT; };
+		65751E743D5EFD4066E50746 /* juce_LagrangeInterpolator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LagrangeInterpolator.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_LagrangeInterpolator.h; sourceTree = SOURCE_ROOT; };
+		6589EAEF497ABA76A295B121 /* juce_VSTPluginFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_VSTPluginFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.h; sourceTree = SOURCE_ROOT; };
+		658D08592154525DA1C40826 /* juce_FileLogger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileLogger.cpp; path = ../../JuceLibraryCode/modules/juce_core/logging/juce_FileLogger.cpp; sourceTree = SOURCE_ROOT; };
+		6596D69CCD1502DC6BBD15F1 /* juce_CharPointer_UTF32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CharPointer_UTF32.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_UTF32.h; sourceTree = SOURCE_ROOT; };
+		65980344D141B0008A94E2E4 /* juce_win32_DirectShowComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_DirectShowComponent.cpp; path = ../../JuceLibraryCode/modules/juce_video/native/juce_win32_DirectShowComponent.cpp; sourceTree = SOURCE_ROOT; };
+		65A447DCF8A68BAABC20FC7D /* juce_FileFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileFilter.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileFilter.h; sourceTree = SOURCE_ROOT; };
+		65BE7542749DCCAE33ACF40F /* juce_OldSchoolLookAndFeel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OldSchoolLookAndFeel.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/lookandfeel/juce_OldSchoolLookAndFeel.h; sourceTree = SOURCE_ROOT; };
+		65DA1366481AB10AFB3AF344 /* juce_PerformanceCounter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PerformanceCounter.h; path = ../../JuceLibraryCode/modules/juce_core/time/juce_PerformanceCounter.h; sourceTree = SOURCE_ROOT; };
+		65F4459CC1832883FFF6C166 /* juce_audio_devices.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_audio_devices.mm; path = ../../JuceLibraryCode/modules/juce_audio_devices/juce_audio_devices.mm; sourceTree = SOURCE_ROOT; };
+		66463AB11EA4D6341C32F27E /* DataWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataWindow.cpp; path = ../../Source/Processors/Visualization/DataWindow.cpp; sourceTree = SOURCE_ROOT; };
+		66C663401829E0F7E787F708 /* juce_PropertySet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PropertySet.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_PropertySet.h; sourceTree = SOURCE_ROOT; };
+		66D3F831CE4F6AE89E4C869A /* juce_LinkedListPointer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LinkedListPointer.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_LinkedListPointer.h; sourceTree = SOURCE_ROOT; };
+		66F524552E8DE88CDC2E40FD /* silkscreen-serialized */ = {isa = PBXFileReference; lastKnownFileType = file; name = "silkscreen-serialized"; path = "../../Resources/Fonts/silkscreen-serialized"; sourceTree = SOURCE_ROOT; };
+		66FE597910F6A68CBB6FA055 /* juce_MemoryInputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MemoryInputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryInputStream.cpp; sourceTree = SOURCE_ROOT; };
+		670987D88775D6B240C34820 /* juce_NotificationType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_NotificationType.h; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_NotificationType.h; sourceTree = SOURCE_ROOT; };
+		674FDCCEF6A1379A0F689004 /* juce_ComponentBoundsConstrainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComponentBoundsConstrainer.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBoundsConstrainer.h; sourceTree = SOURCE_ROOT; };
+		67BB47E709B643D4C01AB34C /* juce_AudioDeviceSelectorComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioDeviceSelectorComponent.cpp; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioDeviceSelectorComponent.cpp; sourceTree = SOURCE_ROOT; };
+		6832130272774CD542793762 /* juce_mac_CoreGraphicsContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_CoreGraphicsContext.mm; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsContext.mm; sourceTree = SOURCE_ROOT; };
+		686FA8DDF2848517CBFB9E4A /* juce_MouseCursor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MouseCursor.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseCursor.cpp; sourceTree = SOURCE_ROOT; };
+		6880C148A38A5C8D0092E358 /* Merger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Merger.h; path = ../../Source/Processors/Utilities/Merger.h; sourceTree = SOURCE_ROOT; };
+		6917A53BAA3CA2819E4C10BF /* juce_ToolbarItemComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ToolbarItemComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemComponent.cpp; sourceTree = SOURCE_ROOT; };
+		693E9C5C9A435F791921DAAE /* juce_AudioDeviceManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioDeviceManager.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp; sourceTree = SOURCE_ROOT; };
+		696F2DC49934E6F01A2DF9FE /* juce_FileTreeComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileTreeComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileTreeComponent.cpp; sourceTree = SOURCE_ROOT; };
+		698B0EC670DA47934444381B /* juce_win32_Network.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Network.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_win32_Network.cpp; sourceTree = SOURCE_ROOT; };
+		6A559D9595A54EF52BF0773A /* juce_Range.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Range.h; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_Range.h; sourceTree = SOURCE_ROOT; };
+		6A63308EBE68478531604BA4 /* juce_DirectoryContentsList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DirectoryContentsList.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsList.cpp; sourceTree = SOURCE_ROOT; };
+		6ABF91320A2EB6D307091AEE /* juce_mac_CameraDevice.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_CameraDevice.mm; path = ../../JuceLibraryCode/modules/juce_video/native/juce_mac_CameraDevice.mm; sourceTree = SOURCE_ROOT; };
+		6B28CEAF75E22F2CCCACBCC7 /* juce_audio_formats.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_audio_formats.mm; path = ../../JuceLibraryCode/modules/juce_audio_formats/juce_audio_formats.mm; sourceTree = SOURCE_ROOT; };
+		6B32691AA8B3D304B68CFA64 /* juce_MemoryMappedAudioFormatReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MemoryMappedAudioFormatReader.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_MemoryMappedAudioFormatReader.h; sourceTree = SOURCE_ROOT; };
+		6B7252D3F574AE21BE464327 /* PipelineA-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineA-02.png"; path = "../../Resources/Images/Buttons/PipelineA-02.png"; sourceTree = SOURCE_ROOT; };
+		6B90F5150FA8E114E8AE98BF /* juce_AudioFormatWriter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioFormatWriter.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatWriter.cpp; sourceTree = SOURCE_ROOT; };
+		6BA113C799640798D3F29A06 /* juce_ProgressBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ProgressBar.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ProgressBar.h; sourceTree = SOURCE_ROOT; };
+		6BA7D7A7E3E2E646E50D334A /* juce_FileSearchPathListComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileSearchPathListComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileSearchPathListComponent.cpp; sourceTree = SOURCE_ROOT; };
+		6BBBC0907D7A62E2F3AB9BDF /* juce_Colours.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Colours.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colours.cpp; sourceTree = SOURCE_ROOT; };
+		6C24163DC4ECD731489CC4F6 /* juce_OwnedArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OwnedArray.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_OwnedArray.h; sourceTree = SOURCE_ROOT; };
+		6C36C3C304EB066B1DFCCD9C /* juce_SystemClipboard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SystemClipboard.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_SystemClipboard.h; sourceTree = SOURCE_ROOT; };
+		6C8489C41782E3D391AF0C26 /* juce_Identifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Identifier.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_Identifier.h; sourceTree = SOURCE_ROOT; };
+		6CA98F8581CEAE2DC9AEBCE9 /* juce_CallbackMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CallbackMessage.h; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_CallbackMessage.h; sourceTree = SOURCE_ROOT; };
+		6CBD8647DB17F1B58B14A3BC /* juce_win32_AudioCDBurner.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_AudioCDBurner.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_AudioCDBurner.cpp; sourceTree = SOURCE_ROOT; };
+		6D34DD9AB987A67BADE71C65 /* RadioButtons-05.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-05.png"; path = "../../Resources/Images/Icons/RadioButtons-05.png"; sourceTree = SOURCE_ROOT; };
+		6D4BA4399FDEB6D2195B257D /* juce_SplashScreen.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SplashScreen.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SplashScreen.h; sourceTree = SOURCE_ROOT; };
+		6D4DFC260B2966E3EBFC0C79 /* juce_SliderPropertyComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_SliderPropertyComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_SliderPropertyComponent.cpp; sourceTree = SOURCE_ROOT; };
+		6D59D5780ECD2CC9703CB499 /* Butterworth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Butterworth.h; path = ../../Source/Dsp/Butterworth.h; sourceTree = SOURCE_ROOT; };
+		6D619C7A3A14981DC4EFF223 /* juce_IIRFilterAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_IIRFilterAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_IIRFilterAudioSource.h; sourceTree = SOURCE_ROOT; };
+		6D77949E9C7C9B5A7795C0E0 /* juce_PathStrokeType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PathStrokeType.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_PathStrokeType.h; sourceTree = SOURCE_ROOT; };
+		6DA8EC2F779DEBB701FE33CA /* juce_win32_HiddenMessageWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_win32_HiddenMessageWindow.h; path = ../../JuceLibraryCode/modules/juce_events/native/juce_win32_HiddenMessageWindow.h; sourceTree = SOURCE_ROOT; };
+		6DCDFF2618CFEECEACE87630 /* juce_android_GraphicsContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_GraphicsContext.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_android_GraphicsContext.cpp; sourceTree = SOURCE_ROOT; };
+		6DD526F86CBF2C3B3487FFE1 /* juce_ComponentBuilder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComponentBuilder.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentBuilder.cpp; sourceTree = SOURCE_ROOT; };
+		6E2F243D8F70CC92391204A4 /* juce_MultiDocumentPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MultiDocumentPanel.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_MultiDocumentPanel.h; sourceTree = SOURCE_ROOT; };
+		6E444E05271A0334FAE9DCA3 /* TrialCircularBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TrialCircularBuffer.h; path = ../../Source/Processors/TrialCircularBuffer.h; sourceTree = SOURCE_ROOT; };
+		6EA1CC7DACDDBA863179521A /* juce_TemporaryFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TemporaryFile.cpp; path = ../../JuceLibraryCode/modules/juce_core/files/juce_TemporaryFile.cpp; sourceTree = SOURCE_ROOT; };
+		6EF4EFD6D74D2573AC6B6A6F /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_audio_devices/juce_module_info; sourceTree = SOURCE_ROOT; };
+		6F9B89F7AD0E13887871D4FE /* SourceDrop.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = SourceDrop.png; path = ../../Resources/Images/Icons/SourceDrop.png; sourceTree = SOURCE_ROOT; };
+		6FE8B0DD6116E6A3456ECF09 /* juce_ios_UIViewComponent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_ios_UIViewComponent.mm; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_ios_UIViewComponent.mm; sourceTree = SOURCE_ROOT; };
+		700597338DEC9AB65C4C8A5E /* juce_DrawableText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DrawableText.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableText.h; sourceTree = SOURCE_ROOT; };
+		70151263C4CB8A4F79431E11 /* EventNodeEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EventNodeEditor.cpp; path = ../../Source/Processors/Editors/EventNodeEditor.cpp; sourceTree = SOURCE_ROOT; };
+		70BF68C222D1E0A0368EB845 /* juce_ApplicationCommandManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ApplicationCommandManager.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandManager.cpp; sourceTree = SOURCE_ROOT; };
+		70ECB490BD59F59D003F3BEE /* juce_android_CameraDevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_CameraDevice.cpp; path = ../../JuceLibraryCode/modules/juce_video/native/juce_android_CameraDevice.cpp; sourceTree = SOURCE_ROOT; };
+		70F06DBCA3948BCC1062E36F /* ChannelSelector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelSelector.h; path = ../../Source/Processors/Editors/ChannelSelector.h; sourceTree = SOURCE_ROOT; };
+		71C0C491E4BB214551D6EAD7 /* AdvancerNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AdvancerNode.cpp; path = ../../Source/Processors/AdvancerNode.cpp; sourceTree = SOURCE_ROOT; };
+		71CF8F6995DF1BA2038C21D6 /* juce_AlertWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AlertWindow.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_AlertWindow.h; sourceTree = SOURCE_ROOT; };
+		7291F19253205B1A5138908E /* juce_DynamicObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DynamicObject.cpp; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_DynamicObject.cpp; sourceTree = SOURCE_ROOT; };
+		72C33BA70B9EE82E39F1EC6C /* juce_MP3AudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MP3AudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_MP3AudioFormat.h; sourceTree = SOURCE_ROOT; };
+		72FCE41894123FC5DB01566B /* juce_OpenGL_win32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGL_win32.h; path = ../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_win32.h; sourceTree = SOURCE_ROOT; };
+		7387114E34496F4606550863 /* juce_HyperlinkButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_HyperlinkButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_HyperlinkButton.cpp; sourceTree = SOURCE_ROOT; };
+		73ACB7A051EDE5F676E35FFD /* juce_PerformanceCounter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PerformanceCounter.cpp; path = ../../JuceLibraryCode/modules/juce_core/time/juce_PerformanceCounter.cpp; sourceTree = SOURCE_ROOT; };
+		73C69D948D33899821536025 /* juce_SystemTrayIconComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SystemTrayIconComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.h; sourceTree = SOURCE_ROOT; };
+		748AF0975561FFFE51DF5F58 /* PhaseDetectorEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PhaseDetectorEditor.h; path = ../../Source/Processors/Editors/PhaseDetectorEditor.h; sourceTree = SOURCE_ROOT; };
+		748E62D05C8FFF74DCA234C7 /* juce_ThreadPool.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ThreadPool.cpp; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ThreadPool.cpp; sourceTree = SOURCE_ROOT; };
+		74A81014471CC0EB0D5E6571 /* juce_ValueTree.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ValueTree.cpp; path = ../../JuceLibraryCode/modules/juce_data_structures/values/juce_ValueTree.cpp; sourceTree = SOURCE_ROOT; };
+		74DE857CEFA10BC49FF591DB /* juce_Synthesiser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Synthesiser.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/synthesisers/juce_Synthesiser.h; sourceTree = SOURCE_ROOT; };
+		753B81CCB5A6B6929679E7B7 /* juce_Application.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Application.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/application/juce_Application.h; sourceTree = SOURCE_ROOT; };
+		7555A13E69B99B1B6C7295FD /* juce_InputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_InputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_InputStream.cpp; sourceTree = SOURCE_ROOT; };
+		758BC480F153DEA79304366B /* ofArduino.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ofArduino.h; path = ../../Source/Processors/Serial/ofArduino.h; sourceTree = SOURCE_ROOT; };
+		75A4EEE127FAB86D65FF5F6E /* juce_RelativeCoordinatePositioner.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RelativeCoordinatePositioner.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinatePositioner.cpp; sourceTree = SOURCE_ROOT; };
+		75B1E4EFCDA9A506CFEDB09F /* PhaseDetectorEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PhaseDetectorEditor.cpp; path = ../../Source/Processors/Editors/PhaseDetectorEditor.cpp; sourceTree = SOURCE_ROOT; };
+		75E0C433EC27CFB712CD9F75 /* juce_PluginListComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PluginListComponent.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginListComponent.h; sourceTree = SOURCE_ROOT; };
+		75FCE8908DD9055F90E93716 /* juce_ResizableBorderComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ResizableBorderComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableBorderComponent.cpp; sourceTree = SOURCE_ROOT; };
+		76140C0485FDDA98C3D98E2A /* juce_OldSchoolLookAndFeel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OldSchoolLookAndFeel.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/lookandfeel/juce_OldSchoolLookAndFeel.cpp; sourceTree = SOURCE_ROOT; };
+		766923F74E30FF5D6B12E7CE /* juce_DrawableComposite.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DrawableComposite.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableComposite.h; sourceTree = SOURCE_ROOT; };
+		76E89CBE70BF8F2476B7AA34 /* juce_SortedSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SortedSet.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_SortedSet.h; sourceTree = SOURCE_ROOT; };
+		76F569AE7B444D8F69EE0E86 /* AudioResamplingNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioResamplingNode.cpp; path = ../../Source/Processors/AudioResamplingNode.cpp; sourceTree = SOURCE_ROOT; };
+		7719FB81DDF23CF0164B131D /* juce_BlowFish.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BlowFish.h; path = ../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_BlowFish.h; sourceTree = SOURCE_ROOT; };
+		77B3E84324445076F1F907E9 /* juce_win32_Threads.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Threads.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_win32_Threads.cpp; sourceTree = SOURCE_ROOT; };
+		77D3770CCBB3EED01A854329 /* SpikeSortBoxes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeSortBoxes.h; path = ../../Source/Processors/SpikeSortBoxes.h; sourceTree = SOURCE_ROOT; };
+		783D8922D5C687E170FA1A2C /* cpmono_plain.otf */ = {isa = PBXFileReference; lastKnownFileType = file.otf; name = cpmono_plain.otf; path = ../../Resources/Fonts/cpmono_plain.otf; sourceTree = SOURCE_ROOT; };
+		784233150B26826701C09103 /* juce_MidiKeyboardComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiKeyboardComponent.h; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.h; sourceTree = SOURCE_ROOT; };
+		786A97B2B4E2BB6406546647 /* juce_FileSearchPathListComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileSearchPathListComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileSearchPathListComponent.h; sourceTree = SOURCE_ROOT; };
+		786F6A40506C2094B812F4D5 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_audio_basics/juce_module_info; sourceTree = SOURCE_ROOT; };
+		788F8B7719B70465762B634B /* DataBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataBuffer.cpp; path = ../../Source/Processors/DataThreads/DataBuffer.cpp; sourceTree = SOURCE_ROOT; };
+		789139D88F449BE488BF3CCB /* juce_AudioFormatReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioFormatReader.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatReader.h; sourceTree = SOURCE_ROOT; };
+		78BA978C614603B5E9ECFFF1 /* juce_ComponentPeer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComponentPeer.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ComponentPeer.cpp; sourceTree = SOURCE_ROOT; };
+		78CC9639B933CE2497264EF2 /* juce_KeyPress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_KeyPress.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyPress.h; sourceTree = SOURCE_ROOT; };
+		78FB85191B054CDE7BD07DB7 /* PeriStimulusTimeHistogramEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PeriStimulusTimeHistogramEditor.h; path = ../../Source/Processors/Editors/PeriStimulusTimeHistogramEditor.h; sourceTree = SOURCE_ROOT; };
+		793A4A777FEFA450F86C78EE /* juce_GraphicsContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GraphicsContext.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/contexts/juce_GraphicsContext.cpp; sourceTree = SOURCE_ROOT; };
+		79BBD2F2F31D76CC4F5BD012 /* RadioButtons_selected-04.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-04.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-04.png"; sourceTree = SOURCE_ROOT; };
+		79C32CA8069962F5DE48F633 /* PulsePal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PulsePal.h; path = ../../Source/Processors/Serial/PulsePal.h; sourceTree = SOURCE_ROOT; };
+		79C91DDF3BC3F15D0338E504 /* ProcessorList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ProcessorList.cpp; path = ../../Source/UI/ProcessorList.cpp; sourceTree = SOURCE_ROOT; };
+		7A93BFD2180B5E00B124CB1A /* juce_PixelFormats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PixelFormats.h; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_PixelFormats.h; sourceTree = SOURCE_ROOT; };
+		7A9F37527280A470F201FB6E /* juce_SystemTrayIconComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_SystemTrayIconComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.cpp; sourceTree = SOURCE_ROOT; };
+		7ACB1CB66D69738904358F43 /* Design.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Design.h; path = ../../Source/Dsp/Design.h; sourceTree = SOURCE_ROOT; };
+		7B42B28FDB2E3AC67EF296F8 /* PracticalSocket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PracticalSocket.h; path = ../../Source/Network/PracticalSocket.h; sourceTree = SOURCE_ROOT; };
+		7B674BB1DA11A4E58EA71624 /* juce_EdgeTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_EdgeTable.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_EdgeTable.cpp; sourceTree = SOURCE_ROOT; };
+		7B7819A5759B54D91E334447 /* LfpTriggeredAverageEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpTriggeredAverageEditor.cpp; path = ../../Source/Processors/Editors/LfpTriggeredAverageEditor.cpp; sourceTree = SOURCE_ROOT; };
+		7BCE1C09508E1B9CFC79C185 /* juce_CaretComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CaretComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_CaretComponent.cpp; sourceTree = SOURCE_ROOT; };
+		7BD2C39F13FDE202141C4B41 /* MessageCenter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MessageCenter.cpp; path = ../../Source/UI/MessageCenter.cpp; sourceTree = SOURCE_ROOT; };
+		7BE7EBBCC4DCF760A1AA697E /* juce_DirectoryContentsList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DirectoryContentsList.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsList.h; sourceTree = SOURCE_ROOT; };
+		7BF1DCDC30FDFBFAF03516C1 /* NotchFilterEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NotchFilterEditor.cpp; path = ../../Source/Processors/Editors/NotchFilterEditor.cpp; sourceTree = SOURCE_ROOT; };
+		7C0F2759385C66CAC3EC362D /* juce_win32_ActiveXComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_ActiveXComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_win32_ActiveXComponent.cpp; sourceTree = SOURCE_ROOT; };
+		7C15112E5F287ACDD74480F5 /* juce_QuickTimeMovieComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_QuickTimeMovieComponent.h; path = ../../JuceLibraryCode/modules/juce_video/playback/juce_QuickTimeMovieComponent.h; sourceTree = SOURCE_ROOT; };
+		7C1D87A0C78F661FB459786B /* saw_wave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = saw_wave.png; path = ../../Resources/Images/Icons/saw_wave.png; sourceTree = SOURCE_ROOT; };
+		7C6921FE817699C1B95AEBF6 /* juce_ScopedReadLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ScopedReadLock.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ScopedReadLock.h; sourceTree = SOURCE_ROOT; };
+		7C71195623459A6C2524D418 /* juce_MidiKeyboardComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiKeyboardComponent.cpp; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp; sourceTree = SOURCE_ROOT; };
+		7CD03E334269D693E1B84856 /* juce_AudioTransportSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioTransportSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioTransportSource.cpp; sourceTree = SOURCE_ROOT; };
+		7CE1E34F6A0091E720854E75 /* juce_Value.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Value.h; path = ../../JuceLibraryCode/modules/juce_data_structures/values/juce_Value.h; sourceTree = SOURCE_ROOT; };
+		7CF939BD59D45EB41B5FE628 /* juce_Button.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Button.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_Button.cpp; sourceTree = SOURCE_ROOT; };
+		7D363D7B36A55EEB3198A827 /* juce_android_Midi.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Midi.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_android_Midi.cpp; sourceTree = SOURCE_ROOT; };
+		7D36B006AE0B139D8A3D8641 /* juce_win32_DirectWriteTypeface.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_DirectWriteTypeface.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_DirectWriteTypeface.cpp; sourceTree = SOURCE_ROOT; };
+		7D8100DC3A532980AEAAD909 /* juce_ArrayAllocationBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ArrayAllocationBase.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_ArrayAllocationBase.h; sourceTree = SOURCE_ROOT; };
+		7D88F7083884A5ED2DBE7534 /* juce_GroupComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GroupComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_GroupComponent.cpp; sourceTree = SOURCE_ROOT; };
+		7D9374931D760ADC65DCBFC6 /* DataViewport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataViewport.h; path = ../../Source/UI/DataViewport.h; sourceTree = SOURCE_ROOT; };
+		7E40891072657FB5ADC2FAB7 /* juce_Array.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Array.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_Array.h; sourceTree = SOURCE_ROOT; };
+		7E581214A64A535E03EA759B /* juce_AlertWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AlertWindow.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_AlertWindow.cpp; sourceTree = SOURCE_ROOT; };
+		7E875E681E18D693D5ADB2FB /* EditorViewport.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EditorViewport.cpp; path = ../../Source/UI/EditorViewport.cpp; sourceTree = SOURCE_ROOT; };
+		7EA46209F07B2C8A83D0873A /* juce_AudioProcessorGraph.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioProcessorGraph.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.cpp; sourceTree = SOURCE_ROOT; };
+		7EBB3F8185EB597DEF77534D /* juce_Message.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Message.h; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_Message.h; sourceTree = SOURCE_ROOT; };
+		7EBEBC6DBA8DCA5A5D8C72E1 /* juce_Timer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Timer.h; path = ../../JuceLibraryCode/modules/juce_events/timers/juce_Timer.h; sourceTree = SOURCE_ROOT; };
+		7ECD5DB4BEBC44559D064E08 /* juce_Logger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Logger.cpp; path = ../../JuceLibraryCode/modules/juce_core/logging/juce_Logger.cpp; sourceTree = SOURCE_ROOT; };
+		7EFF8622168303A4391D6CAE /* RootFinder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RootFinder.h; path = ../../Source/Dsp/RootFinder.h; sourceTree = SOURCE_ROOT; };
+		7F17077973FFDD70C4B78E7E /* juce_PlatformDefs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PlatformDefs.h; path = ../../JuceLibraryCode/modules/juce_core/system/juce_PlatformDefs.h; sourceTree = SOURCE_ROOT; };
+		7F1E84C068D3E6AA13CDD699 /* juce_Justification.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Justification.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/placement/juce_Justification.cpp; sourceTree = SOURCE_ROOT; };
+		7F4241B34F5F7245653B5196 /* NetworkSink.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkSink.cpp; path = ../../Source/Processors/NetworkSink.cpp; sourceTree = SOURCE_ROOT; };
+		7F49EA0CD3379397520AA6F1 /* juce_DeletedAtShutdown.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DeletedAtShutdown.cpp; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_DeletedAtShutdown.cpp; sourceTree = SOURCE_ROOT; };
+		7F92025F0B8FD4FA725CC70B /* juce_ImageConvolutionKernel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ImageConvolutionKernel.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageConvolutionKernel.cpp; sourceTree = SOURCE_ROOT; };
+		7F93E4F0CC8B842AC1D3E560 /* juce_ToolbarItemPalette.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ToolbarItemPalette.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemPalette.h; sourceTree = SOURCE_ROOT; };
+		7FDFE493862CE27EFCAC3F7F /* RadioButtons-04.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-04.png"; path = "../../Resources/Images/Icons/RadioButtons-04.png"; sourceTree = SOURCE_ROOT; };
+		803D306CDAC2BD3BA04534EA /* juce_AudioProcessorEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioProcessorEditor.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.cpp; sourceTree = SOURCE_ROOT; };
+		8077C8D1C544F458947D693E /* juce_TextLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextLayout.h; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_TextLayout.h; sourceTree = SOURCE_ROOT; };
+		80A612858FA1177A262744C6 /* juce_HyperlinkButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_HyperlinkButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_HyperlinkButton.h; sourceTree = SOURCE_ROOT; };
+		80C1B737D2C2CB519D1787D7 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = System/Library/Frameworks/QTKit.framework; sourceTree = SDKROOT; };
+		80D57E78015C789503FE24B4 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_audio_utils/juce_module_info; sourceTree = SOURCE_ROOT; };
+		80E8C07F5807C65BCDFCCF94 /* juce_AudioSampleBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioSampleBuffer.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioSampleBuffer.cpp; sourceTree = SOURCE_ROOT; };
+		80EEDD40F49120ADBE9DCBDF /* rhd2000datablock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rhd2000datablock.h; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000datablock.h"; sourceTree = SOURCE_ROOT; };
+		811C4D165AD7AABF4055059C /* juce_Expression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Expression.h; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_Expression.h; sourceTree = SOURCE_ROOT; };
+		813CB9DFF788D612A0750FBF /* SpikeSortBoxes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeSortBoxes.cpp; path = ../../Source/Processors/SpikeSortBoxes.cpp; sourceTree = SOURCE_ROOT; };
+		816EB8024DD50DE4B7E84CB8 /* juce_ByteOrder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ByteOrder.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_ByteOrder.h; sourceTree = SOURCE_ROOT; };
+		81D578AA5F277EB0946050E5 /* juce_win32_DragAndDrop.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_DragAndDrop.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_win32_DragAndDrop.cpp; sourceTree = SOURCE_ROOT; };
+		822A504EE33F35F18A7F21AF /* juce_AiffAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AiffAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		82EB2BDE7B9A4D5D945497B9 /* juce_MidiMessageSequence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiMessageSequence.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessageSequence.h; sourceTree = SOURCE_ROOT; };
+		837D266B3F62C3B05C2BC28C /* BinaryData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BinaryData.h; path = ../../JuceLibraryCode/BinaryData.h; sourceTree = SOURCE_ROOT; };
+		83803D96768258DA20710764 /* juce_XmlElement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_XmlElement.h; path = ../../JuceLibraryCode/modules/juce_core/xml/juce_XmlElement.h; sourceTree = SOURCE_ROOT; };
+		83950E9D0D7C100B7DCA0E55 /* juce_TextButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_TextButton.h; sourceTree = SOURCE_ROOT; };
+		83E5EA2AA0CB928889AC80AB /* SpikeDetectorEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDetectorEditor.h; path = ../../Source/Processors/Editors/SpikeDetectorEditor.h; sourceTree = SOURCE_ROOT; };
+		847F6986DFA468BA8D80A531 /* miso-light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file.ttf; name = "miso-light.ttf"; path = "../../Resources/Fonts/miso-light.ttf"; sourceTree = SOURCE_ROOT; };
+		84BED3AADBD3FAB6EFEC323E /* NetworkEventsEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkEventsEditor.h; path = ../../Source/Processors/Editors/NetworkEventsEditor.h; sourceTree = SOURCE_ROOT; };
+		8515A61F1E3BD62B9B95B495 /* juce_audio_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_audio_utils.h; path = ../../JuceLibraryCode/modules/juce_audio_utils/juce_audio_utils.h; sourceTree = SOURCE_ROOT; };
+		8515E367462BEF36233E2447 /* juce_AudioUnitPluginFormat.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_AudioUnitPluginFormat.mm; path = ../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm; sourceTree = SOURCE_ROOT; };
+		8551342E7D16FCA4F9A80BC5 /* juce_AudioSubsectionReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioSubsectionReader.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioSubsectionReader.cpp; sourceTree = SOURCE_ROOT; };
+		85928E2EF1C438EBC9EB07EA /* juce_ImageCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ImageCache.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageCache.cpp; sourceTree = SOURCE_ROOT; };
+		85C3F7CDF87409A56082DF67 /* juce_FileListComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileListComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileListComponent.cpp; sourceTree = SOURCE_ROOT; };
+		86515FD9AD34D6FF96C0D8B6 /* juce_BufferingAudioFormatReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BufferingAudioFormatReader.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_BufferingAudioFormatReader.cpp; sourceTree = SOURCE_ROOT; };
+		86688D712937F3D08918C68B /* SerialInput.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SerialInput.cpp; path = ../../Source/Processors/SerialInput.cpp; sourceTree = SOURCE_ROOT; };
+		8689288B66B16EFB106CB2F4 /* juce_TextInputTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextInputTarget.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_TextInputTarget.h; sourceTree = SOURCE_ROOT; };
+		86E8E44A13F17083ED300BD5 /* juce_ChangeListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ChangeListener.h; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ChangeListener.h; sourceTree = SOURCE_ROOT; };
+		86F4AAFCE3FEB34E325F3020 /* juce_win32_ComSmartPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_win32_ComSmartPtr.h; path = ../../JuceLibraryCode/modules/juce_core/native/juce_win32_ComSmartPtr.h; sourceTree = SOURCE_ROOT; };
+		8751DF970A9E3598683BACAF /* FPGAThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FPGAThread.h; path = ../../Source/Processors/DataThreads/FPGAThread.h; sourceTree = SOURCE_ROOT; };
+		879B0383EF2A8B116903A500 /* juce_ImageCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ImageCache.h; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageCache.h; sourceTree = SOURCE_ROOT; };
+		87B4BA68E49DD11197B7AFDB /* JuceHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JuceHeader.h; path = ../../JuceLibraryCode/JuceHeader.h; sourceTree = SOURCE_ROOT; };
+		880CC7C325EFF665AC3006D2 /* juce_KeyListener.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_KeyListener.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyListener.cpp; sourceTree = SOURCE_ROOT; };
+		881237D5E366342B117C0ED7 /* juce_WildcardFileFilter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_WildcardFileFilter.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_WildcardFileFilter.cpp; sourceTree = SOURCE_ROOT; };
+		8822ADC9DB83FAF39B841E31 /* juce_Font.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Font.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Font.cpp; sourceTree = SOURCE_ROOT; };
+		886E18520E8BD77234E1B686 /* FilterNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FilterNode.h; path = ../../Source/Processors/FilterNode.h; sourceTree = SOURCE_ROOT; };
+		8882F8EBE55F52FA8E519249 /* juce_android_Files.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Files.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_android_Files.cpp; sourceTree = SOURCE_ROOT; };
+		88E5D0906646465409715828 /* juce_PreferencesPanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PreferencesPanel.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_PreferencesPanel.cpp; sourceTree = SOURCE_ROOT; };
+		891B132A0355007B4F37454C /* juce_GraphicsContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_GraphicsContext.h; path = ../../JuceLibraryCode/modules/juce_graphics/contexts/juce_GraphicsContext.h; sourceTree = SOURCE_ROOT; };
+		893E1A681FF162F6C9069F62 /* juce_HashMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_HashMap.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_HashMap.h; sourceTree = SOURCE_ROOT; };
+		894C0CAC31D382477E7A122E /* juce_PluginDirectoryScanner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PluginDirectoryScanner.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginDirectoryScanner.h; sourceTree = SOURCE_ROOT; };
+		89B0B267EF0A2A19A082EB86 /* juce_android_Fonts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Fonts.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_android_Fonts.cpp; sourceTree = SOURCE_ROOT; };
+		8A026DB58E3555F7B070DA61 /* juce_MemoryBlock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MemoryBlock.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_MemoryBlock.h; sourceTree = SOURCE_ROOT; };
+		8A91849BE6B96EB8C0663469 /* LfpDisplayEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpDisplayEditor.cpp; path = ../../Source/Processors/Editors/LfpDisplayEditor.cpp; sourceTree = SOURCE_ROOT; };
+		8A989F74B1957BCB3B9BA398 /* rhd2000registers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rhd2000registers.h; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000registers.h"; sourceTree = SOURCE_ROOT; };
+		8AA1009705E8A9531C707ED1 /* juce_JSON.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_JSON.cpp; path = ../../JuceLibraryCode/modules/juce_core/json/juce_JSON.cpp; sourceTree = SOURCE_ROOT; };
+		8AE2DDA47B2DFDEEEF69B12F /* FileReaderIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = FileReaderIcon.png; path = ../../Resources/Images/Icons/FileReaderIcon.png; sourceTree = SOURCE_ROOT; };
+		8B0C9D288C428BA5D956AE13 /* juce_MidiMessage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiMessage.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessage.cpp; sourceTree = SOURCE_ROOT; };
+		8B49B07BC7534B247ADC756A /* juce_WeakReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_WeakReference.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_WeakReference.h; sourceTree = SOURCE_ROOT; };
+		8B745839B225E44C9EB5C6FA /* ParameterEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ParameterEditor.h; path = ../../Source/Processors/Editors/ParameterEditor.h; sourceTree = SOURCE_ROOT; };
+		8B7EB54E1F773517A65D935C /* juce_DropShadowEffect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DropShadowEffect.h; path = ../../JuceLibraryCode/modules/juce_graphics/effects/juce_DropShadowEffect.h; sourceTree = SOURCE_ROOT; };
+		8B8C25A8261F0A21369FB9D8 /* PeriStimulusTimeHistogramEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PeriStimulusTimeHistogramEditor.cpp; path = ../../Source/Processors/Editors/PeriStimulusTimeHistogramEditor.cpp; sourceTree = SOURCE_ROOT; };
+		8B9C0831BE4E09B7C0078B7E /* ArduinoOutputEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ArduinoOutputEditor.h; path = ../../Source/Processors/Editors/ArduinoOutputEditor.h; sourceTree = SOURCE_ROOT; };
+		8C077447B0DFC739C7D2E437 /* juce_MemoryInputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MemoryInputStream.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryInputStream.h; sourceTree = SOURCE_ROOT; };
+		8C268C3D0B8EC2BB8953E7F7 /* juce_ModifierKeys.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ModifierKeys.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_ModifierKeys.cpp; sourceTree = SOURCE_ROOT; };
+		8C38407151E149A7E2A15801 /* juce_SHA256.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SHA256.h; path = ../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_SHA256.h; sourceTree = SOURCE_ROOT; };
+		8C3B6865F2053C80A6E692F1 /* juce_Label.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Label.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Label.cpp; sourceTree = SOURCE_ROOT; };
+		8CAEF601359DB6CB50E89D1A /* juce_ActionBroadcaster.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ActionBroadcaster.cpp; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ActionBroadcaster.cpp; sourceTree = SOURCE_ROOT; };
+		8D4FBD30E1C9EC0DA749BC83 /* juce_DropShadower.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DropShadower.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_DropShadower.cpp; sourceTree = SOURCE_ROOT; };
+		8D6A419A4678968762A59B28 /* juce_BufferingAudioFormatReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BufferingAudioFormatReader.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_BufferingAudioFormatReader.h; sourceTree = SOURCE_ROOT; };
+		8D9DD6147EC0553B092FD367 /* juce_RSAKey.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RSAKey.cpp; path = ../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_RSAKey.cpp; sourceTree = SOURCE_ROOT; };
+		8E02668CAA496759B1F31468 /* NetworkSink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkSink.h; path = ../../Source/Processors/NetworkSink.h; sourceTree = SOURCE_ROOT; };
+		8E61792F6D6FC75CF18095CC /* juce_AudioPluginFormatManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioPluginFormatManager.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.h; sourceTree = SOURCE_ROOT; };
+		8E696460A8A860B7A4044DFC /* juce_WebBrowserComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_WebBrowserComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h; sourceTree = SOURCE_ROOT; };
+		8E78AAA58721DE609F6FFC61 /* juce_DragAndDropContainer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DragAndDropContainer.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.cpp; sourceTree = SOURCE_ROOT; };
+		8EB76CA261F62A89B3D25F81 /* juce_Thread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Thread.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_Thread.h; sourceTree = SOURCE_ROOT; };
+		8F0549459970F529587D6CDD /* juce_WindowsMediaAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_WindowsMediaAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WindowsMediaAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		8F08D5488CE147D693BA21E2 /* juce_osx_ObjCHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_osx_ObjCHelpers.h; path = ../../JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h; sourceTree = SOURCE_ROOT; };
+		8F29CAC0059E3697A5A3652F /* juce_URL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_URL.cpp; path = ../../JuceLibraryCode/modules/juce_core/network/juce_URL.cpp; sourceTree = SOURCE_ROOT; };
+		8F3C158B4FB92CFC48324896 /* juce_SelectedItemSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SelectedItemSet.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_SelectedItemSet.h; sourceTree = SOURCE_ROOT; };
+		8F7B13BF318C11900A2277DD /* juce_XmlDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_XmlDocument.h; path = ../../JuceLibraryCode/modules/juce_core/xml/juce_XmlDocument.h; sourceTree = SOURCE_ROOT; };
+		900C10C1DB76331250A04557 /* tictoc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = tictoc.h; path = ../../Source/Processors/tictoc.h; sourceTree = SOURCE_ROOT; };
+		901C720965646841A94EB099 /* juce_ActiveXControlComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ActiveXControlComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/embedding/juce_ActiveXControlComponent.h; sourceTree = SOURCE_ROOT; };
+		901DB6D5FE9134F2ADB9AE46 /* juce_ChildProcess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ChildProcess.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ChildProcess.h; sourceTree = SOURCE_ROOT; };
+		90607327D7A1BB3C2C4E9264 /* juce_Random.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Random.h; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_Random.h; sourceTree = SOURCE_ROOT; };
+		9069CE21141F5A4C5721BCF3 /* juce_audio_devices.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_audio_devices.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/juce_audio_devices.h; sourceTree = SOURCE_ROOT; };
+		9070DC685E666BBFC2E19DA9 /* juce_PropertyPanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PropertyPanel.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyPanel.cpp; sourceTree = SOURCE_ROOT; };
+		90AD1B6A2293F625D786507A /* juce_MathsFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MathsFunctions.h; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_MathsFunctions.h; sourceTree = SOURCE_ROOT; };
+		90F2939F533A26AC021E42B1 /* juce_ColourGradient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ColourGradient.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_ColourGradient.cpp; sourceTree = SOURCE_ROOT; };
+		911CCC0A579792DC56807DEC /* juce_DrawableRectangle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DrawableRectangle.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableRectangle.cpp; sourceTree = SOURCE_ROOT; };
+		9136BD46BE1E28A96FBBD440 /* SignalGeneratorEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SignalGeneratorEditor.cpp; path = ../../Source/Processors/Editors/SignalGeneratorEditor.cpp; sourceTree = SOURCE_ROOT; };
+		917988BE74F2180BFC0583A3 /* juce_MissingGLDefinitions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MissingGLDefinitions.h; path = ../../JuceLibraryCode/modules/juce_opengl/native/juce_MissingGLDefinitions.h; sourceTree = SOURCE_ROOT; };
+		918837CC0447C50774036664 /* juce_StretchableLayoutResizerBar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_StretchableLayoutResizerBar.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutResizerBar.cpp; sourceTree = SOURCE_ROOT; };
+		91D7B1F8B94AE9CFCC53771F /* EventDetector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EventDetector.h; path = ../../Source/Processors/EventDetector.h; sourceTree = SOURCE_ROOT; };
+		9200FC900D22733AE716C364 /* juce_CharPointer_UTF16.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CharPointer_UTF16.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_UTF16.h; sourceTree = SOURCE_ROOT; };
+		9215DC26F511C58DEE009209 /* FileReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FileReader.cpp; path = ../../Source/Processors/FileReader.cpp; sourceTree = SOURCE_ROOT; };
+		921F5D04122F324502DA4E75 /* juce_TextEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TextEditor.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TextEditor.cpp; sourceTree = SOURCE_ROOT; };
+		92528D6653802FACF658D8EA /* FPGAOutputEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FPGAOutputEditor.h; path = ../../Source/Processors/Editors/FPGAOutputEditor.h; sourceTree = SOURCE_ROOT; };
+		92602D7166325C7232B85EDD /* DataThread.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DataThread.cpp; path = ../../Source/Processors/DataThreads/DataThread.cpp; sourceTree = SOURCE_ROOT; };
+		927AE946A1371490D809876E /* juce_MidiMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiMessage.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessage.h; sourceTree = SOURCE_ROOT; };
+		927FCF11005E78D499DAF197 /* juce_CallOutBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CallOutBox.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_CallOutBox.h; sourceTree = SOURCE_ROOT; };
+		92CB21BEE17D1DD03106AD87 /* ofSerial.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ofSerial.h; path = ../../Source/Processors/Serial/ofSerial.h; sourceTree = SOURCE_ROOT; };
+		92E07CA13571893873565AC7 /* juce_SplashScreen.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_SplashScreen.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_SplashScreen.cpp; sourceTree = SOURCE_ROOT; };
+		92E3405CB31ACFE3F80BBAD4 /* OpenEphysBoardLogoBlack.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = OpenEphysBoardLogoBlack.png; path = ../../Resources/Images/Icons/OpenEphysBoardLogoBlack.png; sourceTree = SOURCE_ROOT; };
+		92EC6BB8A8C4C5A61F43C233 /* juce_ToggleButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ToggleButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToggleButton.h; sourceTree = SOURCE_ROOT; };
+		9360657FDE33FA37D80075D1 /* juce_InterprocessConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_InterprocessConnection.cpp; path = ../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnection.cpp; sourceTree = SOURCE_ROOT; };
+		9380932BED279F91B8C1C04B /* juce_Rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Rectangle.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Rectangle.h; sourceTree = SOURCE_ROOT; };
+		93EFC1AA800FC5DA2F04A213 /* RadioButtons_neutral-04.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-04.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-04.png"; sourceTree = SOURCE_ROOT; };
+		93F842958BCE6A9E09862CF7 /* juce_LADSPAPluginFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LADSPAPluginFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.h; sourceTree = SOURCE_ROOT; };
+		9428D7423971764AC0BA9CB7 /* State.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = State.h; path = ../../Source/Dsp/State.h; sourceTree = SOURCE_ROOT; };
+		945DC754F2EACDFFB7926DE8 /* juce_FileChooser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileChooser.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooser.h; sourceTree = SOURCE_ROOT; };
+		946FDFCA107B3F4C74C471B4 /* juce_InterprocessConnectionServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_InterprocessConnectionServer.h; path = ../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnectionServer.h; sourceTree = SOURCE_ROOT; };
+		94AED5D544719B438B3EE723 /* LogWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LogWindow.cpp; path = ../../Source/UI/LogWindow.cpp; sourceTree = SOURCE_ROOT; };
+		94BD861806F8EA598EC09370 /* juce_ResizableCornerComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ResizableCornerComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableCornerComponent.cpp; sourceTree = SOURCE_ROOT; };
+		95B57108E929DD11F898B7B1 /* FileReaderThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileReaderThread.h; path = ../../Source/Processors/DataThreads/FileReaderThread.h; sourceTree = SOURCE_ROOT; };
+		95EC6B1536DC65070D0ADCEE /* juce_ListBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ListBox.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ListBox.h; sourceTree = SOURCE_ROOT; };
+		967138FE8A086734ADC8CABB /* juce_Value.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Value.cpp; path = ../../JuceLibraryCode/modules/juce_data_structures/values/juce_Value.cpp; sourceTree = SOURCE_ROOT; };
+		96AED479B95D4EC31604D604 /* PeriStimulusTimeHistogramNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PeriStimulusTimeHistogramNode.cpp; path = ../../Source/Processors/PeriStimulusTimeHistogramNode.cpp; sourceTree = SOURCE_ROOT; };
+		96E99CD031BD069997E387FE /* juce_MidiBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiBuffer.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiBuffer.cpp; sourceTree = SOURCE_ROOT; };
+		96F2A45DCB9BB53844B0ED4F /* juce_CodeTokeniser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CodeTokeniser.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CodeTokeniser.h; sourceTree = SOURCE_ROOT; };
+		971E49A78543AADB8CA1D2B7 /* juce_OpenGLTexture.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLTexture.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLTexture.cpp; sourceTree = SOURCE_ROOT; };
+		9731D54410B06C1000370316 /* juce_Image.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Image.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_Image.cpp; sourceTree = SOURCE_ROOT; };
+		97431963DB8D535DEDA9AD47 /* juce_core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_core.h; path = ../../JuceLibraryCode/modules/juce_core/juce_core.h; sourceTree = SOURCE_ROOT; };
+		97C4F046D88561EEE245BE99 /* RadioButtons_selected_over-05.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-05.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-05.png"; sourceTree = SOURCE_ROOT; };
+		982E1A954C316920557F029C /* juce_android_Network.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Network.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_android_Network.cpp; sourceTree = SOURCE_ROOT; };
+		984BC60C0AFF3EDED692FA01 /* GenericEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GenericEditor.h; path = ../../Source/Processors/Editors/GenericEditor.h; sourceTree = SOURCE_ROOT; };
+		985F2B5047476B272B1A4BD4 /* EventNodeEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EventNodeEditor.h; path = ../../Source/Processors/Editors/EventNodeEditor.h; sourceTree = SOURCE_ROOT; };
+		988F01B2B51B2AC7293D07DA /* juce_MidiMessageCollector.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiMessageCollector.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiMessageCollector.cpp; sourceTree = SOURCE_ROOT; };
+		98C81B13A0C34D8A4E93ADD1 /* juce_ToolbarButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ToolbarButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToolbarButton.h; sourceTree = SOURCE_ROOT; };
+		98D2D452F48C86F47FB90BAD /* juce_PNGLoader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PNGLoader.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/image_formats/juce_PNGLoader.cpp; sourceTree = SOURCE_ROOT; };
+		996E4EA6B532E4E436F50243 /* juce_DeletedAtShutdown.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DeletedAtShutdown.h; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_DeletedAtShutdown.h; sourceTree = SOURCE_ROOT; };
+		9978BC2A359BC506F69E545F /* juce_SystemStats.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_SystemStats.cpp; path = ../../JuceLibraryCode/modules/juce_core/system/juce_SystemStats.cpp; sourceTree = SOURCE_ROOT; };
+		99E1BC08B886CFDD2CCFD462 /* open-ephys.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "open-ephys.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A21A229CFACC67E31F4F727 /* RBJ.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RBJ.cpp; path = ../../Source/Dsp/RBJ.cpp; sourceTree = SOURCE_ROOT; };
+		9A29EBC10219D89919E12FCB /* juce_ComponentDragger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComponentDragger.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_ComponentDragger.h; sourceTree = SOURCE_ROOT; };
+		9B178E9015CF469CFD41BC79 /* juce_BufferedInputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BufferedInputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_BufferedInputStream.cpp; sourceTree = SOURCE_ROOT; };
+		9B4EA34E8F90B7CC77694B7E /* juce_DialogWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DialogWindow.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DialogWindow.h; sourceTree = SOURCE_ROOT; };
+		9B5D838CB6224E82C9B36AA3 /* juce_android_Misc.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Misc.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_android_Misc.cpp; sourceTree = SOURCE_ROOT; };
+		9B9EDDFA0AE4991BC7FC7263 /* MessageCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MessageCenter.h; path = ../../Source/UI/MessageCenter.h; sourceTree = SOURCE_ROOT; };
+		9BC055494F9FEE3F90630541 /* Channel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Channel.cpp; path = ../../Source/Processors/Channel.cpp; sourceTree = SOURCE_ROOT; };
+		9BE34B4DECBF4EBFD27C9792 /* juce_AudioIODeviceType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioIODeviceType.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp; sourceTree = SOURCE_ROOT; };
+		9C21DBFB38865E5AFE367C6F /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		9C39C584DA6F507E773687EE /* ReferenceNodeEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ReferenceNodeEditor.cpp; path = ../../Source/Processors/Editors/ReferenceNodeEditor.cpp; sourceTree = SOURCE_ROOT; };
+		9C4342320D2DD65E2BD6351C /* juce_ToolbarButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ToolbarButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToolbarButton.cpp; sourceTree = SOURCE_ROOT; };
+		9C5F99C38CC703FBB871401A /* juce_ReverbAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ReverbAudioSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_ReverbAudioSource.cpp; sourceTree = SOURCE_ROOT; };
+		9C701D5A7298B83CE05ECEBB /* juce_TextEditorKeyMapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextEditorKeyMapper.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_TextEditorKeyMapper.h; sourceTree = SOURCE_ROOT; };
+		9C864C7DBAF37CD0719996A9 /* juce_FileBrowserListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileBrowserListener.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileBrowserListener.h; sourceTree = SOURCE_ROOT; };
+		9C96B0CBFF3D34885BB8B020 /* juce_FileDragAndDropTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileDragAndDropTarget.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_FileDragAndDropTarget.h; sourceTree = SOURCE_ROOT; };
+		9CEDA04DB321755AF74D6FAF /* ChebyshevII.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChebyshevII.h; path = ../../Source/Dsp/ChebyshevII.h; sourceTree = SOURCE_ROOT; };
+		9D050A509BEB9E3879DA35C6 /* ostrich.ttf */ = {isa = PBXFileReference; lastKnownFileType = file.ttf; name = ostrich.ttf; path = ../../Resources/Fonts/ostrich.ttf; sourceTree = SOURCE_ROOT; };
+		9D13E0F774807670270F4790 /* juce_Drawable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Drawable.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_Drawable.h; sourceTree = SOURCE_ROOT; };
+		9D2510B5E6180456C53A455E /* juce_ComboBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComboBox.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ComboBox.cpp; sourceTree = SOURCE_ROOT; };
+		9D78F50147005EDB0E89E2B4 /* FPGAOutput.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FPGAOutput.cpp; path = ../../Source/Processors/FPGAOutput.cpp; sourceTree = SOURCE_ROOT; };
+		9E25AA6C671FB8DCA6E30A43 /* NetworkSinkProcotol.pb.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkSinkProcotol.pb.h; path = ../../Source/Processors/NetworkSinkProcotol.pb.h; sourceTree = SOURCE_ROOT; };
+		9EAAE3C0BFF3D753C375A5FC /* juce_DrawableImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DrawableImage.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableImage.cpp; sourceTree = SOURCE_ROOT; };
+		9EC1C0A21FDCB81BE0EA60EA /* juce_ApplicationBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ApplicationBase.h; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_ApplicationBase.h; sourceTree = SOURCE_ROOT; };
+		9F2853D1A12B686BE3BA2C61 /* juce_OpenGLImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLImage.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLImage.h; sourceTree = SOURCE_ROOT; };
+		9F2BCD132F453B9D9EF09F15 /* RadioButtons-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons-01.png"; path = "../../Resources/Images/Icons/RadioButtons-01.png"; sourceTree = SOURCE_ROOT; };
+		9F3B3184EC6D42CEA35D6ED8 /* EditorViewportButtons.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EditorViewportButtons.cpp; path = ../../Source/UI/EditorViewportButtons.cpp; sourceTree = SOURCE_ROOT; };
+		9F577889CB6C54A2F7B1CA80 /* PracticalSocket.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PracticalSocket.cpp; path = ../../Source/Network/PracticalSocket.cpp; sourceTree = SOURCE_ROOT; };
+		9F61AF101B43110732BB8814 /* juce_AffineTransform.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AffineTransform.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_AffineTransform.cpp; sourceTree = SOURCE_ROOT; };
+		9F6664EB2C39D224C6BCC75E /* juce_Viewport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Viewport.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_Viewport.h; sourceTree = SOURCE_ROOT; };
+		9F845E950F19FEC4E6C88F91 /* juce_Typeface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Typeface.h; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Typeface.h; sourceTree = SOURCE_ROOT; };
+		9FC97A1CFD250F7215B4E397 /* juce_mac_AudioCDBurner.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_AudioCDBurner.mm; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_AudioCDBurner.mm; sourceTree = SOURCE_ROOT; };
+		9FDCF1E2B4651E58240400B9 /* juce_TextEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextEditor.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TextEditor.h; sourceTree = SOURCE_ROOT; };
+		9FFD9560522567A033226BD7 /* PhaseDetector.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PhaseDetector.cpp; path = ../../Source/Processors/PhaseDetector.cpp; sourceTree = SOURCE_ROOT; };
+		A0D768F1B92568344DAC9F0B /* juce_win32_Fonts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Fonts.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_Fonts.cpp; sourceTree = SOURCE_ROOT; };
+		A0E3B98412D88921BB0AA58E /* AudioEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioEditor.h; path = ../../Source/Processors/Editors/AudioEditor.h; sourceTree = SOURCE_ROOT; };
+		A15596CDCC27B86FC070D7FA /* juce_Desktop.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Desktop.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Desktop.cpp; sourceTree = SOURCE_ROOT; };
+		A17E8162EC7A0E513DDEB23C /* juce_PluginDescription.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PluginDescription.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_PluginDescription.cpp; sourceTree = SOURCE_ROOT; };
+		A19C4BB4BD69D4351B344A17 /* juce_MenuBarComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MenuBarComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarComponent.cpp; sourceTree = SOURCE_ROOT; };
+		A234B2D091071A1B710E884B /* ChannelMappingNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelMappingNode.h; path = ../../Source/Processors/ChannelMappingNode.h; sourceTree = SOURCE_ROOT; };
+		A252FE4E6A360CBC4AF694B3 /* SpikeDetectorEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDetectorEditor.cpp; path = ../../Source/Processors/Editors/SpikeDetectorEditor.cpp; sourceTree = SOURCE_ROOT; };
+		A3B6D091280930A016DF8FDA /* juce_OpenGLContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLContext.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLContext.h; sourceTree = SOURCE_ROOT; };
+		A3CAB6B56641ED68D9784348 /* PipelineA-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "PipelineA-01.png"; path = "../../Resources/Images/Buttons/PipelineA-01.png"; sourceTree = SOURCE_ROOT; };
+		A3FB0EA0264580F6B00D993B /* RHD2000Thread.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RHD2000Thread.cpp; path = ../../Source/Processors/DataThreads/RHD2000Thread.cpp; sourceTree = SOURCE_ROOT; };
+		A41AEA0D3ACB2B1E6713AE08 /* juce_OpenGLGraphicsContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLGraphicsContext.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.h; sourceTree = SOURCE_ROOT; };
+		A41C5A4CD5CF8EEFF993A8B1 /* MathSupplement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MathSupplement.h; path = ../../Source/Dsp/MathSupplement.h; sourceTree = SOURCE_ROOT; };
+		A4E2CAAF556D557B24182414 /* RecordNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordNode.cpp; path = ../../Source/Processors/RecordNode.cpp; sourceTree = SOURCE_ROOT; };
+		A4FC82A8339698B6C1AC5F18 /* juce_LookAndFeel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LookAndFeel.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h; sourceTree = SOURCE_ROOT; };
+		A512C5B237A77EF6FB8E11A0 /* BinaryData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BinaryData.cpp; path = ../../JuceLibraryCode/BinaryData.cpp; sourceTree = SOURCE_ROOT; };
+		A540869F28EE158A0A348C28 /* juce_ImageConvolutionKernel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ImageConvolutionKernel.h; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageConvolutionKernel.h; sourceTree = SOURCE_ROOT; };
+		A54886FC74BE0DDC74094EF5 /* juce_DragAndDropContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DragAndDropContainer.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.h; sourceTree = SOURCE_ROOT; };
+		A5C9A0FBD818AEF57858FB31 /* juce_AffineTransform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AffineTransform.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_AffineTransform.h; sourceTree = SOURCE_ROOT; };
+		A5E8E0CF6DA1AEAEE9D872DE /* juce_StandardHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_StandardHeader.h; path = ../../JuceLibraryCode/modules/juce_core/system/juce_StandardHeader.h; sourceTree = SOURCE_ROOT; };
+		A65F5AD9D0C532EBB3A2067D /* juce_GZIPDecompressorInputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GZIPDecompressorInputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPDecompressorInputStream.cpp; sourceTree = SOURCE_ROOT; };
+		A6736FBDFBB0B82E22D2B1C0 /* juce_ThreadLocalValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ThreadLocalValue.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ThreadLocalValue.h; sourceTree = SOURCE_ROOT; };
+		A6A579E4E4AEA865BC71148C /* juce_core.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_core.mm; path = ../../JuceLibraryCode/modules/juce_core/juce_core.mm; sourceTree = SOURCE_ROOT; };
+		A708E79EB9EB7CC44030F5D5 /* juce_ColourGradient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ColourGradient.h; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_ColourGradient.h; sourceTree = SOURCE_ROOT; };
+		A764EF4F46F472715B250E41 /* muteon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = muteon.png; path = ../../Resources/Images/Buttons/muteon.png; sourceTree = SOURCE_ROOT; };
+		A769611E9CBFC127AF5AFB0D /* juce_Time.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Time.cpp; path = ../../JuceLibraryCode/modules/juce_core/time/juce_Time.cpp; sourceTree = SOURCE_ROOT; };
+		A77E8538ED93AAADC9FE2646 /* NetworkEventsEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkEventsEditor.cpp; path = ../../Source/Processors/Editors/NetworkEventsEditor.cpp; sourceTree = SOURCE_ROOT; };
+		A7875D5F8D2A632C99791002 /* juce_ComboBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComboBox.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ComboBox.h; sourceTree = SOURCE_ROOT; };
+		A7D4C9E3ED3763847C087F46 /* SpikeDisplayCanvas.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDisplayCanvas.cpp; path = ../../Source/Processors/Visualization/SpikeDisplayCanvas.cpp; sourceTree = SOURCE_ROOT; };
+		A7FE538FF09AC8A58DE8F1BD /* RadioButtons_selected-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-02.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-02.png"; sourceTree = SOURCE_ROOT; };
+		A8B4D80D55E48F50809DC5E4 /* juce_ios_Windowing.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_ios_Windowing.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_ios_Windowing.mm; sourceTree = SOURCE_ROOT; };
+		A93F302B8D91A997F54D231B /* juce_MarkerList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MarkerList.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_MarkerList.h; sourceTree = SOURCE_ROOT; };
+		A950BD747F318BF6D555CB06 /* juce_mac_Files.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_Files.mm; path = ../../JuceLibraryCode/modules/juce_core/native/juce_mac_Files.mm; sourceTree = SOURCE_ROOT; };
+		A95D898F0998F4609E992B5F /* Elliptic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Elliptic.h; path = ../../Source/Dsp/Elliptic.h; sourceTree = SOURCE_ROOT; };
+		A98A22CF5F208ED6DBE08063 /* ResamplingNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ResamplingNode.cpp; path = ../../Source/Processors/ResamplingNode.cpp; sourceTree = SOURCE_ROOT; };
+		A9A0BC63EB466C75D1B9326A /* juce_MidiMessageCollector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiMessageCollector.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiMessageCollector.h; sourceTree = SOURCE_ROOT; };
+		A9F5A8F835A1A734DF7F6775 /* juce_ChoicePropertyComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ChoicePropertyComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ChoicePropertyComponent.cpp; sourceTree = SOURCE_ROOT; };
+		AA3209223925B66A97AB4509 /* juce_TooltipClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TooltipClient.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_TooltipClient.h; sourceTree = SOURCE_ROOT; };
+		AA3DAC9A4A3FF9E7D279FB23 /* RadioButtons_selected-03.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-03.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-03.png"; sourceTree = SOURCE_ROOT; };
+		AA7F6609B897B9E134377A62 /* cpmono_light.otf */ = {isa = PBXFileReference; lastKnownFileType = file.otf; name = cpmono_light.otf; path = ../../Resources/Fonts/cpmono_light.otf; sourceTree = SOURCE_ROOT; };
+		AADBA8C0AD524CE677428AFF /* juce_GlowEffect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_GlowEffect.h; path = ../../JuceLibraryCode/modules/juce_graphics/effects/juce_GlowEffect.h; sourceTree = SOURCE_ROOT; };
+		AB4C7059669AC385B02179C1 /* juce_FileLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileLogger.h; path = ../../JuceLibraryCode/modules/juce_core/logging/juce_FileLogger.h; sourceTree = SOURCE_ROOT; };
+		ABA3FCD5D762336535D56D94 /* juce_ScopedLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ScopedLock.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ScopedLock.h; sourceTree = SOURCE_ROOT; };
+		AC116E6590D49AB2EF19CB9E /* juce_OpenGLImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLImage.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLImage.cpp; sourceTree = SOURCE_ROOT; };
+		AC2CFF4DA5CE431FCC628BA3 /* ChebyshevI.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChebyshevI.cpp; path = ../../Source/Dsp/ChebyshevI.cpp; sourceTree = SOURCE_ROOT; };
+		ACA28D2B1FECD2C57F0250A6 /* juce_DirectoryContentsDisplayComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DirectoryContentsDisplayComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsDisplayComponent.h; sourceTree = SOURCE_ROOT; };
+		ACAE4A2D65AAC6A36DA9DBCF /* juce_OggVorbisAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OggVorbisAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		AD1950C0733B3470777BF861 /* juce_BubbleMessageComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BubbleMessageComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_BubbleMessageComponent.h; sourceTree = SOURCE_ROOT; };
+		AD7311B9A37893CA0C4BC119 /* juce_ZipFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ZipFile.cpp; path = ../../JuceLibraryCode/modules/juce_core/zip/juce_ZipFile.cpp; sourceTree = SOURCE_ROOT; };
+		AD7D35FCD8CF66B6C393A7F7 /* juce_FileBrowserComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileBrowserComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.h; sourceTree = SOURCE_ROOT; };
+		AD960F561259904BA68DDA73 /* juce_MemoryMappedFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MemoryMappedFile.h; path = ../../JuceLibraryCode/modules/juce_core/files/juce_MemoryMappedFile.h; sourceTree = SOURCE_ROOT; };
+		ADCB42E4C5641007A4B78025 /* SpikeObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeObject.h; path = ../../Source/Processors/Visualization/SpikeObject.h; sourceTree = SOURCE_ROOT; };
+		AE1EA04666EAD34D0CA0373D /* juce_opengl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_opengl.h; path = ../../JuceLibraryCode/modules/juce_opengl/juce_opengl.h; sourceTree = SOURCE_ROOT; };
+		AE3D7946F13CE32AE41DD1B7 /* MatlabLikePlot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MatlabLikePlot.h; path = ../../Source/Processors/Visualization/MatlabLikePlot.h; sourceTree = SOURCE_ROOT; };
+		AE6786E4659DAC92F52E9FA3 /* juce_Toolbar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Toolbar.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Toolbar.h; sourceTree = SOURCE_ROOT; };
+		AE9359DBA841F88EF3DA9700 /* juce_FileSearchPath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileSearchPath.h; path = ../../JuceLibraryCode/modules/juce_core/files/juce_FileSearchPath.h; sourceTree = SOURCE_ROOT; };
+		AEC2DABFC0517B4BE0CD704C /* juce_mac_AudioCDReader.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_AudioCDReader.mm; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_AudioCDReader.mm; sourceTree = SOURCE_ROOT; };
+		AEF53FD0FBBFF5242EDD7032 /* juce_Viewport.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Viewport.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_Viewport.cpp; sourceTree = SOURCE_ROOT; };
+		AF1F3010721A6B29062E4838 /* juce_LowLevelGraphicsContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LowLevelGraphicsContext.h; path = ../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsContext.h; sourceTree = SOURCE_ROOT; };
+		AF3E3AE70160C3392B237316 /* juce_mac_CoreAudio.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_mac_CoreAudio.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp; sourceTree = SOURCE_ROOT; };
+		AF594F191BDCC1FFF2F31204 /* ISCAN.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ISCAN.h; path = ../../Source/Processors/ISCAN.h; sourceTree = SOURCE_ROOT; };
+		AF7106E30ED950436CCEC712 /* juce_freetype_Fonts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_freetype_Fonts.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_freetype_Fonts.cpp; sourceTree = SOURCE_ROOT; };
+		AF8ADA74003E96998A5E4404 /* juce_Typeface.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Typeface.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_Typeface.cpp; sourceTree = SOURCE_ROOT; };
+		AFB684CE06F9256324EE0B4C /* juce_FillType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FillType.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_FillType.cpp; sourceTree = SOURCE_ROOT; };
+		AFE835E175F7159E1E7C6CC7 /* juce_CharacterFunctions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CharacterFunctions.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_CharacterFunctions.cpp; sourceTree = SOURCE_ROOT; };
+		B00A9C0BAD3AF9F48E36A38F /* juce_MouseListener.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MouseListener.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseListener.cpp; sourceTree = SOURCE_ROOT; };
+		B021D393D0E2625741512320 /* juce_RenderingHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RenderingHelpers.h; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_RenderingHelpers.h; sourceTree = SOURCE_ROOT; };
+		B04D87ED6AA4897B6CD3CCF6 /* AudioComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioComponent.cpp; path = ../../Source/Audio/AudioComponent.cpp; sourceTree = SOURCE_ROOT; };
+		B081687E52C6A5157CFCCB17 /* cpmono-black-serialized */ = {isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-black-serialized"; path = "../../Resources/Fonts/cpmono-black-serialized"; sourceTree = SOURCE_ROOT; };
+		B083B1375828610D55F12CF3 /* ChannelMappingEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChannelMappingEditor.cpp; path = ../../Source/Processors/Editors/ChannelMappingEditor.cpp; sourceTree = SOURCE_ROOT; };
+		B0A076D9536B6754F34E4606 /* juce_win32_ASIO.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_ASIO.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_ASIO.cpp; sourceTree = SOURCE_ROOT; };
+		B0DCDCB162FDBF972FA5B548 /* juce_mac_MessageManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_MessageManager.mm; path = ../../JuceLibraryCode/modules/juce_events/native/juce_mac_MessageManager.mm; sourceTree = SOURCE_ROOT; };
+		B0E8FAD5AC445F612E3468B9 /* FilterNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FilterNode.cpp; path = ../../Source/Processors/FilterNode.cpp; sourceTree = SOURCE_ROOT; };
+		B1082A8A306A1947F5B0E5FC /* Splitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Splitter.h; path = ../../Source/Processors/Utilities/Splitter.h; sourceTree = SOURCE_ROOT; };
+		B113BC1061788A9ECB1337C5 /* juce_OpenGLGraphicsContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLGraphicsContext.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.cpp; sourceTree = SOURCE_ROOT; };
+		B11E5B5E4483AF89E6DCBAB3 /* juce_ImageButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ImageButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ImageButton.cpp; sourceTree = SOURCE_ROOT; };
+		B123E2F4439DAD65196A2A9D /* juce_ProgressBar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ProgressBar.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ProgressBar.cpp; sourceTree = SOURCE_ROOT; };
+		B13BDA434DEF56BB48B26896 /* miso-serialized */ = {isa = PBXFileReference; lastKnownFileType = file; name = "miso-serialized"; path = "../../Resources/Fonts/miso-serialized"; sourceTree = SOURCE_ROOT; };
+		B174EBEF82212C8624300F59 /* juce_AudioPluginFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioPluginFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/format/juce_AudioPluginFormat.h; sourceTree = SOURCE_ROOT; };
+		B17AA637E5C357FACC38EBB7 /* juce_SHA256.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_SHA256.cpp; path = ../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_SHA256.cpp; sourceTree = SOURCE_ROOT; };
+		B1887A7D2E27FF4DD03D16C1 /* DefaultDataSource.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = DefaultDataSource.png; path = ../../Resources/Images/Icons/DefaultDataSource.png; sourceTree = SOURCE_ROOT; };
+		B1A8C18C6E4B3572B8B750AD /* juce_MultiTimer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MultiTimer.cpp; path = ../../JuceLibraryCode/modules/juce_events/timers/juce_MultiTimer.cpp; sourceTree = SOURCE_ROOT; };
+		B1ECBE9C48227CBDB16E3702 /* juce_ShapeButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ShapeButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ShapeButton.cpp; sourceTree = SOURCE_ROOT; };
+		B2017626F9A05C8C0EBE9B7E /* juce_MD5.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MD5.cpp; path = ../../JuceLibraryCode/modules/juce_cryptography/hashing/juce_MD5.cpp; sourceTree = SOURCE_ROOT; };
+		B20469D88488F0809126CC80 /* juce_audio_processors.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_audio_processors.mm; path = ../../JuceLibraryCode/modules/juce_audio_processors/juce_audio_processors.mm; sourceTree = SOURCE_ROOT; };
+		B2241E3C5C9F93389586F357 /* juce_DirectoryIterator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DirectoryIterator.h; path = ../../JuceLibraryCode/modules/juce_core/files/juce_DirectoryIterator.h; sourceTree = SOURCE_ROOT; };
+		B23E6EBB5F99CF7FC72FAC4E /* VisualizerEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VisualizerEditor.h; path = ../../Source/Processors/Editors/VisualizerEditor.h; sourceTree = SOURCE_ROOT; };
+		B24098EC4FD79D5EDC9383EC /* juce_Initialisation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Initialisation.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/application/juce_Initialisation.h; sourceTree = SOURCE_ROOT; };
+		B27F558F42AC78F0E564B5AF /* AudioNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioNode.cpp; path = ../../Source/Processors/AudioNode.cpp; sourceTree = SOURCE_ROOT; };
+		B2EF409A1F459E964756BA7C /* juce_FileInputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileInputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/files/juce_FileInputStream.cpp; sourceTree = SOURCE_ROOT; };
+		B2FA9CC4754E136F22281176 /* juce_ImageEffectFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ImageEffectFilter.h; path = ../../JuceLibraryCode/modules/juce_graphics/effects/juce_ImageEffectFilter.h; sourceTree = SOURCE_ROOT; };
+		B3BAC48D01C49D8727D08097 /* juce_ListBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ListBox.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ListBox.cpp; sourceTree = SOURCE_ROOT; };
+		B43C27BEC3AB681389FC5FC5 /* juce_RelativeCoordinate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RelativeCoordinate.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinate.h; sourceTree = SOURCE_ROOT; };
+		B47B3368AA1A182B0CA1AB26 /* Butterworth.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Butterworth.cpp; path = ../../Source/Dsp/Butterworth.cpp; sourceTree = SOURCE_ROOT; };
+		B4C52FC94D6C680C33ED85C9 /* juce_File.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_File.cpp; path = ../../JuceLibraryCode/modules/juce_core/files/juce_File.cpp; sourceTree = SOURCE_ROOT; };
+		B4F0C0B262654C4782B5AC49 /* juce_FileChooserDialogBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileChooserDialogBox.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileChooserDialogBox.h; sourceTree = SOURCE_ROOT; };
+		B5ADA0C1BDBFAE2A2F8ECB48 /* juce_EdgeTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_EdgeTable.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_EdgeTable.h; sourceTree = SOURCE_ROOT; };
+		B5B417E4196236A2CDE7F0CF /* juce_AudioFormatManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioFormatManager.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatManager.cpp; sourceTree = SOURCE_ROOT; };
+		B5E8A19FF91BEAD02C63E05B /* juce_LowLevelGraphicsPostScriptRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LowLevelGraphicsPostScriptRenderer.h; path = ../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsPostScriptRenderer.h; sourceTree = SOURCE_ROOT; };
+		B5FBD4DBD2CFE0FFF457D7F6 /* juce_ReferenceCountedArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ReferenceCountedArray.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_ReferenceCountedArray.h; sourceTree = SOURCE_ROOT; };
+		B60D02B5BF564ABC88841B1F /* juce_TableHeaderComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TableHeaderComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.h; sourceTree = SOURCE_ROOT; };
+		B64193A23B69D4A88CDEDD0C /* juce_MidiOutput.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiOutput.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/midi_io/juce_MidiOutput.cpp; sourceTree = SOURCE_ROOT; };
+		B64893F699A10B03AA4AFF6B /* juce_CharPointer_ASCII.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CharPointer_ASCII.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_ASCII.h; sourceTree = SOURCE_ROOT; };
+		B6567CAE2B538E79E7DA814C /* juce_ThreadWithProgressWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ThreadWithProgressWindow.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ThreadWithProgressWindow.cpp; sourceTree = SOURCE_ROOT; };
+		B674DCA2C2A6AF6B58AA7820 /* juce_ComponentAnimator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComponentAnimator.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentAnimator.cpp; sourceTree = SOURCE_ROOT; };
+		B678CFC6B378A58834D2E41F /* juce_LowLevelGraphicsPostScriptRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_LowLevelGraphicsPostScriptRenderer.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/contexts/juce_LowLevelGraphicsPostScriptRenderer.cpp; sourceTree = SOURCE_ROOT; };
+		B70D836E0756C3D4EE8E20F2 /* SpikeDetector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SpikeDetector.h; path = ../../Source/Processors/SpikeDetector.h; sourceTree = SOURCE_ROOT; };
+		B767A249792EB15A87054409 /* ChebyshevII.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChebyshevII.cpp; path = ../../Source/Dsp/ChebyshevII.cpp; sourceTree = SOURCE_ROOT; };
+		B7BEB7779860FE877E4D1BC8 /* juce_TextDiff.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TextDiff.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_TextDiff.cpp; sourceTree = SOURCE_ROOT; };
+		B7D848E4F85AE11FDE4D164D /* juce_linux_AudioCDReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_AudioCDReader.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_AudioCDReader.cpp; sourceTree = SOURCE_ROOT; };
+		B83EBFAE6306941F79044523 /* juce_DirectoryContentsDisplayComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DirectoryContentsDisplayComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_DirectoryContentsDisplayComponent.cpp; sourceTree = SOURCE_ROOT; };
+		B84E9C47FEE13D162CE9E5D7 /* ISCAN.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ISCAN.cpp; path = ../../Source/Processors/ISCAN.cpp; sourceTree = SOURCE_ROOT; };
+		B87864B2D6A2E741D4B426A3 /* juce_mac_Threads.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_Threads.mm; path = ../../JuceLibraryCode/modules/juce_core/native/juce_mac_Threads.mm; sourceTree = SOURCE_ROOT; };
+		B87C1BD13762817BE27DC2F7 /* juce_FillType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FillType.h; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_FillType.h; sourceTree = SOURCE_ROOT; };
+		B8A9063181FEE1920095F824 /* juce_ChangeBroadcaster.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ChangeBroadcaster.h; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ChangeBroadcaster.h; sourceTree = SOURCE_ROOT; };
+		B8D19858CC01BB5F7C35ED58 /* juce_XmlDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_XmlDocument.cpp; path = ../../JuceLibraryCode/modules/juce_core/xml/juce_XmlDocument.cpp; sourceTree = SOURCE_ROOT; };
+		B917780A75945062761B6945 /* WiFiOutput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WiFiOutput.h; path = ../../Source/Processors/WiFiOutput.h; sourceTree = SOURCE_ROOT; };
+		B93B8666F8AF2E5D2E851B1C /* juce_VSTPluginFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_VSTPluginFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp; sourceTree = SOURCE_ROOT; };
+		B9E2607F1605D308CB331FCC /* juce_StringPairArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_StringPairArray.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_StringPairArray.cpp; sourceTree = SOURCE_ROOT; };
+		BA03776682290FF1AF4C0106 /* juce_PluginDescription.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PluginDescription.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_PluginDescription.h; sourceTree = SOURCE_ROOT; };
+		BA09F5CDB1C01E0FC153DB8E /* juce_NativeMessageBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_NativeMessageBox.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_NativeMessageBox.h; sourceTree = SOURCE_ROOT; };
+		BA2923571505AD47CA1EF878 /* WiFiOutputEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WiFiOutputEditor.h; path = ../../Source/Processors/Editors/WiFiOutputEditor.h; sourceTree = SOURCE_ROOT; };
+		BA422CC894B825834A0C5479 /* GraphViewer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GraphViewer.h; path = ../../Source/UI/GraphViewer.h; sourceTree = SOURCE_ROOT; };
+		BABBEE3876B90C8A57C3074D /* juce_ComponentAnimator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComponentAnimator.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentAnimator.h; sourceTree = SOURCE_ROOT; };
+		BAE93A5EEC37D7B4C793BFA2 /* juce_QuickTimeAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_QuickTimeAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_QuickTimeAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		BB0BB31575E1377F0C560D53 /* juce_RelativeCoordinate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RelativeCoordinate.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinate.cpp; sourceTree = SOURCE_ROOT; };
+		BB26BA9CFAE8C836251E8EAF /* MainWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MainWindow.h; path = ../../Source/MainWindow.h; sourceTree = SOURCE_ROOT; };
+		BBC386B5A369262583AD4DDA /* juce_QuickTimeAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_QuickTimeAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_QuickTimeAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		BBCBB940B85B1695225C9A13 /* AdvancerNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AdvancerNode.h; path = ../../Source/Processors/AdvancerNode.h; sourceTree = SOURCE_ROOT; };
+		BBCDE855BD0A58D3779D96A8 /* RHD2000Editor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RHD2000Editor.h; path = ../../Source/Processors/Editors/RHD2000Editor.h; sourceTree = SOURCE_ROOT; };
+		BBD9C2AED6F500D090069007 /* ReferenceNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ReferenceNode.cpp; path = ../../Source/Processors/ReferenceNode.cpp; sourceTree = SOURCE_ROOT; };
+		BBDFB328C3D5FC72A0446E6A /* juce_graphics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_graphics.mm; path = ../../JuceLibraryCode/modules/juce_graphics/juce_graphics.mm; sourceTree = SOURCE_ROOT; };
+		BBE1DB78E35135B41537DCB5 /* RecentFilesMenuTemplate.nib */ = {isa = PBXFileReference; lastKnownFileType = file.nib; path = RecentFilesMenuTemplate.nib; sourceTree = SOURCE_ROOT; };
+		BBF5345C0570D87C01A73FF9 /* noise_wave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = noise_wave.png; path = ../../Resources/Images/Icons/noise_wave.png; sourceTree = SOURCE_ROOT; };
+		BC06C1E8052799F4696101C3 /* juce_mac_SystemStats.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_SystemStats.mm; path = ../../JuceLibraryCode/modules/juce_core/native/juce_mac_SystemStats.mm; sourceTree = SOURCE_ROOT; };
+		BC3B7E4E25505D9044BFACC7 /* SpikeDetector.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDetector.cpp; path = ../../Source/Processors/SpikeDetector.cpp; sourceTree = SOURCE_ROOT; };
+		BC953E395B22FB1D305E483E /* juce_MACAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MACAddress.h; path = ../../JuceLibraryCode/modules/juce_core/network/juce_MACAddress.h; sourceTree = SOURCE_ROOT; };
+		BCB6A6D5A0C1417D74C29632 /* juce_win32_Files.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Files.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_win32_Files.cpp; sourceTree = SOURCE_ROOT; };
+		BCBBF8764A2101CD0E91DB5D /* juce_DropShadower.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DropShadower.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_DropShadower.h; sourceTree = SOURCE_ROOT; };
+		BD1D02C70CCE095217581A5F /* juce_ios_MessageManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_ios_MessageManager.mm; path = ../../JuceLibraryCode/modules/juce_events/native/juce_ios_MessageManager.mm; sourceTree = SOURCE_ROOT; };
+		BD59A961F87AB628777894DC /* juce_AudioThumbnailCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioThumbnailCache.cpp; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnailCache.cpp; sourceTree = SOURCE_ROOT; };
+		BDFF189EC742274DD2629196 /* juce_RectangleList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RectangleList.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_RectangleList.cpp; sourceTree = SOURCE_ROOT; };
+		BE45C52599CD88A456166B49 /* monkey.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = monkey.png; path = ../../Resources/Images/Icons/monkey.png; sourceTree = SOURCE_ROOT; };
+		BE506F381B90833512348968 /* juce_FloatVectorOperations.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FloatVectorOperations.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.cpp; sourceTree = SOURCE_ROOT; };
+		BEC4B69320BE492526794DFB /* wifi.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = wifi.png; path = ../../Resources/Images/Icons/wifi.png; sourceTree = SOURCE_ROOT; };
+		BF647E1FAE73208AC29C14F7 /* juce_Sampler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Sampler.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/sampler/juce_Sampler.cpp; sourceTree = SOURCE_ROOT; };
+		BF8B07C8BC86002C3DC94DEE /* juce_MemoryOutputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MemoryOutputStream.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryOutputStream.h; sourceTree = SOURCE_ROOT; };
+		BF9B6B0B73FF87595307D858 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_gui_basics/juce_module_info; sourceTree = SOURCE_ROOT; };
+		BFF368651E3CEE5A900391A6 /* square_wave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = square_wave.png; path = ../../Resources/Images/Icons/square_wave.png; sourceTree = SOURCE_ROOT; };
+		C055D09224D84121A3EBB29F /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		C0A718EA721772EA6B837F39 /* juce_win32_SystemStats.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_SystemStats.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_win32_SystemStats.cpp; sourceTree = SOURCE_ROOT; };
+		C0B54E0803BA87C8BC353551 /* juce_video.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_video.h; path = ../../JuceLibraryCode/modules/juce_video/juce_video.h; sourceTree = SOURCE_ROOT; };
+		C0C6335FEE0844872FDF4EE2 /* juce_Memory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Memory.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_Memory.h; sourceTree = SOURCE_ROOT; };
+		C10DC7C6E887B4EAAB8EDF38 /* juce_ChoicePropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ChoicePropertyComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_ChoicePropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		C1435AB0105CDC29A3124E4F /* juce_CustomTypeface.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CustomTypeface.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_CustomTypeface.cpp; sourceTree = SOURCE_ROOT; };
+		C16065CD5A8054262B81C1A3 /* juce_cryptography.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_cryptography.h; path = ../../JuceLibraryCode/modules/juce_cryptography/juce_cryptography.h; sourceTree = SOURCE_ROOT; };
+		C17E85281A455245543930E5 /* juce_mac_NSViewComponentPeer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_NSViewComponentPeer.mm; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm; sourceTree = SOURCE_ROOT; };
+		C195559D311BAB51CFB545BA /* juce_MultiDocumentPanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MultiDocumentPanel.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_MultiDocumentPanel.cpp; sourceTree = SOURCE_ROOT; };
+		C1CB526B75E406851FA918C6 /* State.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = State.cpp; path = ../../Source/Dsp/State.cpp; sourceTree = SOURCE_ROOT; };
+		C1E1CCE5796B40E0A45FB021 /* juce_AudioThumbnail.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioThumbnail.h; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnail.h; sourceTree = SOURCE_ROOT; };
+		C209C7633D01E525231EE894 /* juce_GlyphArrangement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GlyphArrangement.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_GlyphArrangement.cpp; sourceTree = SOURCE_ROOT; };
+		C224FFE93AB9ACD2263F8877 /* LogWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LogWindow.h; path = ../../Source/UI/LogWindow.h; sourceTree = SOURCE_ROOT; };
+		C2746A86EC16D3EA9FAC2C1D /* juce_XmlElement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_XmlElement.cpp; path = ../../JuceLibraryCode/modules/juce_core/xml/juce_XmlElement.cpp; sourceTree = SOURCE_ROOT; };
+		C29BC68B2721471F32906FEB /* ResamplingNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ResamplingNode.h; path = ../../Source/Processors/ResamplingNode.h; sourceTree = SOURCE_ROOT; };
+		C29E664781AA2396C8D59543 /* juce_events.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_events.mm; path = ../../JuceLibraryCode/modules/juce_events/juce_events.mm; sourceTree = SOURCE_ROOT; };
+		C2D1409D20E154E43569C725 /* juce_ImagePreviewComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ImagePreviewComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_ImagePreviewComponent.cpp; sourceTree = SOURCE_ROOT; };
+		C2F9D279FCC5C4AD56A0C1DF /* juce_Decibels.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Decibels.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_Decibels.h; sourceTree = SOURCE_ROOT; };
+		C39772F796D85E8FE98474D5 /* Filter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Filter.h; path = ../../Source/Dsp/Filter.h; sourceTree = SOURCE_ROOT; };
+		C3BD84D9B090F98DD09F5958 /* Params.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Params.h; path = ../../Source/Dsp/Params.h; sourceTree = SOURCE_ROOT; };
+		C41504F388D0B181B003B627 /* juce_RelativePoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RelativePoint.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativePoint.h; sourceTree = SOURCE_ROOT; };
+		C446923C1950EB5BE5E67F15 /* juce_TargetPlatform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TargetPlatform.h; path = ../../JuceLibraryCode/modules/juce_core/system/juce_TargetPlatform.h; sourceTree = SOURCE_ROOT; };
+		C454DFC77F19AB044372610E /* juce_MarkerList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MarkerList.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_MarkerList.cpp; sourceTree = SOURCE_ROOT; };
+		C4B0DF8094C90543A65E03E3 /* Legendre.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Legendre.cpp; path = ../../Source/Dsp/Legendre.cpp; sourceTree = SOURCE_ROOT; };
+		C51CD15B311D0AAC08D0B908 /* ImageIcon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ImageIcon.h; path = ../../Source/Processors/Editors/ImageIcon.h; sourceTree = SOURCE_ROOT; };
+		C5287F057A6A88BC33D5498A /* juce_DrawableComposite.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DrawableComposite.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableComposite.cpp; sourceTree = SOURCE_ROOT; };
+		C54760E4888674CF3CF022E6 /* juce_AudioProcessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioProcessor.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessor.h; sourceTree = SOURCE_ROOT; };
+		C5785E58E6F915165729EF16 /* RecordControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RecordControl.h; path = ../../Source/Processors/Utilities/RecordControl.h; sourceTree = SOURCE_ROOT; };
+		C5ABE6BDCA91410BA92A7BD9 /* ResamplingNodeEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ResamplingNodeEditor.cpp; path = ../../Source/Processors/Editors/ResamplingNodeEditor.cpp; sourceTree = SOURCE_ROOT; };
+		C5D0E0996D20BEEEDBFD64FA /* juce_ValueTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ValueTree.h; path = ../../JuceLibraryCode/modules/juce_data_structures/values/juce_ValueTree.h; sourceTree = SOURCE_ROOT; };
+		C5D9C53AE4AE414244E1E19A /* muteoff.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = muteoff.png; path = ../../Resources/Images/Buttons/muteoff.png; sourceTree = SOURCE_ROOT; };
+		C5F9A0F8EB81AC15D9BDD61F /* juce_OpenGLFrameBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLFrameBuffer.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLFrameBuffer.h; sourceTree = SOURCE_ROOT; };
+		C660716FDD337EFB1A7C6C72 /* juce_Path.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Path.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Path.h; sourceTree = SOURCE_ROOT; };
+		C679AE9BBB9B1EE3BAB09E11 /* juce_FileBasedDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileBasedDocument.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/documents/juce_FileBasedDocument.h; sourceTree = SOURCE_ROOT; };
+		C67AA7952D9EF7E248118B85 /* juce_StringPool.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_StringPool.cpp; path = ../../JuceLibraryCode/modules/juce_core/text/juce_StringPool.cpp; sourceTree = SOURCE_ROOT; };
+		C67C5EC0EE8DBC501C8AA395 /* juce_NamedPipe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_NamedPipe.h; path = ../../JuceLibraryCode/modules/juce_core/network/juce_NamedPipe.h; sourceTree = SOURCE_ROOT; };
+		C6BDC4DAD5B40321DA67462A /* juce_ApplicationCommandTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ApplicationCommandTarget.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandTarget.h; sourceTree = SOURCE_ROOT; };
+		C6E19D3864B40A52BCC49315 /* juce_ModifierKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ModifierKeys.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_ModifierKeys.h; sourceTree = SOURCE_ROOT; };
+		C74399C81B1A0552CC52093E /* juce_GenericAudioProcessorEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_GenericAudioProcessorEditor.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.h; sourceTree = SOURCE_ROOT; };
+		C79249376E3FDF10615E16EA /* WiFiOutputEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WiFiOutputEditor.cpp; path = ../../Source/Processors/Editors/WiFiOutputEditor.cpp; sourceTree = SOURCE_ROOT; };
+		C7A68BAFB04A7D5FD81FA82B /* juce_PropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PropertyComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_PropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		C7A76C0D1B3DC4A1F059E59B /* juce_Label.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Label.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Label.h; sourceTree = SOURCE_ROOT; };
+		C7CA628FE3E1E3D16B24E059 /* juce_android_Threads.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_Threads.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_android_Threads.cpp; sourceTree = SOURCE_ROOT; };
+		C844D1792A91BE2D8808CB14 /* juce_MessageManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MessageManager.h; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_MessageManager.h; sourceTree = SOURCE_ROOT; };
+		C868329EBC1BBA606AB2EB88 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		C916444FD4BFB79D4DE9FCAF /* juce_AttributedString.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AttributedString.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_AttributedString.cpp; sourceTree = SOURCE_ROOT; };
+		C91ED2E43CF9CC0E83EB50A7 /* NetworkEvents.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkEvents.cpp; path = ../../Source/Processors/NetworkEvents.cpp; sourceTree = SOURCE_ROOT; };
+		C98D4FF283E598244E89CD83 /* juce_TextDiff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TextDiff.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_TextDiff.h; sourceTree = SOURCE_ROOT; };
+		CA09B0483969444C7CD106DC /* juce_mac_Fonts.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_Fonts.mm; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_Fonts.mm; sourceTree = SOURCE_ROOT; };
+		CAA3B9396EA62166234DAEF1 /* VisualizerEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = VisualizerEditor.cpp; path = ../../Source/Processors/Editors/VisualizerEditor.cpp; sourceTree = SOURCE_ROOT; };
+		CB2C4FD47184B2FE84408CAD /* RadioButtons_neutral-03.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-03.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-03.png"; sourceTree = SOURCE_ROOT; };
+		CC35C78D5B446ABF57DDDAE0 /* juce_ImageFileFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ImageFileFormat.h; path = ../../JuceLibraryCode/modules/juce_graphics/images/juce_ImageFileFormat.h; sourceTree = SOURCE_ROOT; };
+		CC42C4D4230BE4F1071CB2D3 /* juce_ResizableEdgeComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ResizableEdgeComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableEdgeComponent.h; sourceTree = SOURCE_ROOT; };
+		CC62E20B1189C697DD238810 /* juce_OpenGL_linux.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGL_linux.h; path = ../../JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_linux.h; sourceTree = SOURCE_ROOT; };
+		CCC20313AD0D0993F9EDD1B3 /* SplitterEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SplitterEditor.h; path = ../../Source/Processors/Editors/SplitterEditor.h; sourceTree = SOURCE_ROOT; };
+		CD2370F8F4A44446558A08FB /* Parameter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Parameter.cpp; path = ../../Source/Processors/Parameter.cpp; sourceTree = SOURCE_ROOT; };
+		CD2E26CFD0DC7F6090E15A20 /* juce_Line.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Line.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_Line.h; sourceTree = SOURCE_ROOT; };
+		CD41C1D09F6D73FA33993F45 /* juce_Desktop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Desktop.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Desktop.h; sourceTree = SOURCE_ROOT; };
+		CD492AC7B458FA6C321B9D0B /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_core/juce_module_info; sourceTree = SOURCE_ROOT; };
+		CD7E06ED47B243518F42DA49 /* MergerA-02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "MergerA-02.png"; path = "../../Resources/Images/Buttons/MergerA-02.png"; sourceTree = SOURCE_ROOT; };
+		CD83E301AE42E6E3317D575D /* juce_TableHeaderComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TableHeaderComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.cpp; sourceTree = SOURCE_ROOT; };
+		CDC18ABAFEF000C720CE8622 /* juce_CallOutBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CallOutBox.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_CallOutBox.cpp; sourceTree = SOURCE_ROOT; };
+		CE2BD40797A6E7647FDBE736 /* juce_ColourSelector.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ColourSelector.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_ColourSelector.cpp; sourceTree = SOURCE_ROOT; };
+		CF5BC8DB7D66C655DABA9129 /* juce_android_FileChooser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_android_FileChooser.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/native/juce_android_FileChooser.cpp; sourceTree = SOURCE_ROOT; };
+		CF758CB1E06DDA1AB7F5C9CC /* juce_events.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_events.h; path = ../../JuceLibraryCode/modules/juce_events/juce_events.h; sourceTree = SOURCE_ROOT; };
+		CFB86C1F2A6076ADC36692AA /* Utilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Utilities.h; path = ../../Source/Dsp/Utilities.h; sourceTree = SOURCE_ROOT; };
+		D01254FA41688494C3CB0889 /* silkscreen.ttf */ = {isa = PBXFileReference; lastKnownFileType = file.ttf; name = silkscreen.ttf; path = ../../Resources/Fonts/silkscreen.ttf; sourceTree = SOURCE_ROOT; };
+		D0247929128D618A2EB01D86 /* juce_OpenGLHelpers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OpenGLHelpers.cpp; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLHelpers.cpp; sourceTree = SOURCE_ROOT; };
+		D056D7F6C8EA8A6BBCC5C092 /* juce_InputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_InputStream.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_InputStream.h; sourceTree = SOURCE_ROOT; };
+		D06A8FDAD8B22537EA594383 /* juce_StretchableLayoutResizerBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_StretchableLayoutResizerBar.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutResizerBar.h; sourceTree = SOURCE_ROOT; };
+		D0D7CE266BD7CC5455926700 /* juce_AudioSourcePlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioSourcePlayer.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioSourcePlayer.h; sourceTree = SOURCE_ROOT; };
+		D0E568AD5445AF061317E01D /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_audio_formats/juce_module_info; sourceTree = SOURCE_ROOT; };
+		D11BC618E53E6605B3A579E1 /* juce_MemoryBlock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MemoryBlock.cpp; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_MemoryBlock.cpp; sourceTree = SOURCE_ROOT; };
+		D128F31F18331117287F5EC5 /* ArduinoOutput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ArduinoOutput.h; path = ../../Source/Processors/ArduinoOutput.h; sourceTree = SOURCE_ROOT; };
+		D162391A46FF93093C328F9D /* juce_GZIPCompressorOutputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GZIPCompressorOutputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/zip/juce_GZIPCompressorOutputStream.cpp; sourceTree = SOURCE_ROOT; };
+		D171071934C8F7F925B0D113 /* juce_TableListBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TableListBox.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_TableListBox.cpp; sourceTree = SOURCE_ROOT; };
+		D1D8F82F848413581B274A5D /* juce_win32_CameraDevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_CameraDevice.cpp; path = ../../JuceLibraryCode/modules/juce_video/native/juce_win32_CameraDevice.cpp; sourceTree = SOURCE_ROOT; };
+		D1F9878B45ABC403F3749567 /* juce_FileBasedDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileBasedDocument.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/documents/juce_FileBasedDocument.cpp; sourceTree = SOURCE_ROOT; };
+		D22D3958949713747DAF59A3 /* juce_linux_SystemStats.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_SystemStats.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_linux_SystemStats.cpp; sourceTree = SOURCE_ROOT; };
+		D2696B30CBEAD7CE72510AFA /* InfoLabel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = InfoLabel.h; path = ../../Source/UI/InfoLabel.h; sourceTree = SOURCE_ROOT; };
+		D2A3B4CDD296B4CEC6902FD7 /* UIComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UIComponent.cpp; path = ../../Source/UI/UIComponent.cpp; sourceTree = SOURCE_ROOT; };
+		D2CCDDF54D6D6F2BF4281F2D /* juce_BooleanPropertyComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BooleanPropertyComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/properties/juce_BooleanPropertyComponent.cpp; sourceTree = SOURCE_ROOT; };
+		D30880F1F9F514CEEDB9F48B /* AppConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppConfig.h; path = ../../JuceLibraryCode/AppConfig.h; sourceTree = SOURCE_ROOT; };
+		D357A886F6365DA33D639FF5 /* juce_mac_NSViewComponent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_NSViewComponent.mm; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_NSViewComponent.mm; sourceTree = SOURCE_ROOT; };
+		D38E60AC4854B6E1EDE488EB /* ArduinoOutput.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ArduinoOutput.cpp; path = ../../Source/Processors/ArduinoOutput.cpp; sourceTree = SOURCE_ROOT; };
+		D3AE8303545E28D793312F46 /* GenericEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = GenericEditor.cpp; path = ../../Source/Processors/Editors/GenericEditor.cpp; sourceTree = SOURCE_ROOT; };
+		D41ED9ADBE3B27E185B2E3F3 /* RadioButtons_neutral-05.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-05.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-05.png"; sourceTree = SOURCE_ROOT; };
+		D46A0FAD95FD6DAC1877712B /* rodent.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = rodent.png; path = ../../Resources/Images/Icons/rodent.png; sourceTree = SOURCE_ROOT; };
+		D48EB74E1B5AAC7846196B01 /* juce_linux_Fonts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Fonts.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_linux_Fonts.cpp; sourceTree = SOURCE_ROOT; };
+		D4B0BD47094D79AB6382228B /* juce_OpenGLTexture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLTexture.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLTexture.h; sourceTree = SOURCE_ROOT; };
+		D4F94F0232F0CD426DFC44C5 /* juce_PreferencesPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PreferencesPanel.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_PreferencesPanel.h; sourceTree = SOURCE_ROOT; };
+		D51315B4241B019BE43EE4F1 /* SplitterEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SplitterEditor.cpp; path = ../../Source/Processors/Editors/SplitterEditor.cpp; sourceTree = SOURCE_ROOT; };
+		D51575B9AA7216CCE4B558E4 /* juce_TopLevelWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TopLevelWindow.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TopLevelWindow.h; sourceTree = SOURCE_ROOT; };
+		D55137DE3404D7DF2A1F50D0 /* juce_GIFLoader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_GIFLoader.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/image_formats/juce_GIFLoader.cpp; sourceTree = SOURCE_ROOT; };
+		D5D6DAA3CFDD395096D2B072 /* juce_ReferenceCountedObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ReferenceCountedObject.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_ReferenceCountedObject.h; sourceTree = SOURCE_ROOT; };
+		D60F42AEB8551E83215691C3 /* juce_ZipFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ZipFile.h; path = ../../JuceLibraryCode/modules/juce_core/zip/juce_ZipFile.h; sourceTree = SOURCE_ROOT; };
+		D627F12C36013C7EFE0B0B63 /* OscilloscopeNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OscilloscopeNode.h; path = ../../Source/Processors/OscilloscopeNode.h; sourceTree = SOURCE_ROOT; };
+		D679982E05B9510FE239D690 /* juce_OutputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_OutputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_OutputStream.cpp; sourceTree = SOURCE_ROOT; };
+		D685CFEA6344360FBFC355B6 /* DiscRecording.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiscRecording.framework; path = System/Library/Frameworks/DiscRecording.framework; sourceTree = SDKROOT; };
+		D71AD519382D547C958B0175 /* juce_UndoableAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_UndoableAction.h; path = ../../JuceLibraryCode/modules/juce_data_structures/undomanager/juce_UndoableAction.h; sourceTree = SOURCE_ROOT; };
+		D7807913367AD1B1FCBDEFAC /* juce_ApplicationBase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ApplicationBase.cpp; path = ../../JuceLibraryCode/modules/juce_events/messages/juce_ApplicationBase.cpp; sourceTree = SOURCE_ROOT; };
+		D7E51310BD1B8EF6A2A77177 /* juce_MenuBarModel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MenuBarModel.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarModel.cpp; sourceTree = SOURCE_ROOT; };
+		D840E516B1DE9F3F730283D5 /* juce_KeyboardFocusTraverser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_KeyboardFocusTraverser.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyboardFocusTraverser.cpp; sourceTree = SOURCE_ROOT; };
+		D88B0ADDC9BF206E3D2EE9F6 /* juce_RectangleList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RectangleList.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_RectangleList.h; sourceTree = SOURCE_ROOT; };
+		D8A40F2BFBEC65019C867786 /* juce_Time.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Time.h; path = ../../JuceLibraryCode/modules/juce_core/time/juce_Time.h; sourceTree = SOURCE_ROOT; };
+		D8AA3ED11D45FACF74B5FC05 /* RadioButtons_neutral-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_neutral-01.png"; path = "../../Resources/Images/Icons/RadioButtons_neutral-01.png"; sourceTree = SOURCE_ROOT; };
+		D8AFDCC674A7514B7019EEA6 /* juce_DrawableButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DrawableButton.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_DrawableButton.h; sourceTree = SOURCE_ROOT; };
+		D8D895B3AD895C6E7FD446BF /* Custom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Custom.cpp; path = ../../Source/Dsp/Custom.cpp; sourceTree = SOURCE_ROOT; };
+		D90290A0AA2C36CE757E46D5 /* FilterEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FilterEditor.cpp; path = ../../Source/Processors/Editors/FilterEditor.cpp; sourceTree = SOURCE_ROOT; };
+		D952A208CC8164F0B459EC9E /* juce_linux_WebBrowserComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_WebBrowserComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_linux_WebBrowserComponent.cpp; sourceTree = SOURCE_ROOT; };
+		D960588B732D973B82500E2D /* juce_AudioProcessorListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioProcessorListener.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/processors/juce_AudioProcessorListener.h; sourceTree = SOURCE_ROOT; };
+		D9C9FCA6D705B72B80DB1142 /* juce_Socket.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Socket.cpp; path = ../../JuceLibraryCode/modules/juce_core/network/juce_Socket.cpp; sourceTree = SOURCE_ROOT; };
+		D9CB4CEC2C07346BE69262A0 /* RadioButtons_selected-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected-01.png"; path = "../../Resources/Images/Icons/RadioButtons_selected-01.png"; sourceTree = SOURCE_ROOT; };
+		DA0AE9F4A1DDC3555247216F /* IntanIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = IntanIcon.png; path = ../../Resources/Images/Icons/IntanIcon.png; sourceTree = SOURCE_ROOT; };
+		DA30BA6BF482A353393D5926 /* juce_RelativeRectangle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RelativeRectangle.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeRectangle.cpp; sourceTree = SOURCE_ROOT; };
+		DAA04A0FD47097893712B241 /* SpikeDisplayNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SpikeDisplayNode.cpp; path = ../../Source/Processors/SpikeDisplayNode.cpp; sourceTree = SOURCE_ROOT; };
+		DAA4306D30617137463ED247 /* juce_RelativeRectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RelativeRectangle.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeRectangle.h; sourceTree = SOURCE_ROOT; };
+		DAC81FECCE54087394BE69F7 /* juce_WaitableEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_WaitableEvent.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_WaitableEvent.h; sourceTree = SOURCE_ROOT; };
+		DACD0879E139527D971D3AC4 /* juce_FileListComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileListComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_FileListComponent.h; sourceTree = SOURCE_ROOT; };
+		DB4F34DA0F04B40EB6A50FB1 /* juce_SystemStats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_SystemStats.h; path = ../../JuceLibraryCode/modules/juce_core/system/juce_SystemStats.h; sourceTree = SOURCE_ROOT; };
+		DB4FB8EAFA1714529E527C3D /* juce_win32_Messaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Messaging.cpp; path = ../../JuceLibraryCode/modules/juce_events/native/juce_win32_Messaging.cpp; sourceTree = SOURCE_ROOT; };
+		DB4FF7675E5C98CF62DA8A2E /* AccessClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AccessClass.h; path = ../../Source/AccessClass.h; sourceTree = SOURCE_ROOT; };
+		DB550BAB034060FF4578BB64 /* juce_audio_basics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_audio_basics.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/juce_audio_basics.h; sourceTree = SOURCE_ROOT; };
+		DB702F259EF24DAB9EC99D0A /* FPGAOutput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FPGAOutput.h; path = ../../Source/Processors/FPGAOutput.h; sourceTree = SOURCE_ROOT; };
+		DB7866AFC8A4894810DBD05E /* juce_InterProcessLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_InterProcessLock.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_InterProcessLock.h; sourceTree = SOURCE_ROOT; };
+		DBB295F412798131D3F04045 /* PulsePalOutput.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PulsePalOutput.cpp; path = ../../Source/Processors/PulsePalOutput.cpp; sourceTree = SOURCE_ROOT; };
+		DBB769DEBCD6468C13A3CD25 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
+		DBB86AD59BA3F6EC09AF2C02 /* LfpDisplayNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpDisplayNode.h; path = ../../Source/Processors/LfpDisplayNode.h; sourceTree = SOURCE_ROOT; };
+		DBCA7E2FFCFD1354DD19DDD6 /* juce_data_structures.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_data_structures.mm; path = ../../JuceLibraryCode/modules/juce_data_structures/juce_data_structures.mm; sourceTree = SOURCE_ROOT; };
+		DBED17FBB262C4DACEEDA9B0 /* juce_MidiKeyboardState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MidiKeyboardState.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiKeyboardState.cpp; sourceTree = SOURCE_ROOT; };
+		DBF1FD9272546EE4C7DD517A /* juce_mac_SystemTrayIcon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_mac_SystemTrayIcon.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/native/juce_mac_SystemTrayIcon.cpp; sourceTree = SOURCE_ROOT; };
+		DC17FC0E3B6E3B7C45079DE0 /* OscilloscopeNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = OscilloscopeNode.cpp; path = ../../Source/Processors/OscilloscopeNode.cpp; sourceTree = SOURCE_ROOT; };
+		DC200873B263C55E82B5384D /* juce_MultiTimer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MultiTimer.h; path = ../../JuceLibraryCode/modules/juce_events/timers/juce_MultiTimer.h; sourceTree = SOURCE_ROOT; };
+		DD5695DE97CEF7BE76869232 /* juce_FileOutputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_FileOutputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/files/juce_FileOutputStream.cpp; sourceTree = SOURCE_ROOT; };
+		DDD2075B59AF7E38447BA84B /* TrialCircularBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TrialCircularBuffer.cpp; path = ../../Source/Processors/TrialCircularBuffer.cpp; sourceTree = SOURCE_ROOT; };
+		DDE157BB06373ECDBB23469C /* juce_StretchableLayoutManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_StretchableLayoutManager.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_StretchableLayoutManager.h; sourceTree = SOURCE_ROOT; };
+		DDE89F0D5E01F079323CC89C /* juce_AudioProcessorPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioProcessorPlayer.h; path = ../../JuceLibraryCode/modules/juce_audio_utils/players/juce_AudioProcessorPlayer.h; sourceTree = SOURCE_ROOT; };
+		DE4861552DB1976665B25DFD /* juce_HighResolutionTimer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_HighResolutionTimer.cpp; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_HighResolutionTimer.cpp; sourceTree = SOURCE_ROOT; };
+		DEB9A630503639D42056236B /* juce_UndoManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_UndoManager.h; path = ../../JuceLibraryCode/modules/juce_data_structures/undomanager/juce_UndoManager.h; sourceTree = SOURCE_ROOT; };
+		DEE2959DBBC84EA8448A0F77 /* juce_TimeSliceThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TimeSliceThread.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_TimeSliceThread.h; sourceTree = SOURCE_ROOT; };
+		DEF465116BB906FD116DA5EB /* ofConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ofConstants.h; path = ../../Source/Processors/Serial/ofConstants.h; sourceTree = SOURCE_ROOT; };
+		DF3C9A1DD67E879E4E0A2727 /* juce_audio_basics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_audio_basics.mm; path = ../../JuceLibraryCode/modules/juce_audio_basics/juce_audio_basics.mm; sourceTree = SOURCE_ROOT; };
+		DFAA7B563CEFB94D9ADB5D6A /* juce_CPlusPlusCodeTokeniser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CPlusPlusCodeTokeniser.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CPlusPlusCodeTokeniser.h; sourceTree = SOURCE_ROOT; };
+		DFFB7396DCE9DF1253217584 /* juce_AudioThumbnailCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioThumbnailCache.h; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnailCache.h; sourceTree = SOURCE_ROOT; };
+		E040EA8B5BB61ABBBD14F12F /* juce_OggVorbisAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OggVorbisAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		E08E877C3A6283CF5C803957 /* MainWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MainWindow.cpp; path = ../../Source/MainWindow.cpp; sourceTree = SOURCE_ROOT; };
+		E0ADC34D69113B79C2F4FF24 /* juce_CustomTypeface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CustomTypeface.h; path = ../../JuceLibraryCode/modules/juce_graphics/fonts/juce_CustomTypeface.h; sourceTree = SOURCE_ROOT; };
+		E0C264CF6345ABB4CAB98B92 /* juce_ScopedPointer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ScopedPointer.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_ScopedPointer.h; sourceTree = SOURCE_ROOT; };
+		E20D5F2F75478DA4943CEDBD /* juce_ActionBroadcaster.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ActionBroadcaster.h; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ActionBroadcaster.h; sourceTree = SOURCE_ROOT; };
+		E216D095C98F850A5FB6FB0F /* ChannelSelector.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ChannelSelector.cpp; path = ../../Source/Processors/Editors/ChannelSelector.cpp; sourceTree = SOURCE_ROOT; };
+		E21CA41B44E191F1804F9662 /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_data_structures/juce_module_info; sourceTree = SOURCE_ROOT; };
+		E23FA5E940A1434B0305875D /* juce_ResizableCornerComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ResizableCornerComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableCornerComponent.h; sourceTree = SOURCE_ROOT; };
+		E2F46E110416D628C11392CA /* Parameter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Parameter.h; path = ../../Source/Processors/Parameter.h; sourceTree = SOURCE_ROOT; };
+		E31563D2E7DDD8315F369233 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		E33F167E4AA1C44596A1EBED /* juce_mac_CoreGraphicsHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_mac_CoreGraphicsHelpers.h; path = ../../JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsHelpers.h; sourceTree = SOURCE_ROOT; };
+		E34E535DA9CBF248E32F7B45 /* juce_ReadWriteLock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ReadWriteLock.cpp; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_ReadWriteLock.cpp; sourceTree = SOURCE_ROOT; };
+		E37140E9E8F7CFDDEEEF6148 /* juce_ToolbarItemFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ToolbarItemFactory.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ToolbarItemFactory.h; sourceTree = SOURCE_ROOT; };
+		E3C4B6B362320594789E1297 /* juce_PropertySet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PropertySet.cpp; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_PropertySet.cpp; sourceTree = SOURCE_ROOT; };
+		E3D9DABE0A9C1DCE6A6515CB /* juce_MixerAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MixerAudioSource.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_MixerAudioSource.cpp; sourceTree = SOURCE_ROOT; };
+		E413F3262886677B4CBF3FA9 /* NotchFilterNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = NotchFilterNode.cpp; path = ../../Source/Processors/NotchFilterNode.cpp; sourceTree = SOURCE_ROOT; };
+		E419C9DA3202B8B6EC2DB723 /* juce_Reverb.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Reverb.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_Reverb.h; sourceTree = SOURCE_ROOT; };
+		E42B745B4D2DCADE54F94757 /* EventNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EventNode.h; path = ../../Source/Processors/EventNode.h; sourceTree = SOURCE_ROOT; };
+		E442E1FA7B58BFF6F1D8CBD8 /* ChannelMappingEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelMappingEditor.h; path = ../../Source/Processors/Editors/ChannelMappingEditor.h; sourceTree = SOURCE_ROOT; };
+		E44B26F5D97CB483242DE05B /* RBJ.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RBJ.h; path = ../../Source/Dsp/RBJ.h; sourceTree = SOURCE_ROOT; };
+		E48A7B152993BCF473725A19 /* juce_CameraDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CameraDevice.h; path = ../../JuceLibraryCode/modules/juce_video/capture/juce_CameraDevice.h; sourceTree = SOURCE_ROOT; };
+		E4A2E203101AF37C169F1569 /* juce_BufferingAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BufferingAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_BufferingAudioSource.h; sourceTree = SOURCE_ROOT; };
+		E53FEAA3754E6B5D99516D56 /* juce_KnownPluginList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_KnownPluginList.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_KnownPluginList.cpp; sourceTree = SOURCE_ROOT; };
+		E58A18793D25A1D75811A052 /* juce_ImagePreviewComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ImagePreviewComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/filebrowser/juce_ImagePreviewComponent.h; sourceTree = SOURCE_ROOT; };
+		E594A85A291E0625E0410A85 /* LfpDisplayEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LfpDisplayEditor.h; path = ../../Source/Processors/Editors/LfpDisplayEditor.h; sourceTree = SOURCE_ROOT; };
+		E5B10AA248D400FDB2645084 /* juce_win32_WASAPI.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_WASAPI.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp; sourceTree = SOURCE_ROOT; };
+		E5C1D021C0FD6FAD082C5D75 /* GraphViewer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = GraphViewer.cpp; path = ../../Source/UI/GraphViewer.cpp; sourceTree = SOURCE_ROOT; };
+		E666E60CC07666669FC77C7D /* juce_MemoryOutputStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MemoryOutputStream.cpp; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_MemoryOutputStream.cpp; sourceTree = SOURCE_ROOT; };
+		E67C5ACDC8208CDE200EC8C6 /* juce_graphics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_graphics.h; path = ../../JuceLibraryCode/modules/juce_graphics/juce_graphics.h; sourceTree = SOURCE_ROOT; };
+		E6D3A973D5CEF18CA2BAFF59 /* juce_TextButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TextButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_TextButton.cpp; sourceTree = SOURCE_ROOT; };
+		E7366E169158F5A2D1D7B55A /* juce_MidiFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MidiFile.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiFile.h; sourceTree = SOURCE_ROOT; };
+		E7460F066237871A704733E7 /* juce_InterprocessConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_InterprocessConnection.h; path = ../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnection.h; sourceTree = SOURCE_ROOT; };
+		E79259F2164D16553A69B458 /* AudioComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AudioComponent.h; path = ../../Source/Audio/AudioComponent.h; sourceTree = SOURCE_ROOT; };
+		E79B7DC03F81DA1F8CDE21CA /* juce_ApplicationCommandManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ApplicationCommandManager.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_ApplicationCommandManager.h; sourceTree = SOURCE_ROOT; };
+		E7ACE8C1456403A574236451 /* cpmono-bold-serialized */ = {isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-bold-serialized"; path = "../../Resources/Fonts/cpmono-bold-serialized"; sourceTree = SOURCE_ROOT; };
+		E7EE416EF527C7506B499070 /* juce_BigInteger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BigInteger.h; path = ../../JuceLibraryCode/modules/juce_core/maths/juce_BigInteger.h; sourceTree = SOURCE_ROOT; };
+		E8174B3346AA69361BF73AE1 /* Cascade.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Cascade.h; path = ../../Source/Dsp/Cascade.h; sourceTree = SOURCE_ROOT; };
+		E817F0471AF514FD075B5DB7 /* SerialInput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SerialInput.h; path = ../../Source/Processors/SerialInput.h; sourceTree = SOURCE_ROOT; };
+		E835BEB3C42E4B241804BE13 /* cpmono-light-serialized */ = {isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-light-serialized"; path = "../../Resources/Fonts/cpmono-light-serialized"; sourceTree = SOURCE_ROOT; };
+		E8480C4ED7F9579F6172F7B5 /* Common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Common.h; path = ../../Source/Dsp/Common.h; sourceTree = SOURCE_ROOT; };
+		E8964C0BE264A55753BC6B7B /* juce_linux_Midi.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_Midi.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_Midi.cpp; sourceTree = SOURCE_ROOT; };
+		E90FCB43DA2FF766597DA75E /* Documentation.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Documentation.cpp; path = ../../Source/Dsp/Documentation.cpp; sourceTree = SOURCE_ROOT; };
+		E91923510CB2280C3A3B9E9C /* juce_LocalisedStrings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_LocalisedStrings.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_LocalisedStrings.h; sourceTree = SOURCE_ROOT; };
+		E91A272EF06892937CB4B9CE /* juce_ComponentDragger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ComponentDragger.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_ComponentDragger.cpp; sourceTree = SOURCE_ROOT; };
+		E93BE115650B1CB80EACB841 /* EditorViewportButtons.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EditorViewportButtons.h; path = ../../Source/UI/EditorViewportButtons.h; sourceTree = SOURCE_ROOT; };
+		E946426F95E0240683CB3337 /* juce_DrawablePath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DrawablePath.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawablePath.h; sourceTree = SOURCE_ROOT; };
+		E97684DCE824DEDA6683C6CD /* juce_Synthesiser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Synthesiser.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/synthesisers/juce_Synthesiser.cpp; sourceTree = SOURCE_ROOT; };
+		EA2FC92CECD1EDA1F07DC59C /* juce_TooltipWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TooltipWindow.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TooltipWindow.h; sourceTree = SOURCE_ROOT; };
+		EA354D7D8E48D461415D52D8 /* juce_JPEGLoader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_JPEGLoader.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/image_formats/juce_JPEGLoader.cpp; sourceTree = SOURCE_ROOT; };
+		EA535EA158451360B7B8AE52 /* LfpDisplayNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LfpDisplayNode.cpp; path = ../../Source/Processors/LfpDisplayNode.cpp; sourceTree = SOURCE_ROOT; };
+		EA73332E3D5AEC04ADDFBB2A /* juce_AudioDataConverters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioDataConverters.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioDataConverters.h; sourceTree = SOURCE_ROOT; };
+		EA9518CDEA7049C21D5CE2D5 /* juce_Process.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Process.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_Process.h; sourceTree = SOURCE_ROOT; };
+		EAB2319C7AA57E06A2247CDF /* juce_BorderSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BorderSize.h; path = ../../JuceLibraryCode/modules/juce_graphics/geometry/juce_BorderSize.h; sourceTree = SOURCE_ROOT; };
+		EAB637B566FEBBDADA654262 /* juce_VSTMidiEventList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_VSTMidiEventList.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_VSTMidiEventList.h; sourceTree = SOURCE_ROOT; };
+		EAB6A66678B122C578B16445 /* juce_HighResolutionTimer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_HighResolutionTimer.h; path = ../../JuceLibraryCode/modules/juce_core/threads/juce_HighResolutionTimer.h; sourceTree = SOURCE_ROOT; };
+		EAC262A83CD2BEA14542AE89 /* juce_StringPool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_StringPool.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_StringPool.h; sourceTree = SOURCE_ROOT; };
+		EAC7A64301F0BF2C5E33A1F9 /* juce_InterprocessConnectionServer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_InterprocessConnectionServer.cpp; path = ../../JuceLibraryCode/modules/juce_events/interprocess/juce_InterprocessConnectionServer.cpp; sourceTree = SOURCE_ROOT; };
+		EAEA49B9394D802B79CA8164 /* juce_StringPairArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_StringPairArray.h; path = ../../JuceLibraryCode/modules/juce_core/text/juce_StringPairArray.h; sourceTree = SOURCE_ROOT; };
+		EB5F9A50EB53A57D6AE303C2 /* juce_mac_QuickTimeMovieComponent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = juce_mac_QuickTimeMovieComponent.mm; path = ../../JuceLibraryCode/modules/juce_video/native/juce_mac_QuickTimeMovieComponent.mm; sourceTree = SOURCE_ROOT; };
+		EBD8622EAEF10558809888B7 /* RadioButtons_selected_over-01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "RadioButtons_selected_over-01.png"; path = "../../Resources/Images/Icons/RadioButtons_selected_over-01.png"; sourceTree = SOURCE_ROOT; };
+		EC780F52ABBD7317A5CE2F33 /* ChebyshevI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChebyshevI.h; path = ../../Source/Dsp/ChebyshevI.h; sourceTree = SOURCE_ROOT; };
+		EC95A2CF4B33EA37DA5FC1AC /* nordic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file.ttf; name = nordic.ttf; path = ../../Resources/Fonts/nordic.ttf; sourceTree = SOURCE_ROOT; };
+		ECA6FDB1366BE7EC30F1539B /* SourceNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SourceNode.cpp; path = ../../Source/Processors/SourceNode.cpp; sourceTree = SOURCE_ROOT; };
+		ECB5A75A81B90327F58CBD9E /* rhd2000datablock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rhd2000datablock.cpp; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000datablock.cpp"; sourceTree = SOURCE_ROOT; };
+		ECBEF88BBC974D96ED781C75 /* juce_posix_SharedCode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_posix_SharedCode.h; path = ../../JuceLibraryCode/modules/juce_core/native/juce_posix_SharedCode.h; sourceTree = SOURCE_ROOT; };
+		ECCE033FF2ACE42188FA4A7F /* juce_TemporaryFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TemporaryFile.h; path = ../../JuceLibraryCode/modules/juce_core/files/juce_TemporaryFile.h; sourceTree = SOURCE_ROOT; };
+		ECE3BE71EB6B9CF1CE869BBE /* juce_BubbleComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BubbleComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_BubbleComponent.h; sourceTree = SOURCE_ROOT; };
+		ED86166920362E9D2BE2CB26 /* juce_SVGParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_SVGParser.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_SVGParser.cpp; sourceTree = SOURCE_ROOT; };
+		ED887A521EEB8F3EBA7DDB31 /* juce_AudioIODeviceType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioIODeviceType.h; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.h; sourceTree = SOURCE_ROOT; };
+		EDA209B0E7D124EA581023AD /* juce_AudioFormatManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioFormatManager.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatManager.h; sourceTree = SOURCE_ROOT; };
+		EDAC82BD742A54182E8DF2FE /* juce_RelativeCoordinatePositioner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RelativeCoordinatePositioner.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinatePositioner.h; sourceTree = SOURCE_ROOT; };
+		EE0336B43A39FD585DF638EE /* juce_ResizableEdgeComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ResizableEdgeComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableEdgeComponent.cpp; sourceTree = SOURCE_ROOT; };
+		EE2C669B127D00C86B1B8CA8 /* juce_win32_Registry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_Registry.cpp; path = ../../JuceLibraryCode/modules/juce_core/native/juce_win32_Registry.cpp; sourceTree = SOURCE_ROOT; };
+		EE4DD055D31F7D9DC718DBD8 /* juce_ComponentMovementWatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_ComponentMovementWatcher.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ComponentMovementWatcher.h; sourceTree = SOURCE_ROOT; };
+		EEA51B7EF1CF19028C6672E0 /* juce_DocumentWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DocumentWindow.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_DocumentWindow.cpp; sourceTree = SOURCE_ROOT; };
+		EEFC66D2DF5FD66B4D83B22F /* juce_Component.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Component.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/components/juce_Component.h; sourceTree = SOURCE_ROOT; };
+		EF059B26886B32000BCF8CFF /* juce_MouseInputSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MouseInputSource.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseInputSource.h; sourceTree = SOURCE_ROOT; };
+		EF3F9AA8D70E1D4D55F13182 /* juce_AudioThumbnail.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioThumbnail.cpp; path = ../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnail.cpp; sourceTree = SOURCE_ROOT; };
+		EF4A6E0E1232071252ACCD7B /* juce_RelativeParallelogram.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RelativeParallelogram.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeParallelogram.h; sourceTree = SOURCE_ROOT; };
+		EF610B2A17D9B1C0D24DCE67 /* juce_android_JNIHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_android_JNIHelpers.h; path = ../../JuceLibraryCode/modules/juce_core/native/juce_android_JNIHelpers.h; sourceTree = SOURCE_ROOT; };
+		EF7B66764093D950724EFE70 /* juce_OpenGLShaderProgram.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_OpenGLShaderProgram.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_OpenGLShaderProgram.h; sourceTree = SOURCE_ROOT; };
+		EF8488936B3D3E9178C9099C /* PulsePalOutput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PulsePalOutput.h; path = ../../Source/Processors/PulsePalOutput.h; sourceTree = SOURCE_ROOT; };
+		EFC21F3CD0EB87D67E044E06 /* juce_MenuBarComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MenuBarComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/menus/juce_MenuBarComponent.h; sourceTree = SOURCE_ROOT; };
+		F09FD6D9CA4997216ADBF54F /* DataBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataBuffer.h; path = ../../Source/Processors/DataThreads/DataBuffer.h; sourceTree = SOURCE_ROOT; };
+		F0CA3600E09054D7DB3B0067 /* SmoothedFilter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SmoothedFilter.h; path = ../../Source/Dsp/SmoothedFilter.h; sourceTree = SOURCE_ROOT; };
+		F0D9A28C206D7A8BA7089D29 /* juce_KeyMappingEditorComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_KeyMappingEditorComponent.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_KeyMappingEditorComponent.h; sourceTree = SOURCE_ROOT; };
+		F0F3834D46EA8FC8ADB206DB /* juce_AbstractFifo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AbstractFifo.cpp; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_AbstractFifo.cpp; sourceTree = SOURCE_ROOT; };
+		F1099BFF0BC1656A23D62E84 /* juce_ScrollBar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ScrollBar.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ScrollBar.cpp; sourceTree = SOURCE_ROOT; };
+		F10FB240E10A5742CE366A91 /* juce_TabbedButtonBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_TabbedButtonBar.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_TabbedButtonBar.h; sourceTree = SOURCE_ROOT; };
+		F115ED75E977A54AAF036B2C /* MatlabLikePlot.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MatlabLikePlot.cpp; path = ../../Source/Processors/Visualization/MatlabLikePlot.cpp; sourceTree = SOURCE_ROOT; };
+		F17DF27524262A21A3EC932D /* juce_PluginListComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_PluginListComponent.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/scanning/juce_PluginListComponent.cpp; sourceTree = SOURCE_ROOT; };
+		F1A3975235880CAC1D5757F4 /* juce_MP3AudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_MP3AudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_MP3AudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		F1DBAE92084D9D90234AC436 /* juce_AudioSourcePlayer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioSourcePlayer.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/sources/juce_AudioSourcePlayer.cpp; sourceTree = SOURCE_ROOT; };
+		F230A4C0186379F9EB0B0F74 /* ReferenceNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ReferenceNode.h; path = ../../Source/Processors/ReferenceNode.h; sourceTree = SOURCE_ROOT; };
+		F28414731D9EE1F75D7B7043 /* juce_AudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_AudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormat.h; sourceTree = SOURCE_ROOT; };
+		F2A500BA3500C4A9D5792A54 /* juce_DrawableImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DrawableImage.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawableImage.h; sourceTree = SOURCE_ROOT; };
+		F2EDB88302B8A9356F43B834 /* juce_Primes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Primes.h; path = ../../JuceLibraryCode/modules/juce_cryptography/encryption/juce_Primes.h; sourceTree = SOURCE_ROOT; };
+		F2F11D7C596DAE5579610CCC /* juce_win32_AudioCDReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_win32_AudioCDReader.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_win32_AudioCDReader.cpp; sourceTree = SOURCE_ROOT; };
+		F3D0224E4247BCB06A9E4DDF /* juce_KeyPressMappingSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_KeyPressMappingSet.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/commands/juce_KeyPressMappingSet.cpp; sourceTree = SOURCE_ROOT; };
+		F3F48717927A4E24F7373C09 /* juce_NamedValueSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_NamedValueSet.h; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_NamedValueSet.h; sourceTree = SOURCE_ROOT; };
+		F463A19E6EFEB2837582B117 /* juce_audio_processors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_audio_processors.h; path = ../../JuceLibraryCode/modules/juce_audio_processors/juce_audio_processors.h; sourceTree = SOURCE_ROOT; };
+		F46843B979D0385C733C797A /* juce_BubbleMessageComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_BubbleMessageComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_BubbleMessageComponent.cpp; sourceTree = SOURCE_ROOT; };
+		F4D2A03314AB1CF852CC4F2A /* juce_CPlusPlusCodeTokeniserFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_CPlusPlusCodeTokeniserFunctions.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/code_editor/juce_CPlusPlusCodeTokeniserFunctions.h; sourceTree = SOURCE_ROOT; };
+		F5642B98949DC0FA45EF904E /* juce_BufferedInputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_BufferedInputStream.h; path = ../../JuceLibraryCode/modules/juce_core/streams/juce_BufferedInputStream.h; sourceTree = SOURCE_ROOT; };
+		F5A00ACFA3D76168F22F1205 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		F6EBDA368C553C37BE703BE5 /* juce_Vector3D.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Vector3D.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Vector3D.h; sourceTree = SOURCE_ROOT; };
+		F70B7D65EF56B8A0ED36478C /* juce_WavAudioFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_WavAudioFormat.h; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_WavAudioFormat.h; sourceTree = SOURCE_ROOT; };
+		F796260525BD82FFC1D1732C /* juce_Uuid.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Uuid.cpp; path = ../../JuceLibraryCode/modules/juce_core/misc/juce_Uuid.cpp; sourceTree = SOURCE_ROOT; };
+		F7979AFD5780D9B2208736EE /* juce_TooltipWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_TooltipWindow.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TooltipWindow.cpp; sourceTree = SOURCE_ROOT; };
+		F7F374C05CDE0DB7712D18D1 /* juce_Atomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Atomic.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_Atomic.h; sourceTree = SOURCE_ROOT; };
+		F8322ED101601866FFB1698C /* juce_FileOutputStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_FileOutputStream.h; path = ../../JuceLibraryCode/modules/juce_core/files/juce_FileOutputStream.h; sourceTree = SOURCE_ROOT; };
+		F88A99110564C87FBA281F2C /* juce_module_info */ = {isa = PBXFileReference; lastKnownFileType = text; name = juce_module_info; path = ../../JuceLibraryCode/modules/juce_video/juce_module_info; sourceTree = SOURCE_ROOT; };
+		F8E202A1374401022F87F26E /* juce_CoreAudioFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_CoreAudioFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp; sourceTree = SOURCE_ROOT; };
+		F8EFE3709FDDC2D5F0843058 /* juce_Variant.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Variant.cpp; path = ../../JuceLibraryCode/modules/juce_core/containers/juce_Variant.cpp; sourceTree = SOURCE_ROOT; };
+		F94BFC6B5057806EEF8B59DA /* juce_AudioIODevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_AudioIODevice.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODevice.cpp; sourceTree = SOURCE_ROOT; };
+		F94DD42C7BBF81C101D3F605 /* EventNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EventNode.cpp; path = ../../Source/Processors/EventNode.cpp; sourceTree = SOURCE_ROOT; };
+		F9E2371F1A99B292F2947FF5 /* juce_DragAndDropTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_DragAndDropTarget.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_DragAndDropTarget.h; sourceTree = SOURCE_ROOT; };
+		F9F37AD1C3E7CA932FF44E69 /* juce_LagrangeInterpolator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_LagrangeInterpolator.cpp; path = ../../JuceLibraryCode/modules/juce_audio_basics/effects/juce_LagrangeInterpolator.cpp; sourceTree = SOURCE_ROOT; };
+		FA1F1E9C7DEA48CAE6C247F4 /* OpenEphysBoardLogoGray.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = OpenEphysBoardLogoGray.png; path = ../../Resources/Images/Icons/OpenEphysBoardLogoGray.png; sourceTree = SOURCE_ROOT; };
+		FA23A1334E4CFA77BC18A153 /* FPGAThread.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FPGAThread.cpp; path = ../../Source/Processors/DataThreads/FPGAThread.cpp; sourceTree = SOURCE_ROOT; };
+		FA2F04BA4E146ABF649BBE89 /* rhd2000evalboard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rhd2000evalboard.h; path = "../../Source/Processors/DataThreads/rhythm-api/rhd2000evalboard.h"; sourceTree = SOURCE_ROOT; };
+		FAC7E62CC15CA977A6FC72D1 /* juce_ChangeBroadcaster.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ChangeBroadcaster.cpp; path = ../../JuceLibraryCode/modules/juce_events/broadcasters/juce_ChangeBroadcaster.cpp; sourceTree = SOURCE_ROOT; };
+		FB071D0659E5F1CC630D765A /* FileReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FileReader.h; path = ../../Source/Processors/FileReader.h; sourceTree = SOURCE_ROOT; };
+		FB1B880F24F376D1AC52F2A6 /* juce_DrawableButton.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_DrawableButton.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/buttons/juce_DrawableButton.cpp; sourceTree = SOURCE_ROOT; };
+		FB1EA9CB3C695925627B0AC6 /* juce_HeapBlock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_HeapBlock.h; path = ../../JuceLibraryCode/modules/juce_core/memory/juce_HeapBlock.h; sourceTree = SOURCE_ROOT; };
+		FB33617B5082CC0CDC189F2C /* juce_KeyboardFocusTraverser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_KeyboardFocusTraverser.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/keyboard/juce_KeyboardFocusTraverser.h; sourceTree = SOURCE_ROOT; };
+		FB7E91937D3BBE00F64F0B72 /* juce_Colours.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Colours.h; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colours.h; sourceTree = SOURCE_ROOT; };
+		FC080F7DF94ABCB7EA09224A /* juce_Colour.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_Colour.cpp; path = ../../JuceLibraryCode/modules/juce_graphics/colour/juce_Colour.cpp; sourceTree = SOURCE_ROOT; };
+		FC20BDD5357D39AC43DFC255 /* juce_LADSPAPluginFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_LADSPAPluginFormat.cpp; path = ../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.cpp; sourceTree = SOURCE_ROOT; };
+		FC85D30C66E7A4E4A6CA29AE /* cpmono_bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file.otf; name = cpmono_bold.otf; path = ../../Resources/Fonts/cpmono_bold.otf; sourceTree = SOURCE_ROOT; };
+		FC887C6CD74FE33F8BA784A6 /* MergerEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MergerEditor.h; path = ../../Source/Processors/Editors/MergerEditor.h; sourceTree = SOURCE_ROOT; };
+		FD03E00D986C57096BA4EEF5 /* OscilloscopeEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OscilloscopeEditor.h; path = ../../Source/Processors/Editors/OscilloscopeEditor.h; sourceTree = SOURCE_ROOT; };
+		FD3A6BD3A8898E137DF257B9 /* juce_RelativeParallelogram.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_RelativeParallelogram.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeParallelogram.cpp; sourceTree = SOURCE_ROOT; };
+		FD770E73FD462E9C9F6DBFB2 /* juce_PositionableAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_PositionableAudioSource.h; path = ../../JuceLibraryCode/modules/juce_audio_basics/sources/juce_PositionableAudioSource.h; sourceTree = SOURCE_ROOT; };
+		FD88DA941838FC91D222DF35 /* juce_RecentlyOpenedFilesList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_RecentlyOpenedFilesList.h; path = ../../JuceLibraryCode/modules/juce_gui_extra/misc/juce_RecentlyOpenedFilesList.h; sourceTree = SOURCE_ROOT; };
+		FDAAB4F0D2A15A6F0F71945A /* juce_ResizableWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ResizableWindow.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_ResizableWindow.cpp; sourceTree = SOURCE_ROOT; };
+		FEB3730E084D7DD433D14A6C /* juce_MouseListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_MouseListener.h; path = ../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_MouseListener.h; sourceTree = SOURCE_ROOT; };
+		FEF0A4E3C8D22A830BCE2B67 /* juce_linux_JackAudio.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_linux_JackAudio.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp; sourceTree = SOURCE_ROOT; };
+		FF082466FC37DC44320B3B7E /* juce_Draggable3DOrientation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_Draggable3DOrientation.h; path = ../../JuceLibraryCode/modules/juce_opengl/opengl/juce_Draggable3DOrientation.h; sourceTree = SOURCE_ROOT; };
+		FF1B5858C942CA02EEC38E69 /* juce_ios_Audio.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ios_Audio.cpp; path = ../../JuceLibraryCode/modules/juce_audio_devices/native/juce_ios_Audio.cpp; sourceTree = SOURCE_ROOT; };
+		FF3E5A9F8B9250790C6DA089 /* juce_URL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = juce_URL.h; path = ../../JuceLibraryCode/modules/juce_core/network/juce_URL.h; sourceTree = SOURCE_ROOT; };
+		FF450FAFD49105CE7157DFC0 /* Channel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Channel.h; path = ../../Source/Processors/Channel.h; sourceTree = SOURCE_ROOT; };
+		FFABF04684556C4A54A62439 /* tictoc.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tictoc.cpp; path = ../../Source/Processors/tictoc.cpp; sourceTree = SOURCE_ROOT; };
+		FFBB9CE85A7C91FB11E4AEC8 /* juce_ImageComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_ImageComponent.cpp; path = ../../JuceLibraryCode/modules/juce_gui_basics/widgets/juce_ImageComponent.cpp; sourceTree = SOURCE_ROOT; };
+		FFFBDB9A00240D797751FEE6 /* DataWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataWindow.h; path = ../../Source/Processors/Visualization/DataWindow.h; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7BE915E5A64C787EBF13A8E7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0D3DFADD627629AD52668186 /* Accelerate.framework in Frameworks */,
+				38568B2E6C61E2F07173B568 /* AudioToolbox.framework in Frameworks */,
+				C8D7AC0B88A9A2C182B2B752 /* Carbon.framework in Frameworks */,
+				A94130738A9973148544664A /* Cocoa.framework in Frameworks */,
+				E5CBEA12D7AD7788C9BF5737 /* CoreAudio.framework in Frameworks */,
+				9212DC2AEE118398CC970DDF /* CoreMIDI.framework in Frameworks */,
+				3D0C7CA4AD9E3963D52E89BD /* DiscRecording.framework in Frameworks */,
+				3130878C465F3294A89CA142 /* IOKit.framework in Frameworks */,
+				E100912B2FCE36A30D097C95 /* OpenGL.framework in Frameworks */,
+				CAB9D9DEF279F93132B45F90 /* QTKit.framework in Frameworks */,
+				CA4DCF67B48352BE633A616D /* QuartzCore.framework in Frameworks */,
+				FD4865450F4C47FF3C6327FE /* QuickTime.framework in Frameworks */,
+				512D7D16D0A95BDD0D6D6E45 /* WebKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		008433D940C09C1A15B916BA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				39F287BE4C0B4F3BD4A949FD /* Accelerate.framework */,
+				C868329EBC1BBA606AB2EB88 /* AudioToolbox.framework */,
+				DBB769DEBCD6468C13A3CD25 /* Carbon.framework */,
+				F5A00ACFA3D76168F22F1205 /* Cocoa.framework */,
+				27313EA12BC45638321922CA /* CoreAudio.framework */,
+				243817BA562AD7FA76C834C9 /* CoreMIDI.framework */,
+				D685CFEA6344360FBFC355B6 /* DiscRecording.framework */,
+				E31563D2E7DDD8315F369233 /* IOKit.framework */,
+				9C21DBFB38865E5AFE367C6F /* OpenGL.framework */,
+				80C1B737D2C2CB519D1787D7 /* QTKit.framework */,
+				C055D09224D84121A3EBB29F /* QuartzCore.framework */,
+				56169D835A3E3029D6E3904C /* QuickTime.framework */,
+				4FD13AA663EEE7CC2F83033D /* WebKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		048B10371EA2D5C7D883CC70 /* Icons */ = {
+			isa = PBXGroup;
+			children = (
+				261B5AA82F2A86CC5500D8D2 /* ArduinoIcon.png */,
+				BE45C52599CD88A456166B49 /* monkey.png */,
+				D46A0FAD95FD6DAC1877712B /* rodent.png */,
+				92E3405CB31ACFE3F80BBAD4 /* OpenEphysBoardLogoBlack.png */,
+				FA1F1E9C7DEA48CAE6C247F4 /* OpenEphysBoardLogoGray.png */,
+				9F2BCD132F453B9D9EF09F15 /* RadioButtons-01.png */,
+				57941E5B2E1FF6028A68D4A7 /* RadioButtons-02.png */,
+				168823A9EBD85BFBFD2CE2EE /* RadioButtons-03.png */,
+				7FDFE493862CE27EFCAC3F7F /* RadioButtons-04.png */,
+				6D34DD9AB987A67BADE71C65 /* RadioButtons-05.png */,
+				D8AA3ED11D45FACF74B5FC05 /* RadioButtons_neutral-01.png */,
+				3A6FE617A781EEFFD39E1216 /* RadioButtons_neutral-02.png */,
+				CB2C4FD47184B2FE84408CAD /* RadioButtons_neutral-03.png */,
+				93EFC1AA800FC5DA2F04A213 /* RadioButtons_neutral-04.png */,
+				D41ED9ADBE3B27E185B2E3F3 /* RadioButtons_neutral-05.png */,
+				D9CB4CEC2C07346BE69262A0 /* RadioButtons_selected-01.png */,
+				A7FE538FF09AC8A58DE8F1BD /* RadioButtons_selected-02.png */,
+				AA3DAC9A4A3FF9E7D279FB23 /* RadioButtons_selected-03.png */,
+				79BBD2F2F31D76CC4F5BD012 /* RadioButtons_selected-04.png */,
+				32CEF6C84CD06B18035B035C /* RadioButtons_selected-05.png */,
+				EBD8622EAEF10558809888B7 /* RadioButtons_selected_over-01.png */,
+				1A22BB28E65B6D6636CCEBF1 /* RadioButtons_selected_over-02.png */,
+				1712916024EC787B6C231732 /* RadioButtons_selected_over-03.png */,
+				47976F6BE2942EED64AEA4D2 /* RadioButtons_selected_over-04.png */,
+				97C4F046D88561EEE245BE99 /* RadioButtons_selected_over-05.png */,
+				BBF5345C0570D87C01A73FF9 /* noise_wave.png */,
+				7C1D87A0C78F661FB459786B /* saw_wave.png */,
+				35AEAE0CC0B546625E163B9B /* sine_wave.png */,
+				BFF368651E3CEE5A900391A6 /* square_wave.png */,
+				5C5E4C396CD83C46F58644A2 /* triangle_wave.png */,
+				BEC4B69320BE492526794DFB /* wifi.png */,
+				6F9B89F7AD0E13887871D4FE /* SourceDrop.png */,
+				B1887A7D2E27FF4DD03D16C1 /* DefaultDataSource.png */,
+				8AE2DDA47B2DFDEEEF69B12F /* FileReaderIcon.png */,
+				DA0AE9F4A1DDC3555247216F /* IntanIcon.png */,
+			);
+			name = Icons;
+			sourceTree = "<group>";
+		};
+		09C2000EFECCE35F3F793E55 /* lookandfeel */ = {
+			isa = PBXGroup;
+			children = (
+				5FEFF62D585CF777C950E569 /* juce_LookAndFeel.cpp */,
+				A4FC82A8339698B6C1AC5F18 /* juce_LookAndFeel.h */,
+			);
+			name = lookandfeel;
+			sourceTree = "<group>";
+		};
+		09F214A405A08FDFC47244A5 /* players */ = {
+			isa = PBXGroup;
+			children = (
+				57F66B4A911601169AF195E9 /* juce_AudioProcessorPlayer.cpp */,
+				DDE89F0D5E01F079323CC89C /* juce_AudioProcessorPlayer.h */,
+			);
+			name = players;
+			sourceTree = "<group>";
+		};
+		0A3CD1724922FB098543C013 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				1194EE0956A9645270582979 /* juce_android_Messaging.cpp */,
+				BD1D02C70CCE095217581A5F /* juce_ios_MessageManager.mm */,
+				19A8A8E1BF043B390E02C429 /* juce_linux_Messaging.cpp */,
+				B0DCDCB162FDBF972FA5B548 /* juce_mac_MessageManager.mm */,
+				4B5998D72503BD73D28E828A /* juce_osx_MessageQueue.h */,
+				627956A7A1CB15251D02C8C5 /* juce_ScopedXLock.h */,
+				6DA8EC2F779DEBB701FE33CA /* juce_win32_HiddenMessageWindow.h */,
+				DB4FB8EAFA1714529E527C3D /* juce_win32_Messaging.cpp */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		147EC1A2CF770171DFB61105 /* sampler */ = {
+			isa = PBXGroup;
+			children = (
+				BF647E1FAE73208AC29C14F7 /* juce_Sampler.cpp */,
+				3EE92345839A4E5F608D82AC /* juce_Sampler.h */,
+			);
+			name = sampler;
+			sourceTree = "<group>";
+		};
+		14805A0D1A6C3ED796515AD6 /* format */ = {
+			isa = PBXGroup;
+			children = (
+				18C2F9CA38393D106FB834E2 /* juce_AudioPluginFormat.cpp */,
+				B174EBEF82212C8624300F59 /* juce_AudioPluginFormat.h */,
+				0316B49B86725305C70783CA /* juce_AudioPluginFormatManager.cpp */,
+				8E61792F6D6FC75CF18095CC /* juce_AudioPluginFormatManager.h */,
+			);
+			name = format;
+			sourceTree = "<group>";
+		};
+		14AA2721588E8A9253FFA98B /* synthesisers */ = {
+			isa = PBXGroup;
+			children = (
+				E97684DCE824DEDA6683C6CD /* juce_Synthesiser.cpp */,
+				74DE857CEFA10BC49FF591DB /* juce_Synthesiser.h */,
+			);
+			name = synthesisers;
+			sourceTree = "<group>";
+		};
+		17BAAA5A77781988BAA8CDEF /* xml */ = {
+			isa = PBXGroup;
+			children = (
+				B8D19858CC01BB5F7C35ED58 /* juce_XmlDocument.cpp */,
+				8F7B13BF318C11900A2277DD /* juce_XmlDocument.h */,
+				C2746A86EC16D3EA9FAC2C1D /* juce_XmlElement.cpp */,
+				83803D96768258DA20710764 /* juce_XmlElement.h */,
+			);
+			name = xml;
+			sourceTree = "<group>";
+		};
+		18CF6DB446071363AB4F1EC4 /* midi */ = {
+			isa = PBXGroup;
+			children = (
+				96E99CD031BD069997E387FE /* juce_MidiBuffer.cpp */,
+				018F4E079EB12A78C4F8F773 /* juce_MidiBuffer.h */,
+				1307DAE32BA702565A67D127 /* juce_MidiFile.cpp */,
+				E7366E169158F5A2D1D7B55A /* juce_MidiFile.h */,
+				DBED17FBB262C4DACEEDA9B0 /* juce_MidiKeyboardState.cpp */,
+				161E095C716133CB255B6CCD /* juce_MidiKeyboardState.h */,
+				8B0C9D288C428BA5D956AE13 /* juce_MidiMessage.cpp */,
+				927AE946A1371490D809876E /* juce_MidiMessage.h */,
+				560A28C1966B1817873CF764 /* juce_MidiMessageSequence.cpp */,
+				82EB2BDE7B9A4D5D945497B9 /* juce_MidiMessageSequence.h */,
+			);
+			name = midi;
+			sourceTree = "<group>";
+		};
+		1BF4F68D4169491DD79D0B01 /* contexts */ = {
+			isa = PBXGroup;
+			children = (
+				793A4A777FEFA450F86C78EE /* juce_GraphicsContext.cpp */,
+				891B132A0355007B4F37454C /* juce_GraphicsContext.h */,
+				AF1F3010721A6B29062E4838 /* juce_LowLevelGraphicsContext.h */,
+				B678CFC6B378A58834D2E41F /* juce_LowLevelGraphicsPostScriptRenderer.cpp */,
+				B5E8A19FF91BEAD02C63E05B /* juce_LowLevelGraphicsPostScriptRenderer.h */,
+				2F8252D3FF527D6559B12615 /* juce_LowLevelGraphicsSoftwareRenderer.cpp */,
+				301783FC4E3B19CA3C0AC85B /* juce_LowLevelGraphicsSoftwareRenderer.h */,
+			);
+			name = contexts;
+			sourceTree = "<group>";
+		};
+		1D78FCCF430CD91FD1DBD95B /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				E5C1D021C0FD6FAD082C5D75 /* GraphViewer.cpp */,
+				BA422CC894B825834A0C5479 /* GraphViewer.h */,
+				9F3B3184EC6D42CEA35D6ED8 /* EditorViewportButtons.cpp */,
+				E93BE115650B1CB80EACB841 /* EditorViewportButtons.h */,
+				0987F7E90136D0E08A606A22 /* SignalChainManager.cpp */,
+				48F6281AB92B232E5187D00C /* SignalChainManager.h */,
+				7E875E681E18D693D5ADB2FB /* EditorViewport.cpp */,
+				57FBA8BC3104D3AF41FBECD8 /* EditorViewport.h */,
+				79C91DDF3BC3F15D0338E504 /* ProcessorList.cpp */,
+				105B1452DF6CE1D80D69A9D1 /* ProcessorList.h */,
+				3774BBCA6CB133D9A854CF71 /* CustomLookAndFeel.cpp */,
+				19148DBA36B94FA639DF3A72 /* CustomLookAndFeel.h */,
+				17E13CCDA0C82F92EAB05BE6 /* InfoLabel.cpp */,
+				D2696B30CBEAD7CE72510AFA /* InfoLabel.h */,
+				47A3942AC30A3212C01F1CAF /* DataViewport.cpp */,
+				7D9374931D760ADC65DCBFC6 /* DataViewport.h */,
+				7BD2C39F13FDE202141C4B41 /* MessageCenter.cpp */,
+				9B9EDDFA0AE4991BC7FC7263 /* MessageCenter.h */,
+				94AED5D544719B438B3EE723 /* LogWindow.cpp */,
+				C224FFE93AB9ACD2263F8877 /* LogWindow.h */,
+				610E487E060C42B52FD5AAC9 /* ControlPanel.cpp */,
+				0FE8ACC50ED8E7FFC9E6B9B4 /* ControlPanel.h */,
+				D2A3B4CDD296B4CEC6902FD7 /* UIComponent.cpp */,
+				3FC794735FA8DDA39A62224B /* UIComponent.h */,
+			);
+			name = UI;
+			sourceTree = "<group>";
+		};
+		1DF9A40DB990AEC6AD278C31 /* network */ = {
+			isa = PBXGroup;
+			children = (
+				0BF3932F3EA1149C2F7E31F9 /* juce_IPAddress.cpp */,
+				3AFF1BE2EC512169120121CF /* juce_IPAddress.h */,
+				4F31D61C0C2AB3472C6C1429 /* juce_MACAddress.cpp */,
+				BC953E395B22FB1D305E483E /* juce_MACAddress.h */,
+				087FA26464FB283EC6FD4795 /* juce_NamedPipe.cpp */,
+				C67C5EC0EE8DBC501C8AA395 /* juce_NamedPipe.h */,
+				D9C9FCA6D705B72B80DB1142 /* juce_Socket.cpp */,
+				01D791730840EB0BA7FD61BA /* juce_Socket.h */,
+				8F29CAC0059E3697A5A3652F /* juce_URL.cpp */,
+				FF3E5A9F8B9250790C6DA089 /* juce_URL.h */,
+			);
+			name = network;
+			sourceTree = "<group>";
+		};
+		1E253D48AC292849CD3054CB /* maths */ = {
+			isa = PBXGroup;
+			children = (
+				0A8BC957DBEE226346C1EA25 /* juce_BigInteger.cpp */,
+				E7EE416EF527C7506B499070 /* juce_BigInteger.h */,
+				2B19F2DE42A91F56C2380F9A /* juce_Expression.cpp */,
+				811C4D165AD7AABF4055059C /* juce_Expression.h */,
+				90AD1B6A2293F625D786507A /* juce_MathsFunctions.h */,
+				2B134713E91426120A994CB7 /* juce_Random.cpp */,
+				90607327D7A1BB3C2C4E9264 /* juce_Random.h */,
+				6A559D9595A54EF52BF0773A /* juce_Range.h */,
+			);
+			name = maths;
+			sourceTree = "<group>";
+		};
+		208431C2D4A7C383FD247CE3 /* format_types */ = {
+			isa = PBXGroup;
+			children = (
+				03D7B457E0915E43A6AFF4B4 /* juce_AudioUnitPluginFormat.h */,
+				8515E367462BEF36233E2447 /* juce_AudioUnitPluginFormat.mm */,
+				FC20BDD5357D39AC43DFC255 /* juce_LADSPAPluginFormat.cpp */,
+				93F842958BCE6A9E09862CF7 /* juce_LADSPAPluginFormat.h */,
+				EAB637B566FEBBDADA654262 /* juce_VSTMidiEventList.h */,
+				B93B8666F8AF2E5D2E851B1C /* juce_VSTPluginFormat.cpp */,
+				6589EAEF497ABA76A295B121 /* juce_VSTPluginFormat.h */,
+			);
+			name = format_types;
+			sourceTree = "<group>";
+		};
+		2097A54F0DC05D433BEB7C81 /* sources */ = {
+			isa = PBXGroup;
+			children = (
+				F1DBAE92084D9D90234AC436 /* juce_AudioSourcePlayer.cpp */,
+				D0D7CE266BD7CC5455926700 /* juce_AudioSourcePlayer.h */,
+				7CD03E334269D693E1B84856 /* juce_AudioTransportSource.cpp */,
+				402BC572EE3E8EC418946CE0 /* juce_AudioTransportSource.h */,
+			);
+			name = sources;
+			sourceTree = "<group>";
+		};
+		21BB3DD364DC0C39CC9594B9 /* processors */ = {
+			isa = PBXGroup;
+			children = (
+				5B2CDF3CF10A92F6CA45F3DE /* juce_AudioPlayHead.h */,
+				3DA70F9AAA904543B519874B /* juce_AudioPluginInstance.h */,
+				06072EC6BCD3B7D8C17C2402 /* juce_AudioProcessor.cpp */,
+				C54760E4888674CF3CF022E6 /* juce_AudioProcessor.h */,
+				803D306CDAC2BD3BA04534EA /* juce_AudioProcessorEditor.cpp */,
+				256E22D98B16B09BD521C4A4 /* juce_AudioProcessorEditor.h */,
+				7EA46209F07B2C8A83D0873A /* juce_AudioProcessorGraph.cpp */,
+				2F9BB379BCFCFE0D88CC0408 /* juce_AudioProcessorGraph.h */,
+				D960588B732D973B82500E2D /* juce_AudioProcessorListener.h */,
+				32A1325430309CF4114C9618 /* juce_GenericAudioProcessorEditor.cpp */,
+				C74399C81B1A0552CC52093E /* juce_GenericAudioProcessorEditor.h */,
+				A17E8162EC7A0E513DDEB23C /* juce_PluginDescription.cpp */,
+				BA03776682290FF1AF4C0106 /* juce_PluginDescription.h */,
+			);
+			name = processors;
+			sourceTree = "<group>";
+		};
+		23BCC80BAA5B674946A538A4 /* menus */ = {
+			isa = PBXGroup;
+			children = (
+				A19C4BB4BD69D4351B344A17 /* juce_MenuBarComponent.cpp */,
+				EFC21F3CD0EB87D67E044E06 /* juce_MenuBarComponent.h */,
+				D7E51310BD1B8EF6A2A77177 /* juce_MenuBarModel.cpp */,
+				4B3DBFE485F45E62C53A90B8 /* juce_MenuBarModel.h */,
+				0790CCE2FCFDFA6944DFC402 /* juce_PopupMenu.cpp */,
+				361E3A46C9BFAD1530593487 /* juce_PopupMenu.h */,
+			);
+			name = menus;
+			sourceTree = "<group>";
+		};
+		2512062DBF7A12B895E6F6D9 /* audio_cd */ = {
+			isa = PBXGroup;
+			children = (
+				19043050D1DADAEAB48FB803 /* juce_AudioCDBurner.h */,
+				078625CF5C083AD538D23401 /* juce_AudioCDReader.cpp */,
+				1463D2DAB3A1D8CEE825056A /* juce_AudioCDReader.h */,
+			);
+			name = audio_cd;
+			sourceTree = "<group>";
+		};
+		259BB14332EF6F524455BF3C /* broadcasters */ = {
+			isa = PBXGroup;
+			children = (
+				8CAEF601359DB6CB50E89D1A /* juce_ActionBroadcaster.cpp */,
+				E20D5F2F75478DA4943CEDBD /* juce_ActionBroadcaster.h */,
+				38711221C089A16CC29E93D2 /* juce_ActionListener.h */,
+				3A2C762575D9728B1F822ED3 /* juce_AsyncUpdater.cpp */,
+				5379FC603780F30A2F05FE78 /* juce_AsyncUpdater.h */,
+				FAC7E62CC15CA977A6FC72D1 /* juce_ChangeBroadcaster.cpp */,
+				B8A9063181FEE1920095F824 /* juce_ChangeBroadcaster.h */,
+				86E8E44A13F17083ED300BD5 /* juce_ChangeListener.h */,
+				0DD0CBF9BBD4A503F2B7868D /* juce_ListenerList.h */,
+			);
+			name = broadcasters;
+			sourceTree = "<group>";
+		};
+		2A882D30C0E50E70FCD95554 /* lookandfeel */ = {
+			isa = PBXGroup;
+			children = (
+				76140C0485FDDA98C3D98E2A /* juce_OldSchoolLookAndFeel.cpp */,
+				65BE7542749DCCAE33ACF40F /* juce_OldSchoolLookAndFeel.h */,
+			);
+			name = lookandfeel;
+			sourceTree = "<group>";
+		};
+		2A96C9BD7209F57EE8E19BBA /* hashing */ = {
+			isa = PBXGroup;
+			children = (
+				B2017626F9A05C8C0EBE9B7E /* juce_MD5.cpp */,
+				0FA84E49DB493BCC886A355F /* juce_MD5.h */,
+				B17AA637E5C357FACC38EBB7 /* juce_SHA256.cpp */,
+				8C38407151E149A7E2A15801 /* juce_SHA256.h */,
+			);
+			name = hashing;
+			sourceTree = "<group>";
+		};
+		2D49786EE07B37713213F905 /* juce_opengl */ = {
+			isa = PBXGroup;
+			children = (
+				57F522311CAC2E8BF761B95A /* opengl */,
+				7C6BF9E0D166E4E5C3F2A005 /* native */,
+				4540694F9744C9F4D29149CE /* juce_module_info */,
+				AE1EA04666EAD34D0CA0373D /* juce_opengl.h */,
+			);
+			name = juce_opengl;
+			sourceTree = "<group>";
+		};
+		328279397CFDFC5C31C08F49 /* images */ = {
+			isa = PBXGroup;
+			children = (
+				9731D54410B06C1000370316 /* juce_Image.cpp */,
+				217032322A2570ABAC47194C /* juce_Image.h */,
+				85928E2EF1C438EBC9EB07EA /* juce_ImageCache.cpp */,
+				879B0383EF2A8B116903A500 /* juce_ImageCache.h */,
+				7F92025F0B8FD4FA725CC70B /* juce_ImageConvolutionKernel.cpp */,
+				A540869F28EE158A0A348C28 /* juce_ImageConvolutionKernel.h */,
+				5AB3809F029824EE2DE0A798 /* juce_ImageFileFormat.cpp */,
+				CC35C78D5B446ABF57DDDAE0 /* juce_ImageFileFormat.h */,
+			);
+			name = images;
+			sourceTree = "<group>";
+		};
+		328BE41789531FE4F91F7DA1 /* Juce Modules */ = {
+			isa = PBXGroup;
+			children = (
+				9311E4762BC3218510204A0F /* juce_audio_basics */,
+				83416B76189CFC2030936CCA /* juce_audio_devices */,
+				E2F864696FA2DDDAD60C7E83 /* juce_audio_formats */,
+				95530BD93D8ECFCC072C0850 /* juce_audio_processors */,
+				702A741EEADCBB982DDE18B0 /* juce_audio_utils */,
+				7333A0F468D3745057EB2368 /* juce_core */,
+				F196226BFBA15D76688C61C6 /* juce_cryptography */,
+				A7F7E551BA5A75737261BB4C /* juce_data_structures */,
+				F61CCB10A356CE4278F74478 /* juce_events */,
+				448EFC87A2DEF32F9547F801 /* juce_graphics */,
+				83E1A8B708A967FC7D5B9FE4 /* juce_gui_basics */,
+				E3229181F8CC2BD5E409AF00 /* juce_gui_extra */,
+				2D49786EE07B37713213F905 /* juce_opengl */,
+				AD985677A45CD32AB58EECA5 /* juce_video */,
+			);
+			name = "Juce Modules";
+			sourceTree = "<group>";
+		};
+		3564F28A16A2BDF3B1D5035E /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				420B0E95F1300ABFDC125DBF /* AccessClass.cpp */,
+				DB4FF7675E5C98CF62DA8A2E /* AccessClass.h */,
+				B016FBDF648372A23D7EAAD8 /* Network */,
+				BCD632E634E0F8A50827F9B6 /* Dsp */,
+				C451728043944D40C69166C1 /* Audio */,
+				83A3E005DDFCC55F277EEDA5 /* Processors */,
+				1D78FCCF430CD91FD1DBD95B /* UI */,
+				E08E877C3A6283CF5C803957 /* MainWindow.cpp */,
+				BB26BA9CFAE8C836251E8EAF /* MainWindow.h */,
+				2C89EC72FF6A7118EF459DC3 /* Main.cpp */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		3CAB707CFF748C665802E65E /* logging */ = {
+			isa = PBXGroup;
+			children = (
+				658D08592154525DA1C40826 /* juce_FileLogger.cpp */,
+				AB4C7059669AC385B02179C1 /* juce_FileLogger.h */,
+				7ECD5DB4BEBC44559D064E08 /* juce_Logger.cpp */,
+				0A351ED88CF00C0697701E73 /* juce_Logger.h */,
+			);
+			name = logging;
+			sourceTree = "<group>";
+		};
+		3DA4EA9C737426FDAF1484AD /* windows */ = {
+			isa = PBXGroup;
+			children = (
+				7E581214A64A535E03EA759B /* juce_AlertWindow.cpp */,
+				71CF8F6995DF1BA2038C21D6 /* juce_AlertWindow.h */,
+				CDC18ABAFEF000C720CE8622 /* juce_CallOutBox.cpp */,
+				927FCF11005E78D499DAF197 /* juce_CallOutBox.h */,
+				78BA978C614603B5E9ECFFF1 /* juce_ComponentPeer.cpp */,
+				483ABD5C1CF789943AB4AFB6 /* juce_ComponentPeer.h */,
+				2D577016FEEE23DD5703C924 /* juce_DialogWindow.cpp */,
+				9B4EA34E8F90B7CC77694B7E /* juce_DialogWindow.h */,
+				EEA51B7EF1CF19028C6672E0 /* juce_DocumentWindow.cpp */,
+				581287A24510A9EACEE09CE4 /* juce_DocumentWindow.h */,
+				BA09F5CDB1C01E0FC153DB8E /* juce_NativeMessageBox.h */,
+				FDAAB4F0D2A15A6F0F71945A /* juce_ResizableWindow.cpp */,
+				13D9868B08E941F6827E157C /* juce_ResizableWindow.h */,
+				B6567CAE2B538E79E7DA814C /* juce_ThreadWithProgressWindow.cpp */,
+				027C1143CC66EA8F73C39A74 /* juce_ThreadWithProgressWindow.h */,
+				F7979AFD5780D9B2208736EE /* juce_TooltipWindow.cpp */,
+				EA2FC92CECD1EDA1F07DC59C /* juce_TooltipWindow.h */,
+				55811E331B55E0547326CF22 /* juce_TopLevelWindow.cpp */,
+				D51575B9AA7216CCE4B558E4 /* juce_TopLevelWindow.h */,
+			);
+			name = windows;
+			sourceTree = "<group>";
+		};
+		3DE49DED45C5CDD8D184E248 /* Serial */ = {
+			isa = PBXGroup;
+			children = (
+				48E12736F471C43C959AD15C /* PulsePal.cpp */,
+				79C32CA8069962F5DE48F633 /* PulsePal.h */,
+				3753B3B311AE0A9F4CC5AD40 /* ofArduino.cpp */,
+				758BC480F153DEA79304366B /* ofArduino.h */,
+				DEF465116BB906FD116DA5EB /* ofConstants.h */,
+				308F614D30DCB9AE3767C928 /* ofSerial.cpp */,
+				92CB21BEE17D1DD03106AD87 /* ofSerial.h */,
+			);
+			name = Serial;
+			sourceTree = "<group>";
+		};
+		42DE5996B56B332A5B6C636D /* undomanager */ = {
+			isa = PBXGroup;
+			children = (
+				D71AD519382D547C958B0175 /* juce_UndoableAction.h */,
+				11D619EEF63C1827EA91F593 /* juce_UndoManager.cpp */,
+				DEB9A630503639D42056236B /* juce_UndoManager.h */,
+			);
+			name = undomanager;
+			sourceTree = "<group>";
+		};
+		42F1804D0EC2EB60625F783F /* midi_io */ = {
+			isa = PBXGroup;
+			children = (
+				26FF78F12CCB8725C0DAF9C2 /* juce_MidiInput.h */,
+				988F01B2B51B2AC7293D07DA /* juce_MidiMessageCollector.cpp */,
+				A9A0BC63EB466C75D1B9326A /* juce_MidiMessageCollector.h */,
+				B64193A23B69D4A88CDEDD0C /* juce_MidiOutput.cpp */,
+				0242AB5BCD8C002DC2E30BAC /* juce_MidiOutput.h */,
+			);
+			name = midi_io;
+			sourceTree = "<group>";
+		};
+		444DE4CB4BD092CB31057DFC /* buttons */ = {
+			isa = PBXGroup;
+			children = (
+				5FEBF3F722DB6191BF659816 /* juce_ArrowButton.cpp */,
+				08DAD5894A480950C66F5873 /* juce_ArrowButton.h */,
+				7CF939BD59D45EB41B5FE628 /* juce_Button.cpp */,
+				390856DF83DAC70909D5B397 /* juce_Button.h */,
+				FB1B880F24F376D1AC52F2A6 /* juce_DrawableButton.cpp */,
+				D8AFDCC674A7514B7019EEA6 /* juce_DrawableButton.h */,
+				7387114E34496F4606550863 /* juce_HyperlinkButton.cpp */,
+				80A612858FA1177A262744C6 /* juce_HyperlinkButton.h */,
+				B11E5B5E4483AF89E6DCBAB3 /* juce_ImageButton.cpp */,
+				393801D2B91773D376D874B0 /* juce_ImageButton.h */,
+				B1ECBE9C48227CBDB16E3702 /* juce_ShapeButton.cpp */,
+				44E04E5F584A8BFAD062A09D /* juce_ShapeButton.h */,
+				E6D3A973D5CEF18CA2BAFF59 /* juce_TextButton.cpp */,
+				83950E9D0D7C100B7DCA0E55 /* juce_TextButton.h */,
+				31BE5E435604D33173940048 /* juce_ToggleButton.cpp */,
+				92EC6BB8A8C4C5A61F43C233 /* juce_ToggleButton.h */,
+				9C4342320D2DD65E2BD6351C /* juce_ToolbarButton.cpp */,
+				98C81B13A0C34D8A4E93ADD1 /* juce_ToolbarButton.h */,
+			);
+			name = buttons;
+			sourceTree = "<group>";
+		};
+		448EFC87A2DEF32F9547F801 /* juce_graphics */ = {
+			isa = PBXGroup;
+			children = (
+				D3C338AADE455AEA6C248E21 /* colour */,
+				1BF4F68D4169491DD79D0B01 /* contexts */,
+				328279397CFDFC5C31C08F49 /* images */,
+				7E444D9FB4474A6546E9B779 /* image_formats */,
+				91DA3CD69EAB03C727AA39C8 /* geometry */,
+				89F126369D1761C7A09E35C3 /* placement */,
+				6837ABCAE2AD67F0AD5F9AE3 /* fonts */,
+				D6EA061B97C039BF4BAAB444 /* effects */,
+				E30221BFC59C887A6337E8C8 /* native */,
+				25433DB6D2EAEBB307EFB960 /* juce_module_info */,
+				E67C5ACDC8208CDE200EC8C6 /* juce_graphics.h */,
+			);
+			name = juce_graphics;
+			sourceTree = "<group>";
+		};
+		45BA9E76F27503E30F331299 /* commands */ = {
+			isa = PBXGroup;
+			children = (
+				167524110873F9888CF1B9E8 /* juce_ApplicationCommandID.h */,
+				0DBB88B6BEC06FCECE4CBD28 /* juce_ApplicationCommandInfo.cpp */,
+				0B2502A656E77E00AF15A343 /* juce_ApplicationCommandInfo.h */,
+				70BF68C222D1E0A0368EB845 /* juce_ApplicationCommandManager.cpp */,
+				E79B7DC03F81DA1F8CDE21CA /* juce_ApplicationCommandManager.h */,
+				4B74A7F0FDCE3E1706E5B320 /* juce_ApplicationCommandTarget.cpp */,
+				C6BDC4DAD5B40321DA67462A /* juce_ApplicationCommandTarget.h */,
+				F3D0224E4247BCB06A9E4DDF /* juce_KeyPressMappingSet.cpp */,
+				1CFA355CD6811C253C72BDDA /* juce_KeyPressMappingSet.h */,
+			);
+			name = commands;
+			sourceTree = "<group>";
+		};
+		469F0AB7234589951A8F29FA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				46EF49B14DF7357A8287D9D8 /* Info.plist */,
+				BBE1DB78E35135B41537DCB5 /* RecentFilesMenuTemplate.nib */,
+				61317B5191E05925F232E18C /* unibody-8.otf */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		4CA0453E4C12495F1018A4E1 /* filebrowser */ = {
+			isa = PBXGroup;
+			children = (
+				B83EBFAE6306941F79044523 /* juce_DirectoryContentsDisplayComponent.cpp */,
+				ACA28D2B1FECD2C57F0250A6 /* juce_DirectoryContentsDisplayComponent.h */,
+				6A63308EBE68478531604BA4 /* juce_DirectoryContentsList.cpp */,
+				7BE7EBBCC4DCF760A1AA697E /* juce_DirectoryContentsList.h */,
+				353937A4E68C8C6916C6D1F9 /* juce_FileBrowserComponent.cpp */,
+				AD7D35FCD8CF66B6C393A7F7 /* juce_FileBrowserComponent.h */,
+				9C864C7DBAF37CD0719996A9 /* juce_FileBrowserListener.h */,
+				3EAF57CE45DBACE2F88DA4C5 /* juce_FileChooser.cpp */,
+				945DC754F2EACDFFB7926DE8 /* juce_FileChooser.h */,
+				033AE5DE19F0EEDC47D41C80 /* juce_FileChooserDialogBox.cpp */,
+				B4F0C0B262654C4782B5AC49 /* juce_FileChooserDialogBox.h */,
+				284F3E94F0C96EA1DD89E606 /* juce_FileFilter.cpp */,
+				65A447DCF8A68BAABC20FC7D /* juce_FileFilter.h */,
+				85C3F7CDF87409A56082DF67 /* juce_FileListComponent.cpp */,
+				DACD0879E139527D971D3AC4 /* juce_FileListComponent.h */,
+				52A8F84DCDDF0186B511B9CD /* juce_FilenameComponent.cpp */,
+				499A12199A8A8C5AEDAA47E4 /* juce_FilenameComponent.h */,
+				1C474C73937D98E9D3FFEEC0 /* juce_FilePreviewComponent.h */,
+				6BA7D7A7E3E2E646E50D334A /* juce_FileSearchPathListComponent.cpp */,
+				786A97B2B4E2BB6406546647 /* juce_FileSearchPathListComponent.h */,
+				696F2DC49934E6F01A2DF9FE /* juce_FileTreeComponent.cpp */,
+				405298E6CE1C80EC7CC43A87 /* juce_FileTreeComponent.h */,
+				C2D1409D20E154E43569C725 /* juce_ImagePreviewComponent.cpp */,
+				E58A18793D25A1D75811A052 /* juce_ImagePreviewComponent.h */,
+				881237D5E366342B117C0ED7 /* juce_WildcardFileFilter.cpp */,
+				316FB94579DA666A388F429A /* juce_WildcardFileFilter.h */,
+			);
+			name = filebrowser;
+			sourceTree = "<group>";
+		};
+		4DD214F6A346B4C4F28B3C5A /* embedding */ = {
+			isa = PBXGroup;
+			children = (
+				901C720965646841A94EB099 /* juce_ActiveXControlComponent.h */,
+				32D568631762765C07D4BF0D /* juce_NSViewComponent.h */,
+				0E4B0B8425DBA19B6F3FE4BF /* juce_UIViewComponent.h */,
+			);
+			name = embedding;
+			sourceTree = "<group>";
+		};
+		4E3C60995CC567F1A839CAE3 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				258938780F93A7CF41366F26 /* RecordControl.cpp */,
+				C5785E58E6F915165729EF16 /* RecordControl.h */,
+				4867923F31CC3EDC9B1A5BE5 /* Merger.cpp */,
+				6880C148A38A5C8D0092E358 /* Merger.h */,
+				2C4730CAFED4F6292B575318 /* Splitter.cpp */,
+				B1082A8A306A1947F5B0E5FC /* Splitter.h */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
+		530413F49A2E29570D8A9761 /* timers */ = {
+			isa = PBXGroup;
+			children = (
+				B1A8C18C6E4B3572B8B750AD /* juce_MultiTimer.cpp */,
+				DC200873B263C55E82B5384D /* juce_MultiTimer.h */,
+				0A46EF94E558D5E19F96E646 /* juce_Timer.cpp */,
+				7EBEBC6DBA8DCA5A5D8C72E1 /* juce_Timer.h */,
+			);
+			name = timers;
+			sourceTree = "<group>";
+		};
+		553F5880E9CFE9C4A045C0C0 /* effects */ = {
+			isa = PBXGroup;
+			children = (
+				C2F9D279FCC5C4AD56A0C1DF /* juce_Decibels.h */,
+				3BEB59C6E8F833331C0783D5 /* juce_IIRFilter.cpp */,
+				63F4150ABBA43B2215230034 /* juce_IIRFilter.h */,
+				F9F37AD1C3E7CA932FF44E69 /* juce_LagrangeInterpolator.cpp */,
+				65751E743D5EFD4066E50746 /* juce_LagrangeInterpolator.h */,
+				E419C9DA3202B8B6EC2DB723 /* juce_Reverb.h */,
+			);
+			name = effects;
+			sourceTree = "<group>";
+		};
+		572BB2781CE421A968F9D023 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				8882F8EBE55F52FA8E519249 /* juce_android_Files.cpp */,
+				EF610B2A17D9B1C0D24DCE67 /* juce_android_JNIHelpers.h */,
+				9B5D838CB6224E82C9B36AA3 /* juce_android_Misc.cpp */,
+				982E1A954C316920557F029C /* juce_android_Network.cpp */,
+				23F048594D4C9AD8C3399877 /* juce_android_SystemStats.cpp */,
+				C7CA628FE3E1E3D16B24E059 /* juce_android_Threads.cpp */,
+				60B1BDA3E9E14F9515963082 /* juce_BasicNativeHeaders.h */,
+				3FB80C5CFD953986778DCBA2 /* juce_linux_Files.cpp */,
+				5F6DCA68A982E930389644FD /* juce_linux_Network.cpp */,
+				D22D3958949713747DAF59A3 /* juce_linux_SystemStats.cpp */,
+				4D67518E9223C1C19BD4EF2E /* juce_linux_Threads.cpp */,
+				A950BD747F318BF6D555CB06 /* juce_mac_Files.mm */,
+				63AF6BE7FE2A9E7882743B4F /* juce_mac_Network.mm */,
+				28847C807E6B05303FB8FB34 /* juce_mac_Strings.mm */,
+				BC06C1E8052799F4696101C3 /* juce_mac_SystemStats.mm */,
+				B87864B2D6A2E741D4B426A3 /* juce_mac_Threads.mm */,
+				8F08D5488CE147D693BA21E2 /* juce_osx_ObjCHelpers.h */,
+				28D5AEEEFC4FA8877419C829 /* juce_posix_NamedPipe.cpp */,
+				ECBEF88BBC974D96ED781C75 /* juce_posix_SharedCode.h */,
+				86F4AAFCE3FEB34E325F3020 /* juce_win32_ComSmartPtr.h */,
+				BCB6A6D5A0C1417D74C29632 /* juce_win32_Files.cpp */,
+				698B0EC670DA47934444381B /* juce_win32_Network.cpp */,
+				EE2C669B127D00C86B1B8CA8 /* juce_win32_Registry.cpp */,
+				C0A718EA721772EA6B837F39 /* juce_win32_SystemStats.cpp */,
+				77B3E84324445076F1F907E9 /* juce_win32_Threads.cpp */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		57F522311CAC2E8BF761B95A /* opengl */ = {
+			isa = PBXGroup;
+			children = (
+				FF082466FC37DC44320B3B7E /* juce_Draggable3DOrientation.h */,
+				05DCAE8CA29532E2169D7AC1 /* juce_Matrix3D.h */,
+				4CF403118BBAAD5B6763542A /* juce_OpenGLContext.cpp */,
+				A3B6D091280930A016DF8FDA /* juce_OpenGLContext.h */,
+				146C6A6E3C6B17F2AF475B50 /* juce_OpenGLFrameBuffer.cpp */,
+				C5F9A0F8EB81AC15D9BDD61F /* juce_OpenGLFrameBuffer.h */,
+				B113BC1061788A9ECB1337C5 /* juce_OpenGLGraphicsContext.cpp */,
+				A41AEA0D3ACB2B1E6713AE08 /* juce_OpenGLGraphicsContext.h */,
+				D0247929128D618A2EB01D86 /* juce_OpenGLHelpers.cpp */,
+				4C4E2282C145D13C86CB23FA /* juce_OpenGLHelpers.h */,
+				AC116E6590D49AB2EF19CB9E /* juce_OpenGLImage.cpp */,
+				9F2853D1A12B686BE3BA2C61 /* juce_OpenGLImage.h */,
+				29381F22B8FDF48C3EAC3A9F /* juce_OpenGLPixelFormat.cpp */,
+				455FFBB0C34B760D892D2D57 /* juce_OpenGLPixelFormat.h */,
+				5D9792840E8050DCC766B368 /* juce_OpenGLRenderer.h */,
+				61B0CBF705D5FC0431776286 /* juce_OpenGLShaderProgram.cpp */,
+				EF7B66764093D950724EFE70 /* juce_OpenGLShaderProgram.h */,
+				971E49A78543AADB8CA1D2B7 /* juce_OpenGLTexture.cpp */,
+				D4B0BD47094D79AB6382228B /* juce_OpenGLTexture.h */,
+				12B5243A9435FABAFBE20165 /* juce_Quaternion.h */,
+				F6EBDA368C553C37BE703BE5 /* juce_Vector3D.h */,
+			);
+			name = opengl;
+			sourceTree = "<group>";
+		};
+		5B916D6239703986EFCDB624 /* Buttons */ = {
+			isa = PBXGroup;
+			children = (
+				C5D9C53AE4AE414244E1E19A /* muteoff.png */,
+				A764EF4F46F472715B250E41 /* muteon.png */,
+				05C35036E964AAD6024E0766 /* MergerA-01.png */,
+				CD7E06ED47B243518F42DA49 /* MergerA-02.png */,
+				4F4E8E3B32DB7A91B41C9FFA /* MergerB-01.png */,
+				3FFC2A3429D8B1D957D18CA7 /* MergerB-02.png */,
+				A3CAB6B56641ED68D9784348 /* PipelineA-01.png */,
+				6B7252D3F574AE21BE464327 /* PipelineA-02.png */,
+				381F5DC605AE69088004DF80 /* PipelineB-01.png */,
+				5EA661C13CB7197A45F20028 /* PipelineB-02.png */,
+			);
+			name = Buttons;
+			sourceTree = "<group>";
+		};
+		6101DBF4D993FE2CB50D4F90 /* drawables */ = {
+			isa = PBXGroup;
+			children = (
+				13212C01A5E138553FAFBE9C /* juce_Drawable.cpp */,
+				9D13E0F774807670270F4790 /* juce_Drawable.h */,
+				C5287F057A6A88BC33D5498A /* juce_DrawableComposite.cpp */,
+				766923F74E30FF5D6B12E7CE /* juce_DrawableComposite.h */,
+				9EAAE3C0BFF3D753C375A5FC /* juce_DrawableImage.cpp */,
+				F2A500BA3500C4A9D5792A54 /* juce_DrawableImage.h */,
+				25F7BEADC001FA3D1EA9B32C /* juce_DrawablePath.cpp */,
+				E946426F95E0240683CB3337 /* juce_DrawablePath.h */,
+				911CCC0A579792DC56807DEC /* juce_DrawableRectangle.cpp */,
+				617F5DFAAE97F48FA996A781 /* juce_DrawableRectangle.h */,
+				4434939E139A45962C8CFB4C /* juce_DrawableShape.cpp */,
+				496180D5D96088CBB59035B1 /* juce_DrawableShape.h */,
+				08A7A7FD7D77C0657270E9BF /* juce_DrawableText.cpp */,
+				700597338DEC9AB65C4C8A5E /* juce_DrawableText.h */,
+				ED86166920362E9D2BE2CB26 /* juce_SVGParser.cpp */,
+			);
+			name = drawables;
+			sourceTree = "<group>";
+		};
+		62693BDBB3A4F98A8A8B45F6 /* gui */ = {
+			isa = PBXGroup;
+			children = (
+				67BB47E709B643D4C01AB34C /* juce_AudioDeviceSelectorComponent.cpp */,
+				45A66E543B62A2C32AB3BA23 /* juce_AudioDeviceSelectorComponent.h */,
+				EF3F9AA8D70E1D4D55F13182 /* juce_AudioThumbnail.cpp */,
+				C1E1CCE5796B40E0A45FB021 /* juce_AudioThumbnail.h */,
+				482A60A44EE6CB84FCB9DC88 /* juce_AudioThumbnailBase.h */,
+				BD59A961F87AB628777894DC /* juce_AudioThumbnailCache.cpp */,
+				DFFB7396DCE9DF1253217584 /* juce_AudioThumbnailCache.h */,
+				7C71195623459A6C2524D418 /* juce_MidiKeyboardComponent.cpp */,
+				784233150B26826701C09103 /* juce_MidiKeyboardComponent.h */,
+			);
+			name = gui;
+			sourceTree = "<group>";
+		};
+		6415B8D280F206E770758A6A /* streams */ = {
+			isa = PBXGroup;
+			children = (
+				9B178E9015CF469CFD41BC79 /* juce_BufferedInputStream.cpp */,
+				F5642B98949DC0FA45EF904E /* juce_BufferedInputStream.h */,
+				32976762B1DB850DB65B9504 /* juce_FileInputSource.cpp */,
+				27548017AB2ABAF17E1D5DF5 /* juce_FileInputSource.h */,
+				09160DF53438B400BFE85E07 /* juce_InputSource.h */,
+				7555A13E69B99B1B6C7295FD /* juce_InputStream.cpp */,
+				D056D7F6C8EA8A6BBCC5C092 /* juce_InputStream.h */,
+				66FE597910F6A68CBB6FA055 /* juce_MemoryInputStream.cpp */,
+				8C077447B0DFC739C7D2E437 /* juce_MemoryInputStream.h */,
+				E666E60CC07666669FC77C7D /* juce_MemoryOutputStream.cpp */,
+				BF8B07C8BC86002C3DC94DEE /* juce_MemoryOutputStream.h */,
+				D679982E05B9510FE239D690 /* juce_OutputStream.cpp */,
+				0B5B63E563EFA7E816DE3DCA /* juce_OutputStream.h */,
+				0CCB1C4D687001E04DE1DD9C /* juce_SubregionStream.cpp */,
+				4978EF4C5F506F3289BC0D99 /* juce_SubregionStream.h */,
+			);
+			name = streams;
+			sourceTree = "<group>";
+		};
+		6783EE5E12C56ECE3D7FD1E2 /* app_properties */ = {
+			isa = PBXGroup;
+			children = (
+				31A3925602D128195100B74D /* juce_ApplicationProperties.cpp */,
+				5B6B25AA065FB6CDE7D6C507 /* juce_ApplicationProperties.h */,
+				1CCC1D4213B17ABF6222EC82 /* juce_PropertiesFile.cpp */,
+				2AE12F85965B8BE4A0E12F67 /* juce_PropertiesFile.h */,
+			);
+			name = app_properties;
+			sourceTree = "<group>";
+		};
+		6837ABCAE2AD67F0AD5F9AE3 /* fonts */ = {
+			isa = PBXGroup;
+			children = (
+				C916444FD4BFB79D4DE9FCAF /* juce_AttributedString.cpp */,
+				1AEEC114AFAB6E81205FBCD1 /* juce_AttributedString.h */,
+				C1435AB0105CDC29A3124E4F /* juce_CustomTypeface.cpp */,
+				E0ADC34D69113B79C2F4FF24 /* juce_CustomTypeface.h */,
+				8822ADC9DB83FAF39B841E31 /* juce_Font.cpp */,
+				1777330D3BDAE99A93F98943 /* juce_Font.h */,
+				C209C7633D01E525231EE894 /* juce_GlyphArrangement.cpp */,
+				14DD0220B41F74C01A9DC676 /* juce_GlyphArrangement.h */,
+				4650B5724FE3C0608FB07A04 /* juce_TextLayout.cpp */,
+				8077C8D1C544F458947D693E /* juce_TextLayout.h */,
+				AF8ADA74003E96998A5E4404 /* juce_Typeface.cpp */,
+				9F845E950F19FEC4E6C88F91 /* juce_Typeface.h */,
+			);
+			name = fonts;
+			sourceTree = "<group>";
+		};
+		689A94018921FED3F037B194 /* messages */ = {
+			isa = PBXGroup;
+			children = (
+				D7807913367AD1B1FCBDEFAC /* juce_ApplicationBase.cpp */,
+				9EC1C0A21FDCB81BE0EA60EA /* juce_ApplicationBase.h */,
+				6CA98F8581CEAE2DC9AEBCE9 /* juce_CallbackMessage.h */,
+				7F49EA0CD3379397520AA6F1 /* juce_DeletedAtShutdown.cpp */,
+				996E4EA6B532E4E436F50243 /* juce_DeletedAtShutdown.h */,
+				7EBB3F8185EB597DEF77534D /* juce_Message.h */,
+				5A7D81B70480B40EEBC2FF54 /* juce_MessageListener.cpp */,
+				2924B990E35D3B51AA245978 /* juce_MessageListener.h */,
+				18A730DF335EEB3A4D13FDCA /* juce_MessageManager.cpp */,
+				C844D1792A91BE2D8808CB14 /* juce_MessageManager.h */,
+				670987D88775D6B240C34820 /* juce_NotificationType.h */,
+			);
+			name = messages;
+			sourceTree = "<group>";
+		};
+		6956236084207D7C136E5032 /* audio_io */ = {
+			isa = PBXGroup;
+			children = (
+				693E9C5C9A435F791921DAAE /* juce_AudioDeviceManager.cpp */,
+				642C4CFA27846188E3D53688 /* juce_AudioDeviceManager.h */,
+				F94BFC6B5057806EEF8B59DA /* juce_AudioIODevice.cpp */,
+				2D1BF69121265C83C7937EB6 /* juce_AudioIODevice.h */,
+				9BE34B4DECBF4EBFD27C9792 /* juce_AudioIODeviceType.cpp */,
+				ED887A521EEB8F3EBA7DDB31 /* juce_AudioIODeviceType.h */,
+				3E5E427D405905C53A37283D /* juce_SystemAudioVolume.h */,
+			);
+			name = audio_io;
+			sourceTree = "<group>";
+		};
+		6DD8D8DBBBD09193A15803D0 /* properties */ = {
+			isa = PBXGroup;
+			children = (
+				D2CCDDF54D6D6F2BF4281F2D /* juce_BooleanPropertyComponent.cpp */,
+				18B410DA5435C02C82BA13F8 /* juce_BooleanPropertyComponent.h */,
+				174842EA681FA29BE38A6272 /* juce_ButtonPropertyComponent.cpp */,
+				434E153E6C8337C1E4A2709A /* juce_ButtonPropertyComponent.h */,
+				A9F5A8F835A1A734DF7F6775 /* juce_ChoicePropertyComponent.cpp */,
+				C10DC7C6E887B4EAAB8EDF38 /* juce_ChoicePropertyComponent.h */,
+				651E9B78A5139F7A5BCA4D90 /* juce_PropertyComponent.cpp */,
+				C7A68BAFB04A7D5FD81FA82B /* juce_PropertyComponent.h */,
+				9070DC685E666BBFC2E19DA9 /* juce_PropertyPanel.cpp */,
+				0D8ECE32F7D0FE74185F6EF4 /* juce_PropertyPanel.h */,
+				6D4DFC260B2966E3EBFC0C79 /* juce_SliderPropertyComponent.cpp */,
+				58958CC3F750D383261E2FBC /* juce_SliderPropertyComponent.h */,
+				414D8E6E4EE98E66C2583A50 /* juce_TextPropertyComponent.cpp */,
+				208DCD7025D0DF2740C01E4A /* juce_TextPropertyComponent.h */,
+			);
+			name = properties;
+			sourceTree = "<group>";
+		};
+		6DDA36A41852F78F61C4BA23 /* codecs */ = {
+			isa = PBXGroup;
+			children = (
+				4AE1520FF569371665090B39 /* juce_AiffAudioFormat.cpp */,
+				822A504EE33F35F18A7F21AF /* juce_AiffAudioFormat.h */,
+				F8E202A1374401022F87F26E /* juce_CoreAudioFormat.cpp */,
+				2BC005B37A0FB3179C2F3AC7 /* juce_CoreAudioFormat.h */,
+				02DA588D3B873F1971ACD912 /* juce_FlacAudioFormat.cpp */,
+				266FC6DA3123E576811DD828 /* juce_FlacAudioFormat.h */,
+				2F2EDBE0623561191234AF21 /* juce_LAMEEncoderAudioFormat.cpp */,
+				4CA9556E9C18029A47F34C7C /* juce_LAMEEncoderAudioFormat.h */,
+				F1A3975235880CAC1D5757F4 /* juce_MP3AudioFormat.cpp */,
+				72C33BA70B9EE82E39F1EC6C /* juce_MP3AudioFormat.h */,
+				ACAE4A2D65AAC6A36DA9DBCF /* juce_OggVorbisAudioFormat.cpp */,
+				E040EA8B5BB61ABBBD14F12F /* juce_OggVorbisAudioFormat.h */,
+				BAE93A5EEC37D7B4C793BFA2 /* juce_QuickTimeAudioFormat.cpp */,
+				BBC386B5A369262583AD4DDA /* juce_QuickTimeAudioFormat.h */,
+				0052A4FD257928E5D83927E6 /* juce_WavAudioFormat.cpp */,
+				F70B7D65EF56B8A0ED36478C /* juce_WavAudioFormat.h */,
+				0C646E9950FB580B21E1F2BD /* juce_WindowsMediaAudioFormat.cpp */,
+				8F0549459970F529587D6CDD /* juce_WindowsMediaAudioFormat.h */,
+			);
+			name = codecs;
+			sourceTree = "<group>";
+		};
+		702A741EEADCBB982DDE18B0 /* juce_audio_utils */ = {
+			isa = PBXGroup;
+			children = (
+				62693BDBB3A4F98A8A8B45F6 /* gui */,
+				09F214A405A08FDFC47244A5 /* players */,
+				80D57E78015C789503FE24B4 /* juce_module_info */,
+				8515A61F1E3BD62B9B95B495 /* juce_audio_utils.h */,
+			);
+			name = juce_audio_utils;
+			sourceTree = "<group>";
+		};
+		7333A0F468D3745057EB2368 /* juce_core */ = {
+			isa = PBXGroup;
+			children = (
+				CDD260628D8AFE969895A610 /* text */,
+				1E253D48AC292849CD3054CB /* maths */,
+				85E7ADCD4C773A42B7F493E8 /* memory */,
+				B49948DDB0E13018A81FFF94 /* containers */,
+				E5D588C725B362D52B7F0801 /* threads */,
+				8C76D67898D8A6B0FB7F62D5 /* time */,
+				FD67C32AD7A3D9BDC3CB7896 /* files */,
+				1DF9A40DB990AEC6AD278C31 /* network */,
+				6415B8D280F206E770758A6A /* streams */,
+				3CAB707CFF748C665802E65E /* logging */,
+				9D740F320C13F9B82EB64461 /* system */,
+				17BAAA5A77781988BAA8CDEF /* xml */,
+				E4BC8B84B396D69A78DD829B /* json */,
+				7C859D548450DEE24AE009E4 /* zip */,
+				D72CD5E87BC67DDD61A82105 /* unit_tests */,
+				DE30EC58A5AE1CD381356739 /* misc */,
+				572BB2781CE421A968F9D023 /* native */,
+				CD492AC7B458FA6C321B9D0B /* juce_module_info */,
+				97431963DB8D535DEDA9AD47 /* juce_core.h */,
+			);
+			name = juce_core;
+			sourceTree = "<group>";
+		};
+		7377EF4F37D5F898D74C4C2D /* encryption */ = {
+			isa = PBXGroup;
+			children = (
+				0BB4380EDFEAAE0DAB255B90 /* juce_BlowFish.cpp */,
+				7719FB81DDF23CF0164B131D /* juce_BlowFish.h */,
+				511C443A0A806706A772E981 /* juce_Primes.cpp */,
+				F2EDB88302B8A9356F43B834 /* juce_Primes.h */,
+				8D9DD6147EC0553B092FD367 /* juce_RSAKey.cpp */,
+				57C6DD2537116B30FB948A08 /* juce_RSAKey.h */,
+			);
+			name = encryption;
+			sourceTree = "<group>";
+		};
+		78AACAE5A74DDE52FE5848AF /* Images */ = {
+			isa = PBXGroup;
+			children = (
+				048B10371EA2D5C7D883CC70 /* Icons */,
+				5B916D6239703986EFCDB624 /* Buttons */,
+			);
+			name = Images;
+			sourceTree = "<group>";
+		};
+		795DACC07989C186924B5DA3 /* capture */ = {
+			isa = PBXGroup;
+			children = (
+				E48A7B152993BCF473725A19 /* juce_CameraDevice.h */,
+			);
+			name = capture;
+			sourceTree = "<group>";
+		};
+		7C6BF9E0D166E4E5C3F2A005 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				917988BE74F2180BFC0583A3 /* juce_MissingGLDefinitions.h */,
+				3AC9B61C10692BBA96D2F775 /* juce_OpenGL_android.h */,
+				3C18EC09535EA506FC0CBC62 /* juce_OpenGL_ios.h */,
+				CC62E20B1189C697DD238810 /* juce_OpenGL_linux.h */,
+				205E9A5C31827555F1CAC30D /* juce_OpenGL_osx.h */,
+				72FCE41894123FC5DB01566B /* juce_OpenGL_win32.h */,
+				61481DD4AAC7731CE984937D /* juce_OpenGLExtensions.h */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		7C859D548450DEE24AE009E4 /* zip */ = {
+			isa = PBXGroup;
+			children = (
+				D162391A46FF93093C328F9D /* juce_GZIPCompressorOutputStream.cpp */,
+				23C7EA9C89CC98A5EFEC12FA /* juce_GZIPCompressorOutputStream.h */,
+				A65F5AD9D0C532EBB3A2067D /* juce_GZIPDecompressorInputStream.cpp */,
+				5343D594AA7D444A7C6AD924 /* juce_GZIPDecompressorInputStream.h */,
+				AD7311B9A37893CA0C4BC119 /* juce_ZipFile.cpp */,
+				D60F42AEB8551E83215691C3 /* juce_ZipFile.h */,
+			);
+			name = zip;
+			sourceTree = "<group>";
+		};
+		7E444D9FB4474A6546E9B779 /* image_formats */ = {
+			isa = PBXGroup;
+			children = (
+				D55137DE3404D7DF2A1F50D0 /* juce_GIFLoader.cpp */,
+				EA354D7D8E48D461415D52D8 /* juce_JPEGLoader.cpp */,
+				98D2D452F48C86F47FB90BAD /* juce_PNGLoader.cpp */,
+			);
+			name = image_formats;
+			sourceTree = "<group>";
+		};
+		826D8EF5D0C6BF7B9F2AEAF0 /* Juce Library Code */ = {
+			isa = PBXGroup;
+			children = (
+				D30880F1F9F514CEEDB9F48B /* AppConfig.h */,
+				A512C5B237A77EF6FB8E11A0 /* BinaryData.cpp */,
+				837D266B3F62C3B05C2BC28C /* BinaryData.h */,
+				DF3C9A1DD67E879E4E0A2727 /* juce_audio_basics.mm */,
+				65F4459CC1832883FFF6C166 /* juce_audio_devices.mm */,
+				6B28CEAF75E22F2CCCACBCC7 /* juce_audio_formats.mm */,
+				B20469D88488F0809126CC80 /* juce_audio_processors.mm */,
+				56728EC77C65482B9C86FF4D /* juce_audio_utils.mm */,
+				A6A579E4E4AEA865BC71148C /* juce_core.mm */,
+				488D1B00C9E5FE4DAB035EDF /* juce_cryptography.mm */,
+				DBCA7E2FFCFD1354DD19DDD6 /* juce_data_structures.mm */,
+				C29E664781AA2396C8D59543 /* juce_events.mm */,
+				BBDFB328C3D5FC72A0446E6A /* juce_graphics.mm */,
+				23609D430A25F54723269E91 /* juce_gui_basics.mm */,
+				27DC0E650D6D54DF29E6DB68 /* juce_gui_extra.mm */,
+				5915DB02FB7CA8CEC1BF38A9 /* juce_opengl.mm */,
+				4A7695E93CE32F4E95042FCB /* juce_video.mm */,
+				87B4BA68E49DD11197B7AFDB /* JuceHeader.h */,
+			);
+			name = "Juce Library Code";
+			sourceTree = "<group>";
+		};
+		83416B76189CFC2030936CCA /* juce_audio_devices */ = {
+			isa = PBXGroup;
+			children = (
+				6956236084207D7C136E5032 /* audio_io */,
+				42F1804D0EC2EB60625F783F /* midi_io */,
+				2097A54F0DC05D433BEB7C81 /* sources */,
+				2512062DBF7A12B895E6F6D9 /* audio_cd */,
+				FCD30A3CA425C3FDE6CEBAED /* native */,
+				6EF4EFD6D74D2573AC6B6A6F /* juce_module_info */,
+				9069CE21141F5A4C5721BCF3 /* juce_audio_devices.h */,
+			);
+			name = juce_audio_devices;
+			sourceTree = "<group>";
+		};
+		83A3E005DDFCC55F277EEDA5 /* Processors */ = {
+			isa = PBXGroup;
+			children = (
+				FFABF04684556C4A54A62439 /* tictoc.cpp */,
+				900C10C1DB76331250A04557 /* tictoc.h */,
+				DC17FC0E3B6E3B7C45079DE0 /* OscilloscopeNode.cpp */,
+				D627F12C36013C7EFE0B0B63 /* OscilloscopeNode.h */,
+				E413F3262886677B4CBF3FA9 /* NotchFilterNode.cpp */,
+				5D23F70C117457FB8547A537 /* NotchFilterNode.h */,
+				B84E9C47FEE13D162CE9E5D7 /* ISCAN.cpp */,
+				AF594F191BDCC1FFF2F31204 /* ISCAN.h */,
+				96AED479B95D4EC31604D604 /* PeriStimulusTimeHistogramNode.cpp */,
+				4FC4EF4B38B28638B2F09260 /* PeriStimulusTimeHistogramNode.h */,
+				71C0C491E4BB214551D6EAD7 /* AdvancerNode.cpp */,
+				BBCBB940B85B1695225C9A13 /* AdvancerNode.h */,
+				C91ED2E43CF9CC0E83EB50A7 /* NetworkEvents.cpp */,
+				3F3F8C49FB5AB1B91221845E /* NetworkEvents.h */,
+				DDD2075B59AF7E38447BA84B /* TrialCircularBuffer.cpp */,
+				6E444E05271A0334FAE9DCA3 /* TrialCircularBuffer.h */,
+				7F4241B34F5F7245653B5196 /* NetworkSink.cpp */,
+				8E02668CAA496759B1F31468 /* NetworkSink.h */,
+				33EC8C48E03E5FB60DD9D4C5 /* NetworkSinkProcotol.pb.cc */,
+				9E25AA6C671FB8DCA6E30A43 /* NetworkSinkProcotol.pb.h */,
+				86688D712937F3D08918C68B /* SerialInput.cpp */,
+				E817F0471AF514FD075B5DB7 /* SerialInput.h */,
+				813CB9DFF788D612A0750FBF /* SpikeSortBoxes.cpp */,
+				77D3770CCBB3EED01A854329 /* SpikeSortBoxes.h */,
+				9215DC26F511C58DEE009209 /* FileReader.cpp */,
+				FB071D0659E5F1CC630D765A /* FileReader.h */,
+				5654BDD4FBFF01AC3F17FA0D /* ChannelMappingNode.cpp */,
+				A234B2D091071A1B710E884B /* ChannelMappingNode.h */,
+				DBB295F412798131D3F04045 /* PulsePalOutput.cpp */,
+				EF8488936B3D3E9178C9099C /* PulsePalOutput.h */,
+				BBD9C2AED6F500D090069007 /* ReferenceNode.cpp */,
+				F230A4C0186379F9EB0B0F74 /* ReferenceNode.h */,
+				9FFD9560522567A033226BD7 /* PhaseDetector.cpp */,
+				229989EC8A6F145C81348CA9 /* PhaseDetector.h */,
+				76F569AE7B444D8F69EE0E86 /* AudioResamplingNode.cpp */,
+				17CE6B2913E72ED8727ECD56 /* AudioResamplingNode.h */,
+				9BC055494F9FEE3F90630541 /* Channel.cpp */,
+				FF450FAFD49105CE7157DFC0 /* Channel.h */,
+				3DE49DED45C5CDD8D184E248 /* Serial */,
+				39464D2A22940DA2DDCCCFC6 /* EventDetector.cpp */,
+				91D7B1F8B94AE9CFCC53771F /* EventDetector.h */,
+				9D78F50147005EDB0E89E2B4 /* FPGAOutput.cpp */,
+				DB702F259EF24DAB9EC99D0A /* FPGAOutput.h */,
+				D38E60AC4854B6E1EDE488EB /* ArduinoOutput.cpp */,
+				D128F31F18331117287F5EC5 /* ArduinoOutput.h */,
+				CD2370F8F4A44446558A08FB /* Parameter.cpp */,
+				E2F46E110416D628C11392CA /* Parameter.h */,
+				DAA04A0FD47097893712B241 /* SpikeDisplayNode.cpp */,
+				5EA61EDD64BE1E401DD0AA5E /* SpikeDisplayNode.h */,
+				2D41C43686CDE35E86A389D7 /* WiFiOutput.cpp */,
+				B917780A75945062761B6945 /* WiFiOutput.h */,
+				EA535EA158451360B7B8AE52 /* LfpDisplayNode.cpp */,
+				DBB86AD59BA3F6EC09AF2C02 /* LfpDisplayNode.h */,
+				4E3C60995CC567F1A839CAE3 /* Utilities */,
+				C4B85C0286AC2510730355E3 /* Visualization */,
+				BC3B7E4E25505D9044BFACC7 /* SpikeDetector.cpp */,
+				B70D836E0756C3D4EE8E20F2 /* SpikeDetector.h */,
+				B27F558F42AC78F0E564B5AF /* AudioNode.cpp */,
+				5F64FDAFCA899A16C7FDDBCA /* AudioNode.h */,
+				F94DD42C7BBF81C101D3F605 /* EventNode.cpp */,
+				E42B745B4D2DCADE54F94757 /* EventNode.h */,
+				9F16043BF599BCE0C02A00A5 /* Editors */,
+				DEA24DC5AC8325310FB40395 /* DataThreads */,
+				A4E2CAAF556D557B24182414 /* RecordNode.cpp */,
+				3EAE25787DBFBA8EFC42A277 /* RecordNode.h */,
+				5522973FA48A13C6BED293FE /* SignalGenerator.cpp */,
+				23EAFAEA6457DB4E452F8715 /* SignalGenerator.h */,
+				A98A22CF5F208ED6DBE08063 /* ResamplingNode.cpp */,
+				C29BC68B2721471F32906FEB /* ResamplingNode.h */,
+				B0E8FAD5AC445F612E3468B9 /* FilterNode.cpp */,
+				886E18520E8BD77234E1B686 /* FilterNode.h */,
+				ECA6FDB1366BE7EC30F1539B /* SourceNode.cpp */,
+				154303EE3929F26B93792187 /* SourceNode.h */,
+				3AE038CACE48AF85C4FB1ED5 /* GenericProcessor.cpp */,
+				5B2A4DD7133CDE5AEC24CC07 /* GenericProcessor.h */,
+				555D34D0CD8776EE5996CC3A /* ProcessorGraph.cpp */,
+				0FDD7551AC98348D4A98ADC7 /* ProcessorGraph.h */,
+			);
+			name = Processors;
+			sourceTree = "<group>";
+		};
+		83E1A8B708A967FC7D5B9FE4 /* juce_gui_basics */ = {
+			isa = PBXGroup;
+			children = (
+				DA98B2B8AD88362017D0133B /* components */,
+				8EB93734459D15BBDF8EF722 /* mouse */,
+				9A37C74D88FB91820F829E3C /* keyboard */,
+				9627D3CCE9D6810CB06B5D77 /* widgets */,
+				3DA4EA9C737426FDAF1484AD /* windows */,
+				23BCC80BAA5B674946A538A4 /* menus */,
+				DAA118DDF10823819CE57BF1 /* layout */,
+				444DE4CB4BD092CB31057DFC /* buttons */,
+				DE87FCC919AE658D7931F3BA /* positioning */,
+				6101DBF4D993FE2CB50D4F90 /* drawables */,
+				6DD8D8DBBBD09193A15803D0 /* properties */,
+				09C2000EFECCE35F3F793E55 /* lookandfeel */,
+				4CA0453E4C12495F1018A4E1 /* filebrowser */,
+				45BA9E76F27503E30F331299 /* commands */,
+				BB094F61F6A8A5737BCC4CF6 /* misc */,
+				9519CC8E6EF00140A3B507BA /* application */,
+				B324A7959C768520ED46A064 /* native */,
+				BF9B6B0B73FF87595307D858 /* juce_module_info */,
+				3A9826A8C3B668BCC760BEB7 /* juce_gui_basics.h */,
+			);
+			name = juce_gui_basics;
+			sourceTree = "<group>";
+		};
+		85E7ADCD4C773A42B7F493E8 /* memory */ = {
+			isa = PBXGroup;
+			children = (
+				F7F374C05CDE0DB7712D18D1 /* juce_Atomic.h */,
+				816EB8024DD50DE4B7E84CB8 /* juce_ByteOrder.h */,
+				FB1EA9CB3C695925627B0AC6 /* juce_HeapBlock.h */,
+				420843E39C285B620B220C1D /* juce_LeakedObjectDetector.h */,
+				C0C6335FEE0844872FDF4EE2 /* juce_Memory.h */,
+				D11BC618E53E6605B3A579E1 /* juce_MemoryBlock.cpp */,
+				8A026DB58E3555F7B070DA61 /* juce_MemoryBlock.h */,
+				3663C981D28BF165C1B601A7 /* juce_OptionalScopedPointer.h */,
+				D5D6DAA3CFDD395096D2B072 /* juce_ReferenceCountedObject.h */,
+				E0C264CF6345ABB4CAB98B92 /* juce_ScopedPointer.h */,
+				0D884C2CF25F23CE6B99B2A1 /* juce_Singleton.h */,
+				8B49B07BC7534B247ADC756A /* juce_WeakReference.h */,
+			);
+			name = memory;
+			sourceTree = "<group>";
+		};
+		860DF78DDC42F4C5093B46B0 /* sources */ = {
+			isa = PBXGroup;
+			children = (
+				605C7ACB09E7739EBE4F1539 /* juce_AudioSource.h */,
+				3F8DFB0DB8B82F0C2CFBCA05 /* juce_BufferingAudioSource.cpp */,
+				E4A2E203101AF37C169F1569 /* juce_BufferingAudioSource.h */,
+				5C1D2D28960C7957A15B3FE4 /* juce_ChannelRemappingAudioSource.cpp */,
+				3FA24B406E4A9F9F54421C6A /* juce_ChannelRemappingAudioSource.h */,
+				4AD95B75DC581E32650FEDF6 /* juce_IIRFilterAudioSource.cpp */,
+				6D619C7A3A14981DC4EFF223 /* juce_IIRFilterAudioSource.h */,
+				E3D9DABE0A9C1DCE6A6515CB /* juce_MixerAudioSource.cpp */,
+				178AD28BF5BC92B58A3A3539 /* juce_MixerAudioSource.h */,
+				FD770E73FD462E9C9F6DBFB2 /* juce_PositionableAudioSource.h */,
+				1B27BF1CF3F235A55CD5107D /* juce_ResamplingAudioSource.cpp */,
+				6535D85C084292220330EDD9 /* juce_ResamplingAudioSource.h */,
+				9C5F99C38CC703FBB871401A /* juce_ReverbAudioSource.cpp */,
+				1D1ABA743E533A4B7A50DBB0 /* juce_ReverbAudioSource.h */,
+				458A112D564ED066211FD482 /* juce_ToneGeneratorAudioSource.cpp */,
+				3B307527FC3241258EA68519 /* juce_ToneGeneratorAudioSource.h */,
+			);
+			name = sources;
+			sourceTree = "<group>";
+		};
+		89F126369D1761C7A09E35C3 /* placement */ = {
+			isa = PBXGroup;
+			children = (
+				7F1E84C068D3E6AA13CDD699 /* juce_Justification.cpp */,
+				5DB6A07B827D62571BB51943 /* juce_Justification.h */,
+				18CFDBCD4A5B80E78DADCFEB /* juce_RectanglePlacement.cpp */,
+				5265AD5F97C9E813E14937A7 /* juce_RectanglePlacement.h */,
+			);
+			name = placement;
+			sourceTree = "<group>";
+		};
+		8A5AC1CA1E8CB52621B64DA4 /* format */ = {
+			isa = PBXGroup;
+			children = (
+				5C7EEDD80F88872A87FD561B /* juce_AudioFormat.cpp */,
+				F28414731D9EE1F75D7B7043 /* juce_AudioFormat.h */,
+				B5B417E4196236A2CDE7F0CF /* juce_AudioFormatManager.cpp */,
+				EDA209B0E7D124EA581023AD /* juce_AudioFormatManager.h */,
+				4CCA36B2A6C4821E493E74D2 /* juce_AudioFormatReader.cpp */,
+				789139D88F449BE488BF3CCB /* juce_AudioFormatReader.h */,
+				5CE99545433261F3B4A46252 /* juce_AudioFormatReaderSource.cpp */,
+				314955FB1E6DD74C71EB8907 /* juce_AudioFormatReaderSource.h */,
+				6B90F5150FA8E114E8AE98BF /* juce_AudioFormatWriter.cpp */,
+				3BC3A723444252E177C1B1BD /* juce_AudioFormatWriter.h */,
+				8551342E7D16FCA4F9A80BC5 /* juce_AudioSubsectionReader.cpp */,
+				3A6E9EC3DA618EBA06B9DEEB /* juce_AudioSubsectionReader.h */,
+				86515FD9AD34D6FF96C0D8B6 /* juce_BufferingAudioFormatReader.cpp */,
+				8D6A419A4678968762A59B28 /* juce_BufferingAudioFormatReader.h */,
+				6B32691AA8B3D304B68CFA64 /* juce_MemoryMappedAudioFormatReader.h */,
+			);
+			name = format;
+			sourceTree = "<group>";
+		};
+		8C76D67898D8A6B0FB7F62D5 /* time */ = {
+			isa = PBXGroup;
+			children = (
+				73ACB7A051EDE5F676E35FFD /* juce_PerformanceCounter.cpp */,
+				65DA1366481AB10AFB3AF344 /* juce_PerformanceCounter.h */,
+				5DC1AF69A773401DB1E8FB32 /* juce_RelativeTime.cpp */,
+				562E4A50364EEDC3AA2AACB8 /* juce_RelativeTime.h */,
+				A769611E9CBFC127AF5AFB0D /* juce_Time.cpp */,
+				D8A40F2BFBEC65019C867786 /* juce_Time.h */,
+			);
+			name = time;
+			sourceTree = "<group>";
+		};
+		8EB93734459D15BBDF8EF722 /* mouse */ = {
+			isa = PBXGroup;
+			children = (
+				E91A272EF06892937CB4B9CE /* juce_ComponentDragger.cpp */,
+				9A29EBC10219D89919E12FCB /* juce_ComponentDragger.h */,
+				8E78AAA58721DE609F6FFC61 /* juce_DragAndDropContainer.cpp */,
+				A54886FC74BE0DDC74094EF5 /* juce_DragAndDropContainer.h */,
+				F9E2371F1A99B292F2947FF5 /* juce_DragAndDropTarget.h */,
+				9C96B0CBFF3D34885BB8B020 /* juce_FileDragAndDropTarget.h */,
+				4EC254B133A7AAE377B9B3AE /* juce_LassoComponent.h */,
+				686FA8DDF2848517CBFB9E4A /* juce_MouseCursor.cpp */,
+				4E520E7960CC5098C2352E70 /* juce_MouseCursor.h */,
+				565EEC8F429ABF5F9A867137 /* juce_MouseEvent.cpp */,
+				11A5824E0239C86801BE2EB8 /* juce_MouseEvent.h */,
+				3E22E947444B5849011B6C4E /* juce_MouseInputSource.cpp */,
+				EF059B26886B32000BCF8CFF /* juce_MouseInputSource.h */,
+				B00A9C0BAD3AF9F48E36A38F /* juce_MouseListener.cpp */,
+				FEB3730E084D7DD433D14A6C /* juce_MouseListener.h */,
+				8F3C158B4FB92CFC48324896 /* juce_SelectedItemSet.h */,
+				05997833A4AA137FD64348AD /* juce_TextDragAndDropTarget.h */,
+				AA3209223925B66A97AB4509 /* juce_TooltipClient.h */,
+			);
+			name = mouse;
+			sourceTree = "<group>";
+		};
+		91DA3CD69EAB03C727AA39C8 /* geometry */ = {
+			isa = PBXGroup;
+			children = (
+				9F61AF101B43110732BB8814 /* juce_AffineTransform.cpp */,
+				A5C9A0FBD818AEF57858FB31 /* juce_AffineTransform.h */,
+				EAB2319C7AA57E06A2247CDF /* juce_BorderSize.h */,
+				7B674BB1DA11A4E58EA71624 /* juce_EdgeTable.cpp */,
+				B5ADA0C1BDBFAE2A2F8ECB48 /* juce_EdgeTable.h */,
+				CD2E26CFD0DC7F6090E15A20 /* juce_Line.h */,
+				2A3230DEAAC86A9090950703 /* juce_Path.cpp */,
+				C660716FDD337EFB1A7C6C72 /* juce_Path.h */,
+				04C474E0F2F7FDEC714A673C /* juce_PathIterator.cpp */,
+				13D9DC48F19699485F9888A4 /* juce_PathIterator.h */,
+				4C3EA47E012B2D63ADE599DD /* juce_PathStrokeType.cpp */,
+				6D77949E9C7C9B5A7795C0E0 /* juce_PathStrokeType.h */,
+				463A302B39C7815EB981CEBD /* juce_Point.h */,
+				9380932BED279F91B8C1C04B /* juce_Rectangle.h */,
+				BDFF189EC742274DD2629196 /* juce_RectangleList.cpp */,
+				D88B0ADDC9BF206E3D2EE9F6 /* juce_RectangleList.h */,
+			);
+			name = geometry;
+			sourceTree = "<group>";
+		};
+		9311E4762BC3218510204A0F /* juce_audio_basics */ = {
+			isa = PBXGroup;
+			children = (
+				C7E3612878FFD65D522A32A7 /* buffers */,
+				18CF6DB446071363AB4F1EC4 /* midi */,
+				553F5880E9CFE9C4A045C0C0 /* effects */,
+				860DF78DDC42F4C5093B46B0 /* sources */,
+				14AA2721588E8A9253FFA98B /* synthesisers */,
+				786F6A40506C2094B812F4D5 /* juce_module_info */,
+				DB550BAB034060FF4578BB64 /* juce_audio_basics.h */,
+			);
+			name = juce_audio_basics;
+			sourceTree = "<group>";
+		};
+		94D3CC2AE4B67AAA936F9DEA /* values */ = {
+			isa = PBXGroup;
+			children = (
+				967138FE8A086734ADC8CABB /* juce_Value.cpp */,
+				7CE1E34F6A0091E720854E75 /* juce_Value.h */,
+				74A81014471CC0EB0D5E6571 /* juce_ValueTree.cpp */,
+				C5D0E0996D20BEEEDBFD64FA /* juce_ValueTree.h */,
+			);
+			name = values;
+			sourceTree = "<group>";
+		};
+		9519CC8E6EF00140A3B507BA /* application */ = {
+			isa = PBXGroup;
+			children = (
+				2AB1CC4252DB09507ED31482 /* juce_Application.cpp */,
+				753B81CCB5A6B6929679E7B7 /* juce_Application.h */,
+				B24098EC4FD79D5EDC9383EC /* juce_Initialisation.h */,
+			);
+			name = application;
+			sourceTree = "<group>";
+		};
+		95530BD93D8ECFCC072C0850 /* juce_audio_processors */ = {
+			isa = PBXGroup;
+			children = (
+				21BB3DD364DC0C39CC9594B9 /* processors */,
+				14805A0D1A6C3ED796515AD6 /* format */,
+				208431C2D4A7C383FD247CE3 /* format_types */,
+				AF98861ADFF70900F6FD1833 /* scanning */,
+				475824F60D47C28C392954A7 /* juce_module_info */,
+				F463A19E6EFEB2837582B117 /* juce_audio_processors.h */,
+			);
+			name = juce_audio_processors;
+			sourceTree = "<group>";
+		};
+		9627D3CCE9D6810CB06B5D77 /* widgets */ = {
+			isa = PBXGroup;
+			children = (
+				9D2510B5E6180456C53A455E /* juce_ComboBox.cpp */,
+				A7875D5F8D2A632C99791002 /* juce_ComboBox.h */,
+				FFBB9CE85A7C91FB11E4AEC8 /* juce_ImageComponent.cpp */,
+				45D440B69BDB210B17CD424B /* juce_ImageComponent.h */,
+				8C3B6865F2053C80A6E692F1 /* juce_Label.cpp */,
+				C7A76C0D1B3DC4A1F059E59B /* juce_Label.h */,
+				B3BAC48D01C49D8727D08097 /* juce_ListBox.cpp */,
+				95EC6B1536DC65070D0ADCEE /* juce_ListBox.h */,
+				B123E2F4439DAD65196A2A9D /* juce_ProgressBar.cpp */,
+				6BA113C799640798D3F29A06 /* juce_ProgressBar.h */,
+				53C8A2696FE4389E4AB4441C /* juce_Slider.cpp */,
+				21C11A58CAA0F9E86AA204EC /* juce_Slider.h */,
+				CD83E301AE42E6E3317D575D /* juce_TableHeaderComponent.cpp */,
+				B60D02B5BF564ABC88841B1F /* juce_TableHeaderComponent.h */,
+				D171071934C8F7F925B0D113 /* juce_TableListBox.cpp */,
+				3C1E0B87DA3E9AC60D2894F7 /* juce_TableListBox.h */,
+				921F5D04122F324502DA4E75 /* juce_TextEditor.cpp */,
+				9FDCF1E2B4651E58240400B9 /* juce_TextEditor.h */,
+				649F22404167E0D0EA244196 /* juce_Toolbar.cpp */,
+				AE6786E4659DAC92F52E9FA3 /* juce_Toolbar.h */,
+				6917A53BAA3CA2819E4C10BF /* juce_ToolbarItemComponent.cpp */,
+				17FB020EFEAED8493D3CB121 /* juce_ToolbarItemComponent.h */,
+				E37140E9E8F7CFDDEEEF6148 /* juce_ToolbarItemFactory.h */,
+				4BB38A2CD55BF23C7C3E3387 /* juce_ToolbarItemPalette.cpp */,
+				7F93E4F0CC8B842AC1D3E560 /* juce_ToolbarItemPalette.h */,
+				564380494D23DB70680FB0B5 /* juce_TreeView.cpp */,
+				38E493BFC36AC80B1CDAAF35 /* juce_TreeView.h */,
+			);
+			name = widgets;
+			sourceTree = "<group>";
+		};
+		9924BF5224418D631DE02DA4 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				5E94E897783BEEFE61E61A2C /* juce_android_WebBrowserComponent.cpp */,
+				6FE8B0DD6116E6A3456ECF09 /* juce_ios_UIViewComponent.mm */,
+				5284E69CC601457D5C7C1063 /* juce_linux_SystemTrayIcon.cpp */,
+				D952A208CC8164F0B459EC9E /* juce_linux_WebBrowserComponent.cpp */,
+				5A746CDDE80FEA2E45B5BA66 /* juce_mac_AppleRemote.mm */,
+				3A71F2C959CA7DD3C33DC411 /* juce_mac_CarbonViewWrapperComponent.h */,
+				D357A886F6365DA33D639FF5 /* juce_mac_NSViewComponent.mm */,
+				DBF1FD9272546EE4C7DD517A /* juce_mac_SystemTrayIcon.cpp */,
+				3C92F249799E7CBF41FABEA0 /* juce_mac_WebBrowserComponent.mm */,
+				7C0F2759385C66CAC3EC362D /* juce_win32_ActiveXComponent.cpp */,
+				1D7FEC587CFE464A21830C4D /* juce_win32_SystemTrayIcon.cpp */,
+				1BF01252E3A30560525CE057 /* juce_win32_WebBrowserComponent.cpp */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		9A37C74D88FB91820F829E3C /* keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				7BCE1C09508E1B9CFC79C185 /* juce_CaretComponent.cpp */,
+				2FE6DAFB634FF3C20F1D6FD7 /* juce_CaretComponent.h */,
+				D840E516B1DE9F3F730283D5 /* juce_KeyboardFocusTraverser.cpp */,
+				FB33617B5082CC0CDC189F2C /* juce_KeyboardFocusTraverser.h */,
+				880CC7C325EFF665AC3006D2 /* juce_KeyListener.cpp */,
+				40C22F3CD61DDB9C7B3DCCA6 /* juce_KeyListener.h */,
+				33A69BDDCFCD4A4DC14A9961 /* juce_KeyPress.cpp */,
+				78CC9639B933CE2497264EF2 /* juce_KeyPress.h */,
+				8C268C3D0B8EC2BB8953E7F7 /* juce_ModifierKeys.cpp */,
+				C6E19D3864B40A52BCC49315 /* juce_ModifierKeys.h */,
+				6C36C3C304EB066B1DFCCD9C /* juce_SystemClipboard.h */,
+				9C701D5A7298B83CE05ECEBB /* juce_TextEditorKeyMapper.h */,
+				8689288B66B16EFB106CB2F4 /* juce_TextInputTarget.h */,
+			);
+			name = keyboard;
+			sourceTree = "<group>";
+		};
+		9ADB0069D1F40FF3865041E3 /* code_editor */ = {
+			isa = PBXGroup;
+			children = (
+				1D7578F927EC030203A11978 /* juce_CodeDocument.cpp */,
+				5BB1E90842FD8A212CC2D132 /* juce_CodeDocument.h */,
+				586B1E0743FFBE9081A25F4F /* juce_CodeEditorComponent.cpp */,
+				106E81B939C6B35E34DD71FE /* juce_CodeEditorComponent.h */,
+				96F2A45DCB9BB53844B0ED4F /* juce_CodeTokeniser.h */,
+				081E86FE0B991469CFA8D7EA /* juce_CPlusPlusCodeTokeniser.cpp */,
+				DFAA7B563CEFB94D9ADB5D6A /* juce_CPlusPlusCodeTokeniser.h */,
+				F4D2A03314AB1CF852CC4F2A /* juce_CPlusPlusCodeTokeniserFunctions.h */,
+			);
+			name = code_editor;
+			sourceTree = "<group>";
+		};
+		9ADE9FD3E8A58C12B4B2D8B2 /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				B081687E52C6A5157CFCCB17 /* cpmono-black-serialized */,
+				E7ACE8C1456403A574236451 /* cpmono-bold-serialized */,
+				38A9627672C2562DBE257A05 /* cpmono-extralight-serialized */,
+				E835BEB3C42E4B241804BE13 /* cpmono-light-serialized */,
+				1719507D8A73EA71F1C3F306 /* cpmono-plain-serialized */,
+				50DB7E5C152DDD03F2FA4C2D /* BebasNeue.otf */,
+				FC85D30C66E7A4E4A6CA29AE /* cpmono_bold.otf */,
+				24D86195580EFB86AC084DCC /* cpmono_extra_light.otf */,
+				AA7F6609B897B9E134377A62 /* cpmono_light.otf */,
+				783D8922D5C687E170FA1A2C /* cpmono_plain.otf */,
+				32B658D7A44849A6F640AF37 /* miso-bold.ttf */,
+				847F6986DFA468BA8D80A531 /* miso-light.ttf */,
+				0A2AD4AB14F93364EFB9611E /* miso-regular.ttf */,
+				B13BDA434DEF56BB48B26896 /* miso-serialized */,
+				EC95A2CF4B33EA37DA5FC1AC /* nordic.ttf */,
+				9D050A509BEB9E3879DA35C6 /* ostrich.ttf */,
+				66F524552E8DE88CDC2E40FD /* silkscreen-serialized */,
+				D01254FA41688494C3CB0889 /* silkscreen.ttf */,
+				61317B5191E05925F232E18C /* unibody-8.otf */,
+			);
+			name = Fonts;
+			sourceTree = "<group>";
+		};
+		9D44948383EAABF451302146 /* open-ephys */ = {
+			isa = PBXGroup;
+			children = (
+				B9646290EA6B6995F8AEEAFB /* Resources */,
+				3564F28A16A2BDF3B1D5035E /* Source */,
+			);
+			name = "open-ephys";
+			sourceTree = "<group>";
+		};
+		9D740F320C13F9B82EB64461 /* system */ = {
+			isa = PBXGroup;
+			children = (
+				7F17077973FFDD70C4B78E7E /* juce_PlatformDefs.h */,
+				A5E8E0CF6DA1AEAEE9D872DE /* juce_StandardHeader.h */,
+				9978BC2A359BC506F69E545F /* juce_SystemStats.cpp */,
+				DB4F34DA0F04B40EB6A50FB1 /* juce_SystemStats.h */,
+				C446923C1950EB5BE5E67F15 /* juce_TargetPlatform.h */,
+			);
+			name = system;
+			sourceTree = "<group>";
+		};
+		9F16043BF599BCE0C02A00A5 /* Editors */ = {
+			isa = PBXGroup;
+			children = (
+				3F45F344950087E1266A6445 /* OscilloscopeEditor.cpp */,
+				FD03E00D986C57096BA4EEF5 /* OscilloscopeEditor.h */,
+				7BF1DCDC30FDFBFAF03516C1 /* NotchFilterEditor.cpp */,
+				4AF8FD4C7E567639A190D943 /* NotchFilterEditor.h */,
+				A77E8538ED93AAADC9FE2646 /* NetworkEventsEditor.cpp */,
+				84BED3AADBD3FAB6EFEC323E /* NetworkEventsEditor.h */,
+				42C88F6EE487194784FD1D6F /* AdvancerEditor.cpp */,
+				2D27078AC6729A4B47C48099 /* AdvancerEditor.h */,
+				58BBDECD171E15D0768302A1 /* ISCANeditor.cpp */,
+				12BE9C084DEC40230DA8E9A6 /* ISCANeditor.h */,
+				7B7819A5759B54D91E334447 /* LfpTriggeredAverageEditor.cpp */,
+				2196ED9DD4262C60135E77F5 /* LfpTriggeredAverageEditor.h */,
+				8B8C25A8261F0A21369FB9D8 /* PeriStimulusTimeHistogramEditor.cpp */,
+				78FB85191B054CDE7BD07DB7 /* PeriStimulusTimeHistogramEditor.h */,
+				07BEF02C2B930DF7847C2921 /* SerialInputEditor.cpp */,
+				39D2C460FE587C5F564495A0 /* SerialInputEditor.h */,
+				28CCF04CCC028BAE0AEE5840 /* ElectrodeButtons.cpp */,
+				15870472BA2B1779521A21BD /* ElectrodeButtons.h */,
+				B083B1375828610D55F12CF3 /* ChannelMappingEditor.cpp */,
+				E442E1FA7B58BFF6F1D8CBD8 /* ChannelMappingEditor.h */,
+				4B0097003751A59A11FA8C5B /* FileReaderEditor.cpp */,
+				3067867C8C0F6CF6F086A6FC /* FileReaderEditor.h */,
+				75B1E4EFCDA9A506CFEDB09F /* PhaseDetectorEditor.cpp */,
+				748AF0975561FFFE51DF5F58 /* PhaseDetectorEditor.h */,
+				25A9484825F1B93ABC0E577F /* PulsePalOutputEditor.cpp */,
+				00A54510EFB9B0966D0B430C /* PulsePalOutputEditor.h */,
+				45D78C8EF660EECE64BAA33F /* RHD2000Editor.cpp */,
+				BBCDE855BD0A58D3779D96A8 /* RHD2000Editor.h */,
+				1552007C6C6AF750278C5BE5 /* RecordControlEditor.cpp */,
+				0B2B7732073D56E484950C8D /* RecordControlEditor.h */,
+				9C39C584DA6F507E773687EE /* ReferenceNodeEditor.cpp */,
+				1C93ECD2B04F39923E66B529 /* ReferenceNodeEditor.h */,
+				C5ABE6BDCA91410BA92A7BD9 /* ResamplingNodeEditor.cpp */,
+				0CCE619599DB39323E49FF3C /* ResamplingNodeEditor.h */,
+				169F1B20FC9FFE88C53D2735 /* FPGAOutputEditor.cpp */,
+				92528D6653802FACF658D8EA /* FPGAOutputEditor.h */,
+				1AD76E8111A738A8F3717060 /* ArduinoOutputEditor.cpp */,
+				8B9C0831BE4E09B7C0078B7E /* ArduinoOutputEditor.h */,
+				E216D095C98F850A5FB6FB0F /* ChannelSelector.cpp */,
+				70F06DBCA3948BCC1062E36F /* ChannelSelector.h */,
+				46E3A634686BFEF787229582 /* ParameterEditor.cpp */,
+				8B745839B225E44C9EB5C6FA /* ParameterEditor.h */,
+				1EC95CD1D830F6D85ADB3B9D /* SpikeDisplayEditor.cpp */,
+				25ABEB43042E98C668A16432 /* SpikeDisplayEditor.h */,
+				CAA3B9396EA62166234DAEF1 /* VisualizerEditor.cpp */,
+				B23E6EBB5F99CF7FC72FAC4E /* VisualizerEditor.h */,
+				29FD7B383C5DDACAA7B8DFD3 /* MergerEditor.cpp */,
+				FC887C6CD74FE33F8BA784A6 /* MergerEditor.h */,
+				04C6B933E1603B4D0916570D /* ImageIcon.cpp */,
+				C51CD15B311D0AAC08D0B908 /* ImageIcon.h */,
+				C79249376E3FDF10615E16EA /* WiFiOutputEditor.cpp */,
+				BA2923571505AD47CA1EF878 /* WiFiOutputEditor.h */,
+				70151263C4CB8A4F79431E11 /* EventNodeEditor.cpp */,
+				985F2B5047476B272B1A4BD4 /* EventNodeEditor.h */,
+				9136BD46BE1E28A96FBBD440 /* SignalGeneratorEditor.cpp */,
+				265EDA19C88E74249FD66609 /* SignalGeneratorEditor.h */,
+				8A91849BE6B96EB8C0663469 /* LfpDisplayEditor.cpp */,
+				E594A85A291E0625E0410A85 /* LfpDisplayEditor.h */,
+				6328434A329C353DB8D9512C /* SourceNodeEditor.cpp */,
+				028D4D3C0862B4B1312E2395 /* SourceNodeEditor.h */,
+				D51315B4241B019BE43EE4F1 /* SplitterEditor.cpp */,
+				CCC20313AD0D0993F9EDD1B3 /* SplitterEditor.h */,
+				A252FE4E6A360CBC4AF694B3 /* SpikeDetectorEditor.cpp */,
+				83E5EA2AA0CB928889AC80AB /* SpikeDetectorEditor.h */,
+				10BE33089BA6F3468F36CD6C /* AudioEditor.cpp */,
+				A0E3B98412D88921BB0AA58E /* AudioEditor.h */,
+				D90290A0AA2C36CE757E46D5 /* FilterEditor.cpp */,
+				49FA151B1837E543D18858EB /* FilterEditor.h */,
+				D3AE8303545E28D793312F46 /* GenericEditor.cpp */,
+				984BC60C0AFF3EDED692FA01 /* GenericEditor.h */,
+			);
+			name = Editors;
+			sourceTree = "<group>";
+		};
+		A7589AF92E6E958E1F866761 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				9D44948383EAABF451302146 /* open-ephys */,
+				328BE41789531FE4F91F7DA1 /* Juce Modules */,
+				826D8EF5D0C6BF7B9F2AEAF0 /* Juce Library Code */,
+				469F0AB7234589951A8F29FA /* Resources */,
+				008433D940C09C1A15B916BA /* Frameworks */,
+				FA0E0597ED415901958AD5AE /* Products */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		A7F7E551BA5A75737261BB4C /* juce_data_structures */ = {
+			isa = PBXGroup;
+			children = (
+				94D3CC2AE4B67AAA936F9DEA /* values */,
+				42DE5996B56B332A5B6C636D /* undomanager */,
+				6783EE5E12C56ECE3D7FD1E2 /* app_properties */,
+				E21CA41B44E191F1804F9662 /* juce_module_info */,
+				5962848AA3DD93A29EFF5B94 /* juce_data_structures.h */,
+			);
+			name = juce_data_structures;
+			sourceTree = "<group>";
+		};
+		AADD3015266C1EF879776CBB /* playback */ = {
+			isa = PBXGroup;
+			children = (
+				59389DC8664617FD51740F36 /* juce_DirectShowComponent.h */,
+				7C15112E5F287ACDD74480F5 /* juce_QuickTimeMovieComponent.h */,
+			);
+			name = playback;
+			sourceTree = "<group>";
+		};
+		AD985677A45CD32AB58EECA5 /* juce_video */ = {
+			isa = PBXGroup;
+			children = (
+				AADD3015266C1EF879776CBB /* playback */,
+				795DACC07989C186924B5DA3 /* capture */,
+				C55C0342ACE444BC42092159 /* native */,
+				F88A99110564C87FBA281F2C /* juce_module_info */,
+				C0B54E0803BA87C8BC353551 /* juce_video.h */,
+			);
+			name = juce_video;
+			sourceTree = "<group>";
+		};
+		AF98861ADFF70900F6FD1833 /* scanning */ = {
+			isa = PBXGroup;
+			children = (
+				E53FEAA3754E6B5D99516D56 /* juce_KnownPluginList.cpp */,
+				4D84A3A970FB67566A1E5B0B /* juce_KnownPluginList.h */,
+				390EA3109658E8C51EFC8F61 /* juce_PluginDirectoryScanner.cpp */,
+				894C0CAC31D382477E7A122E /* juce_PluginDirectoryScanner.h */,
+				F17DF27524262A21A3EC932D /* juce_PluginListComponent.cpp */,
+				75E0C433EC27CFB712CD9F75 /* juce_PluginListComponent.h */,
+			);
+			name = scanning;
+			sourceTree = "<group>";
+		};
+		B016FBDF648372A23D7EAAD8 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				9F577889CB6C54A2F7B1CA80 /* PracticalSocket.cpp */,
+				7B42B28FDB2E3AC67EF296F8 /* PracticalSocket.h */,
+			);
+			name = Network;
+			sourceTree = "<group>";
+		};
+		B324A7959C768520ED46A064 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				CF5BC8DB7D66C655DABA9129 /* juce_android_FileChooser.cpp */,
+				54339ADDCB6F8E9E7721A986 /* juce_android_Windowing.cpp */,
+				47EE021D6C891095140ED7A9 /* juce_ios_UIViewComponentPeer.mm */,
+				A8B4D80D55E48F50809DC5E4 /* juce_ios_Windowing.mm */,
+				41AF61914A96159E9EA194B0 /* juce_linux_Clipboard.cpp */,
+				48E4FA55FD4440AF44EEA437 /* juce_linux_FileChooser.cpp */,
+				558E925DAC57ADF8810559AC /* juce_linux_Windowing.cpp */,
+				6514FD7E6C5EC12735E49FBC /* juce_mac_FileChooser.mm */,
+				1819C1C4DE5FEEDEA143E3D2 /* juce_mac_MainMenu.mm */,
+				14FE601229C9A40C6E182F28 /* juce_mac_MouseCursor.mm */,
+				C17E85281A455245543930E5 /* juce_mac_NSViewComponentPeer.mm */,
+				20EB4F22A76954F2986F364A /* juce_mac_Windowing.mm */,
+				45258533F9F65AC96D3080B3 /* juce_MultiTouchMapper.h */,
+				81D578AA5F277EB0946050E5 /* juce_win32_DragAndDrop.cpp */,
+				159790C750B1F8B485DBB499 /* juce_win32_FileChooser.cpp */,
+				1518D2BA7FCAF267EF1F02E6 /* juce_win32_Windowing.cpp */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		B49948DDB0E13018A81FFF94 /* containers */ = {
+			isa = PBXGroup;
+			children = (
+				F0F3834D46EA8FC8ADB206DB /* juce_AbstractFifo.cpp */,
+				47BDFDD28759B342B1C50BC0 /* juce_AbstractFifo.h */,
+				7E40891072657FB5ADC2FAB7 /* juce_Array.h */,
+				7D8100DC3A532980AEAAD909 /* juce_ArrayAllocationBase.h */,
+				7291F19253205B1A5138908E /* juce_DynamicObject.cpp */,
+				0E98E81084F183B8426EDA7F /* juce_DynamicObject.h */,
+				193FED8339417E8E6264957A /* juce_ElementComparator.h */,
+				893E1A681FF162F6C9069F62 /* juce_HashMap.h */,
+				66D3F831CE4F6AE89E4C869A /* juce_LinkedListPointer.h */,
+				35C0963BAB9A82F12CDC9F76 /* juce_NamedValueSet.cpp */,
+				F3F48717927A4E24F7373C09 /* juce_NamedValueSet.h */,
+				6C24163DC4ECD731489CC4F6 /* juce_OwnedArray.h */,
+				E3C4B6B362320594789E1297 /* juce_PropertySet.cpp */,
+				66C663401829E0F7E787F708 /* juce_PropertySet.h */,
+				B5FBD4DBD2CFE0FFF457D7F6 /* juce_ReferenceCountedArray.h */,
+				19AB6653E818B409554C5606 /* juce_ScopedValueSetter.h */,
+				76E89CBE70BF8F2476B7AA34 /* juce_SortedSet.h */,
+				49D837FD08100AF0DB797DB4 /* juce_SparseSet.h */,
+				F8EFE3709FDDC2D5F0843058 /* juce_Variant.cpp */,
+				172FA5C9EC4B16BC0C45F269 /* juce_Variant.h */,
+			);
+			name = containers;
+			sourceTree = "<group>";
+		};
+		B9646290EA6B6995F8AEEAFB /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				9ADE9FD3E8A58C12B4B2D8B2 /* Fonts */,
+				78AACAE5A74DDE52FE5848AF /* Images */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		BB094F61F6A8A5737BCC4CF6 /* misc */ = {
+			isa = PBXGroup;
+			children = (
+				04ED2387517934A84ACF9865 /* juce_BubbleComponent.cpp */,
+				ECE3BE71EB6B9CF1CE869BBE /* juce_BubbleComponent.h */,
+				8D4FBD30E1C9EC0DA749BC83 /* juce_DropShadower.cpp */,
+				BCBBF8764A2101CD0E91DB5D /* juce_DropShadower.h */,
+			);
+			name = misc;
+			sourceTree = "<group>";
+		};
+		BCD632E634E0F8A50827F9B6 /* Dsp */ = {
+			isa = PBXGroup;
+			children = (
+				1989E86F8DFDE34887AC0326 /* Bessel.cpp */,
+				29D7893C278FFE00782637B6 /* Bessel.h */,
+				22801F75289646F6A85E5583 /* Biquad.cpp */,
+				361D8C54B3E54766CBC48046 /* Biquad.h */,
+				B47B3368AA1A182B0CA1AB26 /* Butterworth.cpp */,
+				6D59D5780ECD2CC9703CB499 /* Butterworth.h */,
+				09BCBD414282A3AA4F66A3A5 /* Cascade.cpp */,
+				E8174B3346AA69361BF73AE1 /* Cascade.h */,
+				AC2CFF4DA5CE431FCC628BA3 /* ChebyshevI.cpp */,
+				EC780F52ABBD7317A5CE2F33 /* ChebyshevI.h */,
+				B767A249792EB15A87054409 /* ChebyshevII.cpp */,
+				9CEDA04DB321755AF74D6FAF /* ChebyshevII.h */,
+				E8480C4ED7F9579F6172F7B5 /* Common.h */,
+				D8D895B3AD895C6E7FD446BF /* Custom.cpp */,
+				3063CF211ABB734A9FD452EC /* Custom.h */,
+				2B93450006102A0093F5EACB /* Design.cpp */,
+				7ACB1CB66D69738904358F43 /* Design.h */,
+				E90FCB43DA2FF766597DA75E /* Documentation.cpp */,
+				1086169B0EE86E04B64575C2 /* Dsp.h */,
+				392408C1943AC6234BAAC743 /* Elliptic.cpp */,
+				A95D898F0998F4609E992B5F /* Elliptic.h */,
+				587FCA2485B9C89C2A99C23A /* Filter.cpp */,
+				C39772F796D85E8FE98474D5 /* Filter.h */,
+				38313692308D501E4CADF1D5 /* Layout.h */,
+				C4B0DF8094C90543A65E03E3 /* Legendre.cpp */,
+				4939A8B8300394AAD0926C0B /* Legendre.h */,
+				A41C5A4CD5CF8EEFF993A8B1 /* MathSupplement.h */,
+				3F6C67E29CDEDF2EF61C054F /* Param.cpp */,
+				C3BD84D9B090F98DD09F5958 /* Params.h */,
+				65312FAD0900119CDF6CF414 /* PoleFilter.cpp */,
+				5A8D46BEB81DDF24462E3D92 /* PoleFilter.h */,
+				9A21A229CFACC67E31F4F727 /* RBJ.cpp */,
+				E44B26F5D97CB483242DE05B /* RBJ.h */,
+				3F69480D6145C77992FA59BA /* RootFinder.cpp */,
+				7EFF8622168303A4391D6CAE /* RootFinder.h */,
+				F0CA3600E09054D7DB3B0067 /* SmoothedFilter.h */,
+				C1CB526B75E406851FA918C6 /* State.cpp */,
+				9428D7423971764AC0BA9CB7 /* State.h */,
+				6340B1D2FECEABBBE6C0DE28 /* Types.h */,
+				CFB86C1F2A6076ADC36692AA /* Utilities.h */,
+			);
+			name = Dsp;
+			sourceTree = "<group>";
+		};
+		C451728043944D40C69166C1 /* Audio */ = {
+			isa = PBXGroup;
+			children = (
+				B04D87ED6AA4897B6CD3CCF6 /* AudioComponent.cpp */,
+				E79259F2164D16553A69B458 /* AudioComponent.h */,
+			);
+			name = Audio;
+			sourceTree = "<group>";
+		};
+		C4B85C0286AC2510730355E3 /* Visualization */ = {
+			isa = PBXGroup;
+			children = (
+				F115ED75E977A54AAF036B2C /* MatlabLikePlot.cpp */,
+				AE3D7946F13CE32AE41DD1B7 /* MatlabLikePlot.h */,
+				08618BD1F5343B5E6457237F /* SpikeDetectCanvas.cpp */,
+				45C7B3A0676BC07190A2338B /* SpikeDetectCanvas.h */,
+				5894D40A0E8FA6E9B3EBF9D9 /* SpikeObject.cpp */,
+				ADCB42E4C5641007A4B78025 /* SpikeObject.h */,
+				A7D4C9E3ED3763847C087F46 /* SpikeDisplayCanvas.cpp */,
+				4E6EE225098D32E7D5DE60B2 /* SpikeDisplayCanvas.h */,
+				215E1BD79B5870D5356810F0 /* Visualizer.h */,
+				66463AB11EA4D6341C32F27E /* DataWindow.cpp */,
+				FFFBDB9A00240D797751FEE6 /* DataWindow.h */,
+				4A94E809624F99387E600399 /* LfpDisplayCanvas.cpp */,
+				12B5DDCB6E5ECD93A4C55BB5 /* LfpDisplayCanvas.h */,
+			);
+			name = Visualization;
+			sourceTree = "<group>";
+		};
+		C55C0342ACE444BC42092159 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				70ECB490BD59F59D003F3BEE /* juce_android_CameraDevice.cpp */,
+				6ABF91320A2EB6D307091AEE /* juce_mac_CameraDevice.mm */,
+				EB5F9A50EB53A57D6AE303C2 /* juce_mac_QuickTimeMovieComponent.mm */,
+				D1D8F82F848413581B274A5D /* juce_win32_CameraDevice.cpp */,
+				65980344D141B0008A94E2E4 /* juce_win32_DirectShowComponent.cpp */,
+				020205BB77179A9BE3FFF1E1 /* juce_win32_QuickTimeMovieComponent.cpp */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		C7E3612878FFD65D522A32A7 /* buffers */ = {
+			isa = PBXGroup;
+			children = (
+				563F35B171FAF2540923CE45 /* juce_AudioDataConverters.cpp */,
+				EA73332E3D5AEC04ADDFBB2A /* juce_AudioDataConverters.h */,
+				80E8C07F5807C65BCDFCCF94 /* juce_AudioSampleBuffer.cpp */,
+				1CB0D7AC988EDEC838A1C546 /* juce_AudioSampleBuffer.h */,
+				BE506F381B90833512348968 /* juce_FloatVectorOperations.cpp */,
+				42BF0530EADF336E58D39CD3 /* juce_FloatVectorOperations.h */,
+			);
+			name = buffers;
+			sourceTree = "<group>";
+		};
+		C8A65F145D072BB3DA28595B /* misc */ = {
+			isa = PBXGroup;
+			children = (
+				3F56A025C4D83EBDB66E3676 /* juce_AppleRemote.h */,
+				F46843B979D0385C733C797A /* juce_BubbleMessageComponent.cpp */,
+				AD1950C0733B3470777BF861 /* juce_BubbleMessageComponent.h */,
+				CE2BD40797A6E7647FDBE736 /* juce_ColourSelector.cpp */,
+				23D82A4C165DD596474F30E4 /* juce_ColourSelector.h */,
+				1E9FE44F0CCC6604B5469412 /* juce_KeyMappingEditorComponent.cpp */,
+				F0D9A28C206D7A8BA7089D29 /* juce_KeyMappingEditorComponent.h */,
+				88E5D0906646465409715828 /* juce_PreferencesPanel.cpp */,
+				D4F94F0232F0CD426DFC44C5 /* juce_PreferencesPanel.h */,
+				0AA8F001A50408977E76ED96 /* juce_RecentlyOpenedFilesList.cpp */,
+				FD88DA941838FC91D222DF35 /* juce_RecentlyOpenedFilesList.h */,
+				92E07CA13571893873565AC7 /* juce_SplashScreen.cpp */,
+				6D4BA4399FDEB6D2195B257D /* juce_SplashScreen.h */,
+				7A9F37527280A470F201FB6E /* juce_SystemTrayIconComponent.cpp */,
+				73C69D948D33899821536025 /* juce_SystemTrayIconComponent.h */,
+				8E696460A8A860B7A4044DFC /* juce_WebBrowserComponent.h */,
+			);
+			name = misc;
+			sourceTree = "<group>";
+		};
+		CDD260628D8AFE969895A610 /* text */ = {
+			isa = PBXGroup;
+			children = (
+				AFE835E175F7159E1E7C6CC7 /* juce_CharacterFunctions.cpp */,
+				2DA0032B6DF10345C4842BF5 /* juce_CharacterFunctions.h */,
+				B64893F699A10B03AA4AFF6B /* juce_CharPointer_ASCII.h */,
+				9200FC900D22733AE716C364 /* juce_CharPointer_UTF16.h */,
+				6596D69CCD1502DC6BBD15F1 /* juce_CharPointer_UTF32.h */,
+				55F7467B96E236DD558228C9 /* juce_CharPointer_UTF8.h */,
+				05BD169B8574607A6F6AD3B6 /* juce_Identifier.cpp */,
+				6C8489C41782E3D391AF0C26 /* juce_Identifier.h */,
+				1246C8A62803B7E115713705 /* juce_LocalisedStrings.cpp */,
+				E91923510CB2280C3A3B9E9C /* juce_LocalisedStrings.h */,
+				1F12D1392E5DF34C3A3C445D /* juce_NewLine.h */,
+				0A413228C75C046CE683E0E6 /* juce_String.cpp */,
+				09A159213372995F3CCEB85B /* juce_String.h */,
+				38B5A37F33AE3FB2014BF095 /* juce_StringArray.cpp */,
+				2847E92BB432EEB9D5A59260 /* juce_StringArray.h */,
+				B9E2607F1605D308CB331FCC /* juce_StringPairArray.cpp */,
+				EAEA49B9394D802B79CA8164 /* juce_StringPairArray.h */,
+				C67AA7952D9EF7E248118B85 /* juce_StringPool.cpp */,
+				EAC262A83CD2BEA14542AE89 /* juce_StringPool.h */,
+				B7BEB7779860FE877E4D1BC8 /* juce_TextDiff.cpp */,
+				C98D4FF283E598244E89CD83 /* juce_TextDiff.h */,
+			);
+			name = text;
+			sourceTree = "<group>";
+		};
+		D3C338AADE455AEA6C248E21 /* colour */ = {
+			isa = PBXGroup;
+			children = (
+				FC080F7DF94ABCB7EA09224A /* juce_Colour.cpp */,
+				4C81E05B39376F54775A1027 /* juce_Colour.h */,
+				90F2939F533A26AC021E42B1 /* juce_ColourGradient.cpp */,
+				A708E79EB9EB7CC44030F5D5 /* juce_ColourGradient.h */,
+				6BBBC0907D7A62E2F3AB9BDF /* juce_Colours.cpp */,
+				FB7E91937D3BBE00F64F0B72 /* juce_Colours.h */,
+				AFB684CE06F9256324EE0B4C /* juce_FillType.cpp */,
+				B87C1BD13762817BE27DC2F7 /* juce_FillType.h */,
+				7A93BFD2180B5E00B124CB1A /* juce_PixelFormats.h */,
+			);
+			name = colour;
+			sourceTree = "<group>";
+		};
+		D6EA061B97C039BF4BAAB444 /* effects */ = {
+			isa = PBXGroup;
+			children = (
+				1191BF3048664183033BFF89 /* juce_DropShadowEffect.cpp */,
+				8B7EB54E1F773517A65D935C /* juce_DropShadowEffect.h */,
+				0AAFE3F4D106138401C190C5 /* juce_GlowEffect.cpp */,
+				AADBA8C0AD524CE677428AFF /* juce_GlowEffect.h */,
+				B2FA9CC4754E136F22281176 /* juce_ImageEffectFilter.h */,
+			);
+			name = effects;
+			sourceTree = "<group>";
+		};
+		D70BE7E6ECFBD4AD6F29AA64 /* interprocess */ = {
+			isa = PBXGroup;
+			children = (
+				9360657FDE33FA37D80075D1 /* juce_InterprocessConnection.cpp */,
+				E7460F066237871A704733E7 /* juce_InterprocessConnection.h */,
+				EAC7A64301F0BF2C5E33A1F9 /* juce_InterprocessConnectionServer.cpp */,
+				946FDFCA107B3F4C74C471B4 /* juce_InterprocessConnectionServer.h */,
+			);
+			name = interprocess;
+			sourceTree = "<group>";
+		};
+		D72CD5E87BC67DDD61A82105 /* unit_tests */ = {
+			isa = PBXGroup;
+			children = (
+				4D8F94CA49DB11E07918B4C9 /* juce_UnitTest.cpp */,
+				53130F5F47EB211416C028F6 /* juce_UnitTest.h */,
+			);
+			name = unit_tests;
+			sourceTree = "<group>";
+		};
+		DA98B2B8AD88362017D0133B /* components */ = {
+			isa = PBXGroup;
+			children = (
+				085F51FEE5C5FDAA321090A0 /* juce_CachedComponentImage.h */,
+				01C313C323E5CB995C939E0B /* juce_Component.cpp */,
+				EEFC66D2DF5FD66B4D83B22F /* juce_Component.h */,
+				4F4234DC14D3689C22655D0C /* juce_ComponentListener.cpp */,
+				50DD8D693741DD18106C0BA7 /* juce_ComponentListener.h */,
+				A15596CDCC27B86FC070D7FA /* juce_Desktop.cpp */,
+				CD41C1D09F6D73FA33993F45 /* juce_Desktop.h */,
+				1DF5FD417930A62110DF0419 /* juce_ModalComponentManager.cpp */,
+				45883809F1335E6C745F8155 /* juce_ModalComponentManager.h */,
+			);
+			name = components;
+			sourceTree = "<group>";
+		};
+		DAA118DDF10823819CE57BF1 /* layout */ = {
+			isa = PBXGroup;
+			children = (
+				B674DCA2C2A6AF6B58AA7820 /* juce_ComponentAnimator.cpp */,
+				BABBEE3876B90C8A57C3074D /* juce_ComponentAnimator.h */,
+				17B29FF3D3EA14EF2BE149BB /* juce_ComponentBoundsConstrainer.cpp */,
+				674FDCCEF6A1379A0F689004 /* juce_ComponentBoundsConstrainer.h */,
+				6DD526F86CBF2C3B3487FFE1 /* juce_ComponentBuilder.cpp */,
+				2FF422D0633A28558D0227EC /* juce_ComponentBuilder.h */,
+				313970BBDAAA4EDC8B322F3A /* juce_ComponentMovementWatcher.cpp */,
+				EE4DD055D31F7D9DC718DBD8 /* juce_ComponentMovementWatcher.h */,
+				570299171BCE863C54FBBA54 /* juce_ConcertinaPanel.cpp */,
+				4E71B355F2BABAF69CC4114D /* juce_ConcertinaPanel.h */,
+				7D88F7083884A5ED2DBE7534 /* juce_GroupComponent.cpp */,
+				5E0F8A60411A03461FD687CE /* juce_GroupComponent.h */,
+				C195559D311BAB51CFB545BA /* juce_MultiDocumentPanel.cpp */,
+				6E2F243D8F70CC92391204A4 /* juce_MultiDocumentPanel.h */,
+				75FCE8908DD9055F90E93716 /* juce_ResizableBorderComponent.cpp */,
+				5E1EFF4EEA5684FA00CAA353 /* juce_ResizableBorderComponent.h */,
+				94BD861806F8EA598EC09370 /* juce_ResizableCornerComponent.cpp */,
+				E23FA5E940A1434B0305875D /* juce_ResizableCornerComponent.h */,
+				EE0336B43A39FD585DF638EE /* juce_ResizableEdgeComponent.cpp */,
+				CC42C4D4230BE4F1071CB2D3 /* juce_ResizableEdgeComponent.h */,
+				F1099BFF0BC1656A23D62E84 /* juce_ScrollBar.cpp */,
+				5B411F4FCF0F69798C9E4A88 /* juce_ScrollBar.h */,
+				43420911407CC35CE2A02B38 /* juce_StretchableLayoutManager.cpp */,
+				DDE157BB06373ECDBB23469C /* juce_StretchableLayoutManager.h */,
+				918837CC0447C50774036664 /* juce_StretchableLayoutResizerBar.cpp */,
+				D06A8FDAD8B22537EA594383 /* juce_StretchableLayoutResizerBar.h */,
+				3E0942A2D72F50FDE27C14AE /* juce_StretchableObjectResizer.cpp */,
+				416B99B14B44CB16B725C4B2 /* juce_StretchableObjectResizer.h */,
+				0D3C20D1F00B7B1381E6B987 /* juce_TabbedButtonBar.cpp */,
+				F10FB240E10A5742CE366A91 /* juce_TabbedButtonBar.h */,
+				4AE36D25675E32A897F97BFA /* juce_TabbedComponent.cpp */,
+				510ACDAD798813D7FC110197 /* juce_TabbedComponent.h */,
+				AEF53FD0FBBFF5242EDD7032 /* juce_Viewport.cpp */,
+				9F6664EB2C39D224C6BCC75E /* juce_Viewport.h */,
+			);
+			name = layout;
+			sourceTree = "<group>";
+		};
+		DE30EC58A5AE1CD381356739 /* misc */ = {
+			isa = PBXGroup;
+			children = (
+				3FFD5E5D5C1D8B48DBBB9D18 /* juce_Result.cpp */,
+				0BCAC20DAB10B957168B85D6 /* juce_Result.h */,
+				F796260525BD82FFC1D1732C /* juce_Uuid.cpp */,
+				215B159836CE40810964B773 /* juce_Uuid.h */,
+				349C9FCEDC32E73DCB7AE806 /* juce_WindowsRegistry.h */,
+			);
+			name = misc;
+			sourceTree = "<group>";
+		};
+		DE87FCC919AE658D7931F3BA /* positioning */ = {
+			isa = PBXGroup;
+			children = (
+				C454DFC77F19AB044372610E /* juce_MarkerList.cpp */,
+				A93F302B8D91A997F54D231B /* juce_MarkerList.h */,
+				BB0BB31575E1377F0C560D53 /* juce_RelativeCoordinate.cpp */,
+				B43C27BEC3AB681389FC5FC5 /* juce_RelativeCoordinate.h */,
+				75A4EEE127FAB86D65FF5F6E /* juce_RelativeCoordinatePositioner.cpp */,
+				EDAC82BD742A54182E8DF2FE /* juce_RelativeCoordinatePositioner.h */,
+				FD3A6BD3A8898E137DF257B9 /* juce_RelativeParallelogram.cpp */,
+				EF4A6E0E1232071252ACCD7B /* juce_RelativeParallelogram.h */,
+				51926BEEA63BF141D93A5B36 /* juce_RelativePoint.cpp */,
+				C41504F388D0B181B003B627 /* juce_RelativePoint.h */,
+				08907A4BA0D5628476D19C48 /* juce_RelativePointPath.cpp */,
+				4A28A492852AEFBF508C1FC1 /* juce_RelativePointPath.h */,
+				DA30BA6BF482A353393D5926 /* juce_RelativeRectangle.cpp */,
+				DAA4306D30617137463ED247 /* juce_RelativeRectangle.h */,
+			);
+			name = positioning;
+			sourceTree = "<group>";
+		};
+		DEA24DC5AC8325310FB40395 /* DataThreads */ = {
+			isa = PBXGroup;
+			children = (
+				EBA825AF6FDB51EBA368CB8D /* rhythm-api */,
+				A3FB0EA0264580F6B00D993B /* RHD2000Thread.cpp */,
+				23A6BA852B71DAAF3F709428 /* RHD2000Thread.h */,
+				1718EC50691D8421EC00F8B3 /* FileReaderThread.cpp */,
+				95B57108E929DD11F898B7B1 /* FileReaderThread.h */,
+				FA23A1334E4CFA77BC18A153 /* FPGAThread.cpp */,
+				8751DF970A9E3598683BACAF /* FPGAThread.h */,
+				788F8B7719B70465762B634B /* DataBuffer.cpp */,
+				F09FD6D9CA4997216ADBF54F /* DataBuffer.h */,
+				92602D7166325C7232B85EDD /* DataThread.cpp */,
+				0287B009511521BEAAE8A52C /* DataThread.h */,
+			);
+			name = DataThreads;
+			sourceTree = "<group>";
+		};
+		E2198B85DAA7C61CCD912DD5 /* documents */ = {
+			isa = PBXGroup;
+			children = (
+				D1F9878B45ABC403F3749567 /* juce_FileBasedDocument.cpp */,
+				C679AE9BBB9B1EE3BAB09E11 /* juce_FileBasedDocument.h */,
+			);
+			name = documents;
+			sourceTree = "<group>";
+		};
+		E2F864696FA2DDDAD60C7E83 /* juce_audio_formats */ = {
+			isa = PBXGroup;
+			children = (
+				8A5AC1CA1E8CB52621B64DA4 /* format */,
+				6DDA36A41852F78F61C4BA23 /* codecs */,
+				147EC1A2CF770171DFB61105 /* sampler */,
+				D0E568AD5445AF061317E01D /* juce_module_info */,
+				07FD5E530E9E6BFB2ACA4B8C /* juce_audio_formats.h */,
+			);
+			name = juce_audio_formats;
+			sourceTree = "<group>";
+		};
+		E30221BFC59C887A6337E8C8 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				89B0B267EF0A2A19A082EB86 /* juce_android_Fonts.cpp */,
+				6DCDFF2618CFEECEACE87630 /* juce_android_GraphicsContext.cpp */,
+				AF7106E30ED950436CCEC712 /* juce_freetype_Fonts.cpp */,
+				D48EB74E1B5AAC7846196B01 /* juce_linux_Fonts.cpp */,
+				3D100F6FDB04756402F3BCC9 /* juce_mac_CoreGraphicsContext.h */,
+				6832130272774CD542793762 /* juce_mac_CoreGraphicsContext.mm */,
+				E33F167E4AA1C44596A1EBED /* juce_mac_CoreGraphicsHelpers.h */,
+				CA09B0483969444C7CD106DC /* juce_mac_Fonts.mm */,
+				B021D393D0E2625741512320 /* juce_RenderingHelpers.h */,
+				603764889DE750F8E87F6428 /* juce_win32_Direct2DGraphicsContext.cpp */,
+				7D36B006AE0B139D8A3D8641 /* juce_win32_DirectWriteTypeface.cpp */,
+				55EBFCA56B915C8CD043365C /* juce_win32_DirectWriteTypeLayout.cpp */,
+				A0D768F1B92568344DAC9F0B /* juce_win32_Fonts.cpp */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		E3229181F8CC2BD5E409AF00 /* juce_gui_extra */ = {
+			isa = PBXGroup;
+			children = (
+				9ADB0069D1F40FF3865041E3 /* code_editor */,
+				E2198B85DAA7C61CCD912DD5 /* documents */,
+				4DD214F6A346B4C4F28B3C5A /* embedding */,
+				2A882D30C0E50E70FCD95554 /* lookandfeel */,
+				C8A65F145D072BB3DA28595B /* misc */,
+				9924BF5224418D631DE02DA4 /* native */,
+				1C639F4C139C8D7753AA9BB6 /* juce_module_info */,
+				586448E180F8ACBF5A1565B0 /* juce_gui_extra.h */,
+			);
+			name = juce_gui_extra;
+			sourceTree = "<group>";
+		};
+		E4BC8B84B396D69A78DD829B /* json */ = {
+			isa = PBXGroup;
+			children = (
+				8AA1009705E8A9531C707ED1 /* juce_JSON.cpp */,
+				4179FCF100DC52282D0F9753 /* juce_JSON.h */,
+			);
+			name = json;
+			sourceTree = "<group>";
+		};
+		E5D588C725B362D52B7F0801 /* threads */ = {
+			isa = PBXGroup;
+			children = (
+				47041E3794FA20F67F39AE63 /* juce_ChildProcess.cpp */,
+				901DB6D5FE9134F2ADB9AE46 /* juce_ChildProcess.h */,
+				4608E765A643BC0CB2C1BB02 /* juce_CriticalSection.h */,
+				515213CC3271E8DEA8125D33 /* juce_DynamicLibrary.h */,
+				DE4861552DB1976665B25DFD /* juce_HighResolutionTimer.cpp */,
+				EAB6A66678B122C578B16445 /* juce_HighResolutionTimer.h */,
+				DB7866AFC8A4894810DBD05E /* juce_InterProcessLock.h */,
+				EA9518CDEA7049C21D5CE2D5 /* juce_Process.h */,
+				E34E535DA9CBF248E32F7B45 /* juce_ReadWriteLock.cpp */,
+				113404D3FDE3745DF1E8D014 /* juce_ReadWriteLock.h */,
+				ABA3FCD5D762336535D56D94 /* juce_ScopedLock.h */,
+				7C6921FE817699C1B95AEBF6 /* juce_ScopedReadLock.h */,
+				2D20F49E12A7D313049E0258 /* juce_ScopedWriteLock.h */,
+				36A9736F04AAA2F8E9D711BB /* juce_SpinLock.h */,
+				222AC2E9BEFE12BE7FF88879 /* juce_Thread.cpp */,
+				8EB76CA261F62A89B3D25F81 /* juce_Thread.h */,
+				A6736FBDFBB0B82E22D2B1C0 /* juce_ThreadLocalValue.h */,
+				748E62D05C8FFF74DCA234C7 /* juce_ThreadPool.cpp */,
+				0B382285EEDD8A3FDB45C074 /* juce_ThreadPool.h */,
+				4133FE7830C52BBA035D82B8 /* juce_TimeSliceThread.cpp */,
+				DEE2959DBBC84EA8448A0F77 /* juce_TimeSliceThread.h */,
+				DAC81FECCE54087394BE69F7 /* juce_WaitableEvent.h */,
+			);
+			name = threads;
+			sourceTree = "<group>";
+		};
+		EBA825AF6FDB51EBA368CB8D /* rhythm-api */ = {
+			isa = PBXGroup;
+			children = (
+				235A8987D99A191D07208D2F /* okFrontPanelDLL.cpp */,
+				14F594C425F332F455A16D35 /* okFrontPanelDLL.h */,
+				ECB5A75A81B90327F58CBD9E /* rhd2000datablock.cpp */,
+				80EEDD40F49120ADBE9DCBDF /* rhd2000datablock.h */,
+				2D2BAC4320470CF68743F58E /* rhd2000evalboard.cpp */,
+				FA2F04BA4E146ABF649BBE89 /* rhd2000evalboard.h */,
+				5DB3B3197F8C1E5EE159D6FC /* rhd2000registers.cpp */,
+				8A989F74B1957BCB3B9BA398 /* rhd2000registers.h */,
+			);
+			name = "rhythm-api";
+			sourceTree = "<group>";
+		};
+		F196226BFBA15D76688C61C6 /* juce_cryptography */ = {
+			isa = PBXGroup;
+			children = (
+				7377EF4F37D5F898D74C4C2D /* encryption */,
+				2A96C9BD7209F57EE8E19BBA /* hashing */,
+				01859D6E7D95E44BD8E17D91 /* juce_module_info */,
+				C16065CD5A8054262B81C1A3 /* juce_cryptography.h */,
+			);
+			name = juce_cryptography;
+			sourceTree = "<group>";
+		};
+		F61CCB10A356CE4278F74478 /* juce_events */ = {
+			isa = PBXGroup;
+			children = (
+				689A94018921FED3F037B194 /* messages */,
+				530413F49A2E29570D8A9761 /* timers */,
+				259BB14332EF6F524455BF3C /* broadcasters */,
+				D70BE7E6ECFBD4AD6F29AA64 /* interprocess */,
+				0A3CD1724922FB098543C013 /* native */,
+				31FDA03EF1B527B336FA6263 /* juce_module_info */,
+				CF758CB1E06DDA1AB7F5C9CC /* juce_events.h */,
+			);
+			name = juce_events;
+			sourceTree = "<group>";
+		};
+		FA0E0597ED415901958AD5AE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				99E1BC08B886CFDD2CCFD462 /* open-ephys.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FCD30A3CA425C3FDE6CEBAED /* native */ = {
+			isa = PBXGroup;
+			children = (
+				0A42FFB89531588E51762D3E /* juce_android_Audio.cpp */,
+				7D363D7B36A55EEB3198A827 /* juce_android_Midi.cpp */,
+				21D3C1095D2B5A834D998B74 /* juce_android_OpenSL.cpp */,
+				FF1B5858C942CA02EEC38E69 /* juce_ios_Audio.cpp */,
+				601654292170CD2D60E912A6 /* juce_linux_ALSA.cpp */,
+				B7D848E4F85AE11FDE4D164D /* juce_linux_AudioCDReader.cpp */,
+				FEF0A4E3C8D22A830BCE2B67 /* juce_linux_JackAudio.cpp */,
+				E8964C0BE264A55753BC6B7B /* juce_linux_Midi.cpp */,
+				9FC97A1CFD250F7215B4E397 /* juce_mac_AudioCDBurner.mm */,
+				AEC2DABFC0517B4BE0CD704C /* juce_mac_AudioCDReader.mm */,
+				AF3E3AE70160C3392B237316 /* juce_mac_CoreAudio.cpp */,
+				39422C7D01635DD9C00B5136 /* juce_mac_CoreMidi.cpp */,
+				17CACEC7EA0A4B55A06A0993 /* juce_MidiDataConcatenator.h */,
+				B0A076D9536B6754F34E4606 /* juce_win32_ASIO.cpp */,
+				6CBD8647DB17F1B58B14A3BC /* juce_win32_AudioCDBurner.cpp */,
+				F2F11D7C596DAE5579610CCC /* juce_win32_AudioCDReader.cpp */,
+				5B7EC53FD2232CA799D6C018 /* juce_win32_DirectSound.cpp */,
+				25DCA4D0E86DFB51AF637D21 /* juce_win32_Midi.cpp */,
+				E5B10AA248D400FDB2645084 /* juce_win32_WASAPI.cpp */,
+			);
+			name = native;
+			sourceTree = "<group>";
+		};
+		FD67C32AD7A3D9BDC3CB7896 /* files */ = {
+			isa = PBXGroup;
+			children = (
+				0DE9D2FE41553B4D4316DD55 /* juce_DirectoryIterator.cpp */,
+				B2241E3C5C9F93389586F357 /* juce_DirectoryIterator.h */,
+				B4C52FC94D6C680C33ED85C9 /* juce_File.cpp */,
+				108DF32ADFBA5CA48F928A92 /* juce_File.h */,
+				B2EF409A1F459E964756BA7C /* juce_FileInputStream.cpp */,
+				5E663D5A55F191AB92A1383F /* juce_FileInputStream.h */,
+				DD5695DE97CEF7BE76869232 /* juce_FileOutputStream.cpp */,
+				F8322ED101601866FFB1698C /* juce_FileOutputStream.h */,
+				21A0260D2DB039B81DF4970C /* juce_FileSearchPath.cpp */,
+				AE9359DBA841F88EF3DA9700 /* juce_FileSearchPath.h */,
+				AD960F561259904BA68DDA73 /* juce_MemoryMappedFile.h */,
+				6EA1CC7DACDDBA863179521A /* juce_TemporaryFile.cpp */,
+				ECCE033FF2ACE42188FA4A7F /* juce_TemporaryFile.h */,
+			);
+			name = files;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		609761DEC9151D2CDD50270C /* open-ephys */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B0259CB1FA28CEC89ED4FA14 /* Build configuration list for PBXNativeTarget "open-ephys" */;
+			buildPhases = (
+				256EEB2E7946EFA9B0774D25 /* Resources */,
+				0C1B429379FBBA77A635B49A /* Sources */,
+				7BE915E5A64C787EBF13A8E7 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "open-ephys";
+			productInstallPath = "$(HOME)/Applications";
+			productName = "open-ephys";
+			productReference = 99E1BC08B886CFDD2CCFD462 /* open-ephys.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		41375E3272D6505F75FDEEEB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0440;
+			};
+			buildConfigurationList = 3B096175C0B17BFA58475A08 /* Build configuration list for PBXProject "open-ephys" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = A7589AF92E6E958E1F866761 /* Source */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				609761DEC9151D2CDD50270C /* open-ephys */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		256EEB2E7946EFA9B0774D25 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D2BDB63CBD0BED07FF9E44B /* RecentFilesMenuTemplate.nib in Resources */,
+				4FA2949D3023FC2E377AFFB6 /* unibody-8.otf in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0C1B429379FBBA77A635B49A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				14BDAEA656AAFA60334CC55C /* AccessClass.cpp in Sources */,
+				C853FCE2F6C91B3643322CF0 /* PracticalSocket.cpp in Sources */,
+				00A0D05390DB9F2B74DDAA78 /* Bessel.cpp in Sources */,
+				4AD3281B0CCF122A25E33667 /* Biquad.cpp in Sources */,
+				F505DF3C2BA492B5A2F28D05 /* Butterworth.cpp in Sources */,
+				B226387EB0FCE3BE6773FF61 /* Cascade.cpp in Sources */,
+				B3B08037F49EC7540586828F /* ChebyshevI.cpp in Sources */,
+				B6C73582C501D8C3C03A4860 /* ChebyshevII.cpp in Sources */,
+				129ADFA8B25DE091AFA2D9E3 /* Custom.cpp in Sources */,
+				285FF16149C85F2793EBCBAE /* Design.cpp in Sources */,
+				D19775DC99C67AD20F98EF17 /* Documentation.cpp in Sources */,
+				CB470032BC92A30906C96258 /* Elliptic.cpp in Sources */,
+				4FEC4EC2796E37A3B11B50B9 /* Filter.cpp in Sources */,
+				A44FEA7117CFE2F06B9889B4 /* Legendre.cpp in Sources */,
+				C0E966234C8AF91C19CF6EA4 /* Param.cpp in Sources */,
+				BBE886EA79C50D0D68A5A753 /* PoleFilter.cpp in Sources */,
+				9D17609E468FC65EB70ED7F4 /* RBJ.cpp in Sources */,
+				AE06672D2CBF8F64465B2126 /* RootFinder.cpp in Sources */,
+				69630D3ECA4D6014EE3734CD /* State.cpp in Sources */,
+				0AE243437B40602D35435C32 /* AudioComponent.cpp in Sources */,
+				171DBC82575004F0DAF60A80 /* tictoc.cpp in Sources */,
+				04E6370E518D4C41CAC82003 /* OscilloscopeNode.cpp in Sources */,
+				4996C99F2CF9C13880F8C5D8 /* NotchFilterNode.cpp in Sources */,
+				BEC09BF7DFCBD272B5471696 /* ISCAN.cpp in Sources */,
+				0DAD0EFDC8B36F1D9BBB00BC /* PeriStimulusTimeHistogramNode.cpp in Sources */,
+				73DAB4DC87D7333E490F2D7E /* AdvancerNode.cpp in Sources */,
+				94FAD0B2F2538EE8918F9E67 /* NetworkEvents.cpp in Sources */,
+				B8EB3B8A25F7D8BA4F697399 /* TrialCircularBuffer.cpp in Sources */,
+				9BF1FBB0A93003FE8EC94C72 /* NetworkSink.cpp in Sources */,
+				03A83ACD14BB6A18AFA4C81A /* NetworkSinkProcotol.pb.cc in Sources */,
+				B89453078EB0A8107F39EDF3 /* SerialInput.cpp in Sources */,
+				A33C92B3D445EBC6C35E7ABA /* SpikeSortBoxes.cpp in Sources */,
+				F25EC78DCCC9CCEE805AE011 /* FileReader.cpp in Sources */,
+				EA6A1BDDF81818D516B93DD6 /* ChannelMappingNode.cpp in Sources */,
+				7077270005BA819E3D5654B5 /* PulsePalOutput.cpp in Sources */,
+				FDCFDC9CC6D7A82131190FB0 /* ReferenceNode.cpp in Sources */,
+				11D82BA398E9433440B76F66 /* PhaseDetector.cpp in Sources */,
+				EDEE5E21F0C9BDB7DB796083 /* AudioResamplingNode.cpp in Sources */,
+				C6F08BF3EF53274A42BB88EB /* Channel.cpp in Sources */,
+				790911EDF00A4BF77327D99A /* PulsePal.cpp in Sources */,
+				DDDFAE2042D8AD20CC78CE3C /* ofArduino.cpp in Sources */,
+				582C224AA50C9395810C8E27 /* ofSerial.cpp in Sources */,
+				704484388E63CDE33491E1AB /* EventDetector.cpp in Sources */,
+				1691EC0AC4C7083D65B925E2 /* FPGAOutput.cpp in Sources */,
+				AD032CEA5DBE4D4C76D3D2D1 /* ArduinoOutput.cpp in Sources */,
+				9E8544C3983B3203530B5A49 /* Parameter.cpp in Sources */,
+				685151FF4FB872983524A5C3 /* SpikeDisplayNode.cpp in Sources */,
+				627C7B84F5FD275FAF43663A /* WiFiOutput.cpp in Sources */,
+				C59764685E62E7C4D323F84B /* LfpDisplayNode.cpp in Sources */,
+				E4DA638CDD4DD574A6CD843E /* RecordControl.cpp in Sources */,
+				2B4A80DCF867DC025C21966B /* Merger.cpp in Sources */,
+				D0E9E20F9D8FDA700BB6D820 /* Splitter.cpp in Sources */,
+				89223664B6CB2A912E36B091 /* MatlabLikePlot.cpp in Sources */,
+				30530D3307A5202B71B3D751 /* SpikeDetectCanvas.cpp in Sources */,
+				19BB86C918F89D1377F8A0E1 /* SpikeObject.cpp in Sources */,
+				EE56A6BBBFA4A27A4BCF7279 /* SpikeDisplayCanvas.cpp in Sources */,
+				1B620FC17AAECA4C5DE741E2 /* DataWindow.cpp in Sources */,
+				5570682BF1A39FB3E3FAC182 /* LfpDisplayCanvas.cpp in Sources */,
+				ED8CB527B27C67E9E4DA027C /* SpikeDetector.cpp in Sources */,
+				DE758AF46844DF951655966C /* AudioNode.cpp in Sources */,
+				80E5365461A5A7A32C48C563 /* EventNode.cpp in Sources */,
+				155C4E1F4B91745239F99C8A /* OscilloscopeEditor.cpp in Sources */,
+				5E296916472899325DFFC828 /* NotchFilterEditor.cpp in Sources */,
+				BEACD5086C04D68470944B72 /* NetworkEventsEditor.cpp in Sources */,
+				BECDDBEE5F3E0B715BC91F39 /* AdvancerEditor.cpp in Sources */,
+				65C47CAEC038F5C9FAC6811D /* ISCANeditor.cpp in Sources */,
+				DD77A0AB68C932F294B753C2 /* LfpTriggeredAverageEditor.cpp in Sources */,
+				8EF485897B3A20D8E6AC3B40 /* PeriStimulusTimeHistogramEditor.cpp in Sources */,
+				A3CF90DE56808A47519FC101 /* SerialInputEditor.cpp in Sources */,
+				029C3B11BE586DA100895A60 /* ElectrodeButtons.cpp in Sources */,
+				52E0D9DC7F5C4703257D8BEB /* ChannelMappingEditor.cpp in Sources */,
+				EA46BA3970E958013FF85690 /* FileReaderEditor.cpp in Sources */,
+				88B896EB9793E0C44410D981 /* PhaseDetectorEditor.cpp in Sources */,
+				6272253EB0051C1F215CD4D9 /* PulsePalOutputEditor.cpp in Sources */,
+				AF26E388BF6536803E762CB1 /* RHD2000Editor.cpp in Sources */,
+				0CEFF81CD8861F959DB13362 /* RecordControlEditor.cpp in Sources */,
+				352F3875222B1D233013AAF9 /* ReferenceNodeEditor.cpp in Sources */,
+				F0EC60AEFAFF3D289F8110BE /* ResamplingNodeEditor.cpp in Sources */,
+				C3406F00595AEFF068EDB162 /* FPGAOutputEditor.cpp in Sources */,
+				3A2E957EB8D117C535F119E9 /* ArduinoOutputEditor.cpp in Sources */,
+				52AE3F7AEED81BA9ED5C4830 /* ChannelSelector.cpp in Sources */,
+				3933895CA488855A23943F61 /* ParameterEditor.cpp in Sources */,
+				AF67C81811F18FCE6AA9C895 /* SpikeDisplayEditor.cpp in Sources */,
+				AA16BE5A6BBD024C8FCFCDA8 /* VisualizerEditor.cpp in Sources */,
+				992137E90F9D41522FD56875 /* MergerEditor.cpp in Sources */,
+				7F188166D38DA7FB23311413 /* ImageIcon.cpp in Sources */,
+				A454D138EC507C01D299AB0F /* WiFiOutputEditor.cpp in Sources */,
+				784125612E2B7AC6CD89D835 /* EventNodeEditor.cpp in Sources */,
+				21539690A9A5DD20AFAF41D3 /* SignalGeneratorEditor.cpp in Sources */,
+				0836C50051EF59BF91D7B12D /* LfpDisplayEditor.cpp in Sources */,
+				55CD2E9F373B69C3E8363B78 /* SourceNodeEditor.cpp in Sources */,
+				2B29D90B985E9EB788472EFE /* SplitterEditor.cpp in Sources */,
+				D0873C347977633B4421B94D /* SpikeDetectorEditor.cpp in Sources */,
+				BF3254F07C15D467D6DB3FEF /* AudioEditor.cpp in Sources */,
+				6029B20DF2BD523AC0F78896 /* FilterEditor.cpp in Sources */,
+				6702EEA4E99D503C0EE933C4 /* GenericEditor.cpp in Sources */,
+				89FCE8890946693CD5FC4A70 /* okFrontPanelDLL.cpp in Sources */,
+				C9AC286A46B3A1318F298DEF /* rhd2000datablock.cpp in Sources */,
+				DA836EC803E4FF4EDEBE6386 /* rhd2000evalboard.cpp in Sources */,
+				702C9BFCE865CB6C6B8BFB0D /* rhd2000registers.cpp in Sources */,
+				739573501D1D440A72C5C2E5 /* RHD2000Thread.cpp in Sources */,
+				955561F4FF4484648FDB9F73 /* FileReaderThread.cpp in Sources */,
+				6B67D7B6301182C7621294B6 /* FPGAThread.cpp in Sources */,
+				FAE745870674A07A65690433 /* DataBuffer.cpp in Sources */,
+				24CC7E9A7E87F762D4AB0467 /* DataThread.cpp in Sources */,
+				66F3B79BDF9BFB631D7E3584 /* RecordNode.cpp in Sources */,
+				996F9E4989EB47941D8100DA /* SignalGenerator.cpp in Sources */,
+				BE54C019A73BBAE05BFD7D17 /* ResamplingNode.cpp in Sources */,
+				5AE42EF7A713B1EC0ACF9EDE /* FilterNode.cpp in Sources */,
+				71111DE81104B1536ECB6DFB /* SourceNode.cpp in Sources */,
+				85A60568B3DC342C76B4E679 /* GenericProcessor.cpp in Sources */,
+				8A5BACA019DA9B0EFAD5CE93 /* ProcessorGraph.cpp in Sources */,
+				D499273B65D901D0A101CAAA /* GraphViewer.cpp in Sources */,
+				95AE939ADE096394CCD2526F /* EditorViewportButtons.cpp in Sources */,
+				E85DA5FC9A162F129ABA7113 /* SignalChainManager.cpp in Sources */,
+				6A13D8F42A330E2C410B43E3 /* EditorViewport.cpp in Sources */,
+				13F1111511DD01E843E631CA /* ProcessorList.cpp in Sources */,
+				9A80E3D1D1758A31D2169497 /* CustomLookAndFeel.cpp in Sources */,
+				F4397EAE00E0B9F96C8B6C07 /* InfoLabel.cpp in Sources */,
+				09673DA3B4D6EA61DEFC0C46 /* DataViewport.cpp in Sources */,
+				591CED1277A8C945EF60841C /* MessageCenter.cpp in Sources */,
+				0987D2A72DD60B4A7D719707 /* LogWindow.cpp in Sources */,
+				58D3FF3B1F462634167BDFB5 /* ControlPanel.cpp in Sources */,
+				3162B66BC8118715AAA527D7 /* UIComponent.cpp in Sources */,
+				004E78BC139419671A9EA137 /* MainWindow.cpp in Sources */,
+				6306AA945375749C4FE834E6 /* Main.cpp in Sources */,
+				AD7D05519200FB0EE1C7617A /* BinaryData.cpp in Sources */,
+				C2475E008FEB33B3EA7B6C7F /* juce_audio_basics.mm in Sources */,
+				9227961C07C0EE73E89C90B5 /* juce_audio_devices.mm in Sources */,
+				A2EE65335FB2810C04ECBFAF /* juce_audio_formats.mm in Sources */,
+				3FF289281D3318A7BA8BB44D /* juce_audio_processors.mm in Sources */,
+				9E30156DBCE4EAF9EFAF0AC4 /* juce_audio_utils.mm in Sources */,
+				6510492BAE00C95DC620F493 /* juce_core.mm in Sources */,
+				06BCB79AE267E5841F641E38 /* juce_cryptography.mm in Sources */,
+				A0DAD4E5F7583349DC9275F2 /* juce_data_structures.mm in Sources */,
+				FCB767F14565886C9D823916 /* juce_events.mm in Sources */,
+				7015D104F55D5B128341CEA8 /* juce_graphics.mm in Sources */,
+				A269A876BDF3B7011FA4C681 /* juce_gui_basics.mm in Sources */,
+				58E0EC510F2A88E14AE55439 /* juce_gui_extra.mm in Sources */,
+				002427B013C43CE3E6D4E9B5 /* juce_opengl.mm in Sources */,
+				FA2A052548AAD146F3F5AD83 /* juce_video.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		747300E66AC17ACE193A6C37 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_MODEL_TUNING = G5;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
+				GCC_WARN_MISSING_PARENTHESES = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "open-ephys";
+				WARNING_CFLAGS = "-Wreorder";
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+		7A6F9B742B69F66DC3E29FA8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_LINK_OBJC_RUNTIME = NO;
 				COMBINE_HIDPI_IMAGES = YES;
-				OTHER_LDFLAGS = "-lzmq";
-				ONLY_ACTIVE_ARCH = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_NDEBUG=1",
+					"NDEBUG=1",
+					"JUCER_XCODE_MAC_F6D2F4CF=1",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = (
+					../../JuceLibraryCode,
+					"$(inherited)",
+					/opt/local/include,
+				);
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				LIBRARY_SEARCH_PATHS = /opt/local/lib;
+				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
+				OTHER_LDFLAGS = (
+					"-lzmq",
+					"-lprotobuf",
+				);
+				SDKROOT_ppc = macosx10.5;
+			};
+			name = Release;
+		};
+		95F63B27BAC6E72226C3E356 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_LINK_OBJC_RUNTIME = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-				"_DEBUG=1",
-				"DEBUG=1",
-				"JUCER_XCODE_MAC_F6D2F4CF=1"); }; name = Debug; };
-		7A6F9B742B69F66DC3E29FA8 = { isa = XCBuildConfiguration; buildSettings = {
-				HEADER_SEARCH_PATHS = "../../JuceLibraryCode $(inherited)";
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_DEBUG=1",
+					"DEBUG=1",
+					"JUCER_XCODE_MAC_F6D2F4CF=1",
+				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = (
+					../../JuceLibraryCode,
+					"$(inherited)",
+					/opt/local/include,
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
+				LIBRARY_SEARCH_PATHS = /opt/local/lib;
 				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-lzmq",
+					"-lprotobuf",
+				);
 				SDKROOT_ppc = macosx10.5;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_LINK_OBJC_RUNTIME = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				OTHER_LDFLAGS = "-lzmq";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-				"_NDEBUG=1",
-				"NDEBUG=1",
-				"JUCER_XCODE_MAC_F6D2F4CF=1"); }; name = Release; };
-		C8018C9A4DA633CA60663294 = { isa = XCBuildConfiguration; buildSettings = {
+			};
+			name = Debug;
+		};
+		C8018C9A4DA633CA60663294 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_MODEL_TUNING = G5;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
 				GCC_WARN_MISSING_PARENTHESES = YES;
 				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
 				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
-				WARNING_CFLAGS = -Wreorder;
-				GCC_MODEL_TUNING = G5;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
-				ZERO_LINK = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf";
-				PRODUCT_NAME = "open-ephys"; }; name = Debug; };
-		747300E66AC17ACE193A6C37 = { isa = XCBuildConfiguration; buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				GCC_C_LANGUAGE_STANDARD = c99;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				GCC_WARN_MISSING_PARENTHESES = YES;
-				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
-				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
-				WARNING_CFLAGS = -Wreorder;
-				GCC_MODEL_TUNING = G5;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				PRODUCT_NAME = "open-ephys";
+				WARNING_CFLAGS = "-Wreorder";
 				ZERO_LINK = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf";
-				PRODUCT_NAME = "open-ephys"; }; name = Release; };
-		3B096175C0B17BFA58475A08 = { isa = XCConfigurationList; buildConfigurations = (
-				C8018C9A4DA633CA60663294,
-				747300E66AC17ACE193A6C37 ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Debug; };
-		B0259CB1FA28CEC89ED4FA14 = { isa = XCConfigurationList; buildConfigurations = (
-				95F63B27BAC6E72226C3E356,
-				7A6F9B742B69F66DC3E29FA8 ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Debug; };
-		256EEB2E7946EFA9B0774D25 = { isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (
-				2D2BDB63CBD0BED07FF9E44B,
-				4FA2949D3023FC2E377AFFB6 ); runOnlyForDeploymentPostprocessing = 0; };
-		0C1B429379FBBA77A635B49A = { isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
-				14BDAEA656AAFA60334CC55C,
-				C853FCE2F6C91B3643322CF0,
-				00A0D05390DB9F2B74DDAA78,
-				4AD3281B0CCF122A25E33667,
-				F505DF3C2BA492B5A2F28D05,
-				B226387EB0FCE3BE6773FF61,
-				B3B08037F49EC7540586828F,
-				B6C73582C501D8C3C03A4860,
-				129ADFA8B25DE091AFA2D9E3,
-				285FF16149C85F2793EBCBAE,
-				D19775DC99C67AD20F98EF17,
-				CB470032BC92A30906C96258,
-				4FEC4EC2796E37A3B11B50B9,
-				A44FEA7117CFE2F06B9889B4,
-				C0E966234C8AF91C19CF6EA4,
-				BBE886EA79C50D0D68A5A753,
-				9D17609E468FC65EB70ED7F4,
-				AE06672D2CBF8F64465B2126,
-				69630D3ECA4D6014EE3734CD,
-				0AE243437B40602D35435C32,
-				171DBC82575004F0DAF60A80,
-				04E6370E518D4C41CAC82003,
-				4996C99F2CF9C13880F8C5D8,
-				BEC09BF7DFCBD272B5471696,
-				0DAD0EFDC8B36F1D9BBB00BC,
-				73DAB4DC87D7333E490F2D7E,
-				94FAD0B2F2538EE8918F9E67,
-				B8EB3B8A25F7D8BA4F697399,
-				9BF1FBB0A93003FE8EC94C72,
-				03A83ACD14BB6A18AFA4C81A,
-				B89453078EB0A8107F39EDF3,
-				A33C92B3D445EBC6C35E7ABA,
-				F25EC78DCCC9CCEE805AE011,
-				EA6A1BDDF81818D516B93DD6,
-				7077270005BA819E3D5654B5,
-				FDCFDC9CC6D7A82131190FB0,
-				11D82BA398E9433440B76F66,
-				EDEE5E21F0C9BDB7DB796083,
-				C6F08BF3EF53274A42BB88EB,
-				790911EDF00A4BF77327D99A,
-				DDDFAE2042D8AD20CC78CE3C,
-				582C224AA50C9395810C8E27,
-				704484388E63CDE33491E1AB,
-				1691EC0AC4C7083D65B925E2,
-				AD032CEA5DBE4D4C76D3D2D1,
-				9E8544C3983B3203530B5A49,
-				685151FF4FB872983524A5C3,
-				627C7B84F5FD275FAF43663A,
-				C59764685E62E7C4D323F84B,
-				E4DA638CDD4DD574A6CD843E,
-				2B4A80DCF867DC025C21966B,
-				D0E9E20F9D8FDA700BB6D820,
-				89223664B6CB2A912E36B091,
-				30530D3307A5202B71B3D751,
-				19BB86C918F89D1377F8A0E1,
-				EE56A6BBBFA4A27A4BCF7279,
-				1B620FC17AAECA4C5DE741E2,
-				5570682BF1A39FB3E3FAC182,
-				ED8CB527B27C67E9E4DA027C,
-				DE758AF46844DF951655966C,
-				80E5365461A5A7A32C48C563,
-				155C4E1F4B91745239F99C8A,
-				5E296916472899325DFFC828,
-				BEACD5086C04D68470944B72,
-				BECDDBEE5F3E0B715BC91F39,
-				65C47CAEC038F5C9FAC6811D,
-				DD77A0AB68C932F294B753C2,
-				8EF485897B3A20D8E6AC3B40,
-				A3CF90DE56808A47519FC101,
-				029C3B11BE586DA100895A60,
-				52E0D9DC7F5C4703257D8BEB,
-				EA46BA3970E958013FF85690,
-				88B896EB9793E0C44410D981,
-				6272253EB0051C1F215CD4D9,
-				AF26E388BF6536803E762CB1,
-				0CEFF81CD8861F959DB13362,
-				352F3875222B1D233013AAF9,
-				F0EC60AEFAFF3D289F8110BE,
-				C3406F00595AEFF068EDB162,
-				3A2E957EB8D117C535F119E9,
-				52AE3F7AEED81BA9ED5C4830,
-				3933895CA488855A23943F61,
-				AF67C81811F18FCE6AA9C895,
-				AA16BE5A6BBD024C8FCFCDA8,
-				992137E90F9D41522FD56875,
-				7F188166D38DA7FB23311413,
-				A454D138EC507C01D299AB0F,
-				784125612E2B7AC6CD89D835,
-				21539690A9A5DD20AFAF41D3,
-				0836C50051EF59BF91D7B12D,
-				55CD2E9F373B69C3E8363B78,
-				2B29D90B985E9EB788472EFE,
-				D0873C347977633B4421B94D,
-				BF3254F07C15D467D6DB3FEF,
-				6029B20DF2BD523AC0F78896,
-				6702EEA4E99D503C0EE933C4,
-				89FCE8890946693CD5FC4A70,
-				C9AC286A46B3A1318F298DEF,
-				DA836EC803E4FF4EDEBE6386,
-				702C9BFCE865CB6C6B8BFB0D,
-				739573501D1D440A72C5C2E5,
-				955561F4FF4484648FDB9F73,
-				6B67D7B6301182C7621294B6,
-				FAE745870674A07A65690433,
-				24CC7E9A7E87F762D4AB0467,
-				66F3B79BDF9BFB631D7E3584,
-				996F9E4989EB47941D8100DA,
-				BE54C019A73BBAE05BFD7D17,
-				5AE42EF7A713B1EC0ACF9EDE,
-				71111DE81104B1536ECB6DFB,
-				85A60568B3DC342C76B4E679,
-				8A5BACA019DA9B0EFAD5CE93,
-				D499273B65D901D0A101CAAA,
-				95AE939ADE096394CCD2526F,
-				E85DA5FC9A162F129ABA7113,
-				6A13D8F42A330E2C410B43E3,
-				13F1111511DD01E843E631CA,
-				9A80E3D1D1758A31D2169497,
-				F4397EAE00E0B9F96C8B6C07,
-				09673DA3B4D6EA61DEFC0C46,
-				591CED1277A8C945EF60841C,
-				0987D2A72DD60B4A7D719707,
-				58D3FF3B1F462634167BDFB5,
-				3162B66BC8118715AAA527D7,
-				004E78BC139419671A9EA137,
-				6306AA945375749C4FE834E6,
-				AD7D05519200FB0EE1C7617A,
-				C2475E008FEB33B3EA7B6C7F,
-				9227961C07C0EE73E89C90B5,
-				A2EE65335FB2810C04ECBFAF,
-				3FF289281D3318A7BA8BB44D,
-				9E30156DBCE4EAF9EFAF0AC4,
-				6510492BAE00C95DC620F493,
-				06BCB79AE267E5841F641E38,
-				A0DAD4E5F7583349DC9275F2,
-				FCB767F14565886C9D823916,
-				7015D104F55D5B128341CEA8,
-				A269A876BDF3B7011FA4C681,
-				58E0EC510F2A88E14AE55439,
-				002427B013C43CE3E6D4E9B5,
-				FA2A052548AAD146F3F5AD83 ); runOnlyForDeploymentPostprocessing = 0; };
-		7BE915E5A64C787EBF13A8E7 = { isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (
-				0D3DFADD627629AD52668186,
-				38568B2E6C61E2F07173B568,
-				C8D7AC0B88A9A2C182B2B752,
-				A94130738A9973148544664A,
-				E5CBEA12D7AD7788C9BF5737,
-				9212DC2AEE118398CC970DDF,
-				3D0C7CA4AD9E3963D52E89BD,
-				3130878C465F3294A89CA142,
-				E100912B2FCE36A30D097C95,
-				CAB9D9DEF279F93132B45F90,
-				CA4DCF67B48352BE633A616D,
-				FD4865450F4C47FF3C6327FE,
-				512D7D16D0A95BDD0D6D6E45 ); runOnlyForDeploymentPostprocessing = 0; };
-		609761DEC9151D2CDD50270C = { isa = PBXNativeTarget; buildConfigurationList = B0259CB1FA28CEC89ED4FA14; buildPhases = (
-				256EEB2E7946EFA9B0774D25,
-				0C1B429379FBBA77A635B49A,
-				7BE915E5A64C787EBF13A8E7 ); buildRules = ( ); dependencies = ( ); name = "open-ephys"; productName = "open-ephys"; productReference = 99E1BC08B886CFDD2CCFD462; productInstallPath = "$(HOME)/Applications"; productType = "com.apple.product-type.application"; };
-		41375E3272D6505F75FDEEEB = { isa = PBXProject; buildConfigurationList = 3B096175C0B17BFA58475A08; attributes = { LastUpgradeCheck = 0440; }; compatibilityVersion = "Xcode 3.2"; hasScannedForEncodings = 0; mainGroup = A7589AF92E6E958E1F866761; projectDirPath = ""; projectRoot = ""; targets = ( 609761DEC9151D2CDD50270C ); };
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3B096175C0B17BFA58475A08 /* Build configuration list for PBXProject "open-ephys" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C8018C9A4DA633CA60663294 /* Debug */,
+				747300E66AC17ACE193A6C37 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B0259CB1FA28CEC89ED4FA14 /* Build configuration list for PBXNativeTarget "open-ephys" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95F63B27BAC6E72226C3E356 /* Debug */,
+				7A6F9B742B69F66DC3E29FA8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
 	};
-	rootObject = 41375E3272D6505F75FDEEEB;
+	rootObject = 41375E3272D6505F75FDEEEB /* Project object */;
 }


### PR DESCRIPTION
Added Xcode options sufficient to make this compile if Google Protocol
Buffers (protobuf-cpp) and 0MQ (zmq) are installed via MacPorts.

A nice person could add similar search path options to handle the
homebrew case.
