### PR TITLE
fix the wrong ADC_channel names in LFP canvas

### DIFF
--- a/Source/Processors/DataThreads/RHD2000Thread.cpp
+++ b/Source/Processors/DataThreads/RHD2000Thread.cpp
@@ -869,33 +869,36 @@ void RHD2000Thread::setDefaultChannelNamesAndType()
     }
 	//Aux channels
 	for (int i = 0; i < MAX_NUM_DATA_STREAMS; i++)
-    {
-		for (int k = 0; k < 3; k++)
-            {
+    {	
+    	if (numChannelsPerDataStream[i] > 0)
+        {
+			for (int k = 0; k < 3; k++)
+		        {
 
-                type.add(AUX_CHANNEL);
+		            type.add(AUX_CHANNEL);
 
-                if (channelModified(AUX_CHANNEL,i,numChannelsPerDataStream[i]+k, oldName,oldGain, dummy))
-                {
-                    Names.add(oldName);
-                    gains.add(oldGain);
+		            if (channelModified(AUX_CHANNEL,i,numChannelsPerDataStream[i]+k, oldName,oldGain, dummy))
+		            {
+		                Names.add(oldName);
+		                gains.add(oldGain);
 
-                    aux_counter++;
-                }
-                else
-                {
-                    if (numberingScheme == 1)
-                        Names.add("AUX"+String(aux_counter++));
-                    else
-                        Names.add("AUX_"+stream_prefix[i]+"_"+String(1+k));
+		                aux_counter++;
+		            }
+		            else
+		            {
+		                if (numberingScheme == 1)
+		                    Names.add("AUX"+String(aux_counter++));
+		                else
+		                    Names.add("AUX_"+stream_prefix[i]+"_"+String(1+k));
 
-                    gains.add(0.0000374);
+		                gains.add(0.0000374);
 
-                }
+		            }
 
-                stream.add(i);
-                originalChannelNumber.add(numChannelsPerDataStream[i]+k);
-            }
+		            stream.add(i);
+		            originalChannelNumber.add(numChannelsPerDataStream[i]+k);
+		        }
+		 }
 	}
 	//ADC channels
     if (acquireAdcChannels)


### PR DESCRIPTION
The wrong ADC_channel names bug: The ADC channels are given names of "AUX" in LFP viewer.
before ADC channels being enabled: 
![image](https://cloud.githubusercontent.com/assets/7818495/5543989/6bc501aa-8acb-11e4-920b-1cf9896fa0fb.png)

after ADC channels being enabled:
![image](https://cloud.githubusercontent.com/assets/7818495/5543985/5c56bfc4-8acb-11e4-85c7-a3c1da6137bd.png)
