### PR TITLE
Adds /usr/local to library and header search path for OS X

### DIFF
--- a/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
@@ -1998,9 +1998,9 @@
 					AFE835E175F7159E1E7C6CC7,
 					2DA0032B6DF10345C4842BF5,
 					B64893F699A10B03AA4AFF6B,
+					55F7467B96E236DD558228C9,
 					9200FC900D22733AE716C364,
 					6596D69CCD1502DC6BBD15F1,
-					55F7467B96E236DD558228C9,
 					05BD169B8574607A6F6AD3B6,
 					6C8489C41782E3D391AF0C26,
 					1246C8A62803B7E115713705,
@@ -2895,10 +2895,10 @@
 					"JUCE_APP_VERSION=0.3.2",
 					"JUCE_APP_VERSION_HEX=0x302", );
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				HEADER_SEARCH_PATHS = ("../../JuceLibraryCode", "../../JuceLibraryCode/modules", "/opt/local/include", "$(inherited)");
+				HEADER_SEARCH_PATHS = ("../../JuceLibraryCode", "../../JuceLibraryCode/modules", "/opt/local/include", "/usr/local/include", "$(inherited)");
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = ("$(inherited)", "\"/opt/local/lib\"");
+				LIBRARY_SEARCH_PATHS = ("$(inherited)", "\"/opt/local/lib\"", "\"/usr/local/lib\"");
 				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
 				OTHER_LDFLAGS = "-lhdf5 -lhdf5_cpp";
 				SDKROOT_ppc = macosx10.5; }; name = Debug; };
@@ -2918,10 +2918,10 @@
 					"JUCE_APP_VERSION_HEX=0x302", );
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				HEADER_SEARCH_PATHS = ("../../JuceLibraryCode", "../../JuceLibraryCode/modules", "/opt/local/include", "$(inherited)");
+				HEADER_SEARCH_PATHS = ("../../JuceLibraryCode", "../../JuceLibraryCode/modules", "/opt/local/include", "/usr/local/include", "$(inherited)");
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = ("$(inherited)", "\"/opt/local/lib\"");
+				LIBRARY_SEARCH_PATHS = ("$(inherited)", "\"/opt/local/lib\"", "\"/usr/local/lib\"");
 				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
 				OTHER_LDFLAGS = "-lhdf5 -lhdf5_cpp";
 				SDKROOT_ppc = macosx10.5; }; name = Release; };

--- a/open-ephys.jucer
+++ b/open-ephys.jucer
@@ -16,10 +16,10 @@
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="3" targetName="open-ephys"
                        osxSDK="default" osxCompatibility="default" osxArchitecture="default"
-                       headerPath="/opt/local/include" libraryPath="/opt/local/lib"/>
+                       headerPath="/opt/local/include&#10;/usr/local/include" libraryPath="/opt/local/lib&#10;/usr/local/lib"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="open-ephys"
                        osxSDK="default" osxCompatibility="default" osxArchitecture="default"
-                       headerPath="/opt/local/include" libraryPath="/opt/local/lib"/>
+                       headerPath="/opt/local/include&#10;/usr/local/include" libraryPath="/opt/local/lib&#10;/usr/local/lib"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_video" path="JuceLibraryCode/modules"/>


### PR DESCRIPTION
This allows you to build against libhdf5 installed using homebrew (and other package managers that install to /usr/local).
