### PR TITLE
Included unistd.h 

### DIFF
--- a/Resources/Matlab/unix/zeroMQwrapper.cpp
+++ b/Resources/Matlab/unix/zeroMQwrapper.cpp
@@ -13,6 +13,8 @@
 #include <queue>
 #include <list>
 #include <pthread.h>
+#include <unistd.h>
+
 
 typedef struct {
     const char *connect_url;


### PR DESCRIPTION
for successful Linux compile, known fix from https://github.com/open-ephys/GUI/pull/150