### PR TITLE
Fix deprecation warning

### DIFF
--- a/Source/Processors/Visualization/DataWindow.cpp
+++ b/Source/Processors/Visualization/DataWindow.cpp
@@ -46,5 +46,5 @@ void DataWindow::closeButtonPressed()
 {
 	setContentNonOwned(0,false);
     setVisible(false);
-    controlButton->setToggleState(false,false);
+    controlButton->setToggleState(false,dontSendNotification);
 }


### PR DESCRIPTION
Button::setToggleState (bool, bool) was deprecated in favour of Button::setToggleState (bool, NotificationType).
