### PR TITLE
.gitignore vim swap files and gmon.out gcc profile output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ cscope.files
 cscope.out
 *~
 .dir-locals.el
+*.swp
+gmon.out
 
 # 7. Open Ephys data files
 *.continuous


### PR DESCRIPTION
(At least) the linux makefile has the -pg flag set for gcc for both release and debug profiles, producing profile information (gmon.out) output in the folder the executable is called from.
