### PR TITLE
Fix some bugs, remove many compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ Builds/Linux/build/windowState.xml
 Builds/Linux/build/Data
 Builds/Linux/build/*.xml
 Builds/Linux/build/*.out
-Builds/MacOSX/build
 
 # 4. Windows related
 Builds/VisualStudio2012/Debug
@@ -91,3 +90,9 @@ Builds/MacOSX/open-ephys.xcodeproj/*.mode1v3
 Builds/MacOSX/open-ephys.xcodeproj/*.pbxuser
 Builds/MacOSX/open-ephys.xcodeproj/xcuserdata
 Builds/MacOSX/open-ephys.xcodeproj/project.xcworkspace
+Builds/MacOSX/build
+Introjucer/Builds/MacOSX/The Introjucer.xcodeproj/*.mode1v3
+Introjucer/Builds/MacOSX/The Introjucer.xcodeproj/*.pbxuser
+Introjucer/Builds/MacOSX/The Introjucer.xcodeproj/xcuserdata
+Introjucer/Builds/MacOSX/The Introjucer.xcodeproj/project.xcworkspace
+Introjucer/Builds/MacOSX/build

--- a/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		E100912B2FCE36A30D097C95 = {isa = PBXBuildFile; fileRef = 9C21DBFB38865E5AFE367C6F; };
 		CAB9D9DEF279F93132B45F90 = {isa = PBXBuildFile; fileRef = 80C1B737D2C2CB519D1787D7; };
 		CA4DCF67B48352BE633A616D = {isa = PBXBuildFile; fileRef = C055D09224D84121A3EBB29F; };
-		FD4865450F4C47FF3C6327FE = {isa = PBXBuildFile; fileRef = 56169D835A3E3029D6E3904C; };
 		512D7D16D0A95BDD0D6D6E45 = {isa = PBXBuildFile; fileRef = 4FD13AA663EEE7CC2F83033D; };
 		2D2BDB63CBD0BED07FF9E44B = {isa = PBXBuildFile; fileRef = BBE1DB78E35135B41537DCB5; };
 		4FA2949D3023FC2E377AFFB6 = {isa = PBXBuildFile; fileRef = 61317B5191E05925F232E18C; };
@@ -542,7 +541,6 @@
 		55EBFCA56B915C8CD043365C = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_DirectWriteTypeLayout.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/native/juce_win32_DirectWriteTypeLayout.cpp"; sourceTree = "SOURCE_ROOT"; };
 		55F7467B96E236DD558228C9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_CharPointer_UTF8.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_CharPointer_UTF8.h"; sourceTree = "SOURCE_ROOT"; };
 		560A28C1966B1817873CF764 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_MidiMessageSequence.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/midi/juce_MidiMessageSequence.cpp"; sourceTree = "SOURCE_ROOT"; };
-		56169D835A3E3029D6E3904C = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickTime.framework; path = System/Library/Frameworks/QuickTime.framework; sourceTree = SDKROOT; };
 		56242BB33B53F133914517BD = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordControlEditor.cpp; path = ../../Source/Processors/RecordControl/RecordControlEditor.cpp; sourceTree = "SOURCE_ROOT"; };
 		562E4A50364EEDC3AA2AACB8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativeTime.h"; path = "../../JuceLibraryCode/modules/juce_core/time/juce_RelativeTime.h"; sourceTree = "SOURCE_ROOT"; };
 		563F35B171FAF2540923CE45 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioDataConverters.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioDataConverters.cpp"; sourceTree = "SOURCE_ROOT"; };
@@ -1253,23 +1251,24 @@
 		E7ACE8C1456403A574236451 = {isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-bold-serialized"; path = "../../Resources/Fonts/cpmono-bold-serialized"; sourceTree = "SOURCE_ROOT"; };
 		E7EE416EF527C7506B499070 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BigInteger.h"; path = "../../JuceLibraryCode/modules/juce_core/maths/juce_BigInteger.h"; sourceTree = "SOURCE_ROOT"; };
 		E835BEB3C42E4B241804BE13 = {isa = PBXFileReference; lastKnownFileType = file; name = "cpmono-light-serialized"; path = "../../Resources/Fonts/cpmono-light-serialized"; sourceTree = "SOURCE_ROOT"; };
+		E849E3966302E7D4D06712F5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordControl.cpp; path = ../../Source/Processors/RecordControl/RecordControl.cpp; sourceTree = "SOURCE_ROOT"; };
 		E850C14F13F9855CE1E14C1A = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ArduinoOutputEditor.cpp; path = ../../Source/Processors/ArduinoOutput/ArduinoOutputEditor.cpp; sourceTree = "SOURCE_ROOT"; };
 		E8964C0BE264A55753BC6B7B = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_linux_Midi.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_devices/native/juce_linux_Midi.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E8D51D470C9955D7D03D5469 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChebyshevII.h; path = ../../Source/Processors/Dsp/ChebyshevII.h; sourceTree = "SOURCE_ROOT"; };
 		E91923510CB2280C3A3B9E9C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_LocalisedStrings.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_LocalisedStrings.h"; sourceTree = "SOURCE_ROOT"; };
-		E91A272EF06892937CB4B9CE = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentDragger.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_ComponentDragger.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EA2FC92CECD1EDA1F07DC59C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TooltipWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TooltipWindow.h"; sourceTree = "SOURCE_ROOT"; };
+		E946426F95E0240683CB3337 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawablePath.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawablePath.h"; sourceTree = "SOURCE_ROOT"; };
 		EA354D7D8E48D461415D52D8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_JPEGLoader.cpp"; path = "../../JuceLibraryCode/modules/juce_graphics/image_formats/juce_JPEGLoader.cpp"; sourceTree = "SOURCE_ROOT"; };
 		EA9518CDEA7049C21D5CE2D5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_Process.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_Process.h"; sourceTree = "SOURCE_ROOT"; };
 		EAB6A66678B122C578B16445 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_HighResolutionTimer.h"; path = "../../JuceLibraryCode/modules/juce_core/threads/juce_HighResolutionTimer.h"; sourceTree = "SOURCE_ROOT"; };
 		EAC262A83CD2BEA14542AE89 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_StringPool.h"; path = "../../JuceLibraryCode/modules/juce_core/text/juce_StringPool.h"; sourceTree = "SOURCE_ROOT"; };
+		EDA209B0E7D124EA581023AD = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioFormatManager.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatManager.h"; sourceTree = "SOURCE_ROOT"; };
 		EF3F9AA8D70E1D4D55F13182 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_AudioThumbnail.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_utils/gui/juce_AudioThumbnail.cpp"; sourceTree = "SOURCE_ROOT"; };
 		F5A00ACFA3D76168F22F1205 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		99E1BC08B886CFDD2CCFD462 = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "open-ephys.app"; sourceTree = "BUILT_PRODUCTS_DIR"; };
-		E849E3966302E7D4D06712F5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RecordControl.cpp; path = ../../Source/Processors/RecordControl/RecordControl.cpp; sourceTree = "SOURCE_ROOT"; };
+		E8D51D470C9955D7D03D5469 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChebyshevII.h; path = ../../Source/Processors/Dsp/ChebyshevII.h; sourceTree = "SOURCE_ROOT"; };
+		E91A272EF06892937CB4B9CE = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ComponentDragger.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/mouse/juce_ComponentDragger.cpp"; sourceTree = "SOURCE_ROOT"; };
 		E93BE115650B1CB80EACB841 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EditorViewportButtons.h; path = ../../Source/UI/EditorViewportButtons.h; sourceTree = "SOURCE_ROOT"; };
-		E946426F95E0240683CB3337 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_DrawablePath.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_DrawablePath.h"; sourceTree = "SOURCE_ROOT"; };
 		E97684DCE824DEDA6683C6CD = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_Synthesiser.cpp"; path = "../../JuceLibraryCode/modules/juce_audio_basics/synthesisers/juce_Synthesiser.cpp"; sourceTree = "SOURCE_ROOT"; };
+		EA2FC92CECD1EDA1F07DC59C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_TooltipWindow.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/windows/juce_TooltipWindow.h"; sourceTree = "SOURCE_ROOT"; };
 		EA73332E3D5AEC04ADDFBB2A = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioDataConverters.h"; path = "../../JuceLibraryCode/modules/juce_audio_basics/buffers/juce_AudioDataConverters.h"; sourceTree = "SOURCE_ROOT"; };
 		EAB2319C7AA57E06A2247CDF = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BorderSize.h"; path = "../../JuceLibraryCode/modules/juce_graphics/geometry/juce_BorderSize.h"; sourceTree = "SOURCE_ROOT"; };
 		EAB637B566FEBBDADA654262 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_VSTMidiEventList.h"; path = "../../JuceLibraryCode/modules/juce_audio_processors/format_types/juce_VSTMidiEventList.h"; sourceTree = "SOURCE_ROOT"; };
@@ -1284,7 +1283,6 @@
 		ECE3BE71EB6B9CF1CE869BBE = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_BubbleComponent.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/misc/juce_BubbleComponent.h"; sourceTree = "SOURCE_ROOT"; };
 		ED86166920362E9D2BE2CB26 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_SVGParser.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/drawables/juce_SVGParser.cpp"; sourceTree = "SOURCE_ROOT"; };
 		ED887A521EEB8F3EBA7DDB31 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioIODeviceType.h"; path = "../../JuceLibraryCode/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.h"; sourceTree = "SOURCE_ROOT"; };
-		EDA209B0E7D124EA581023AD = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_AudioFormatManager.h"; path = "../../JuceLibraryCode/modules/juce_audio_formats/format/juce_AudioFormatManager.h"; sourceTree = "SOURCE_ROOT"; };
 		EDAC82BD742A54182E8DF2FE = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "juce_RelativeCoordinatePositioner.h"; path = "../../JuceLibraryCode/modules/juce_gui_basics/positioning/juce_RelativeCoordinatePositioner.h"; sourceTree = "SOURCE_ROOT"; };
 		EE0336B43A39FD585DF638EE = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_ResizableEdgeComponent.cpp"; path = "../../JuceLibraryCode/modules/juce_gui_basics/layout/juce_ResizableEdgeComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
 		EE2C669B127D00C86B1B8CA8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "juce_win32_Registry.cpp"; path = "../../JuceLibraryCode/modules/juce_core/native/juce_win32_Registry.cpp"; sourceTree = "SOURCE_ROOT"; };
@@ -2860,7 +2858,6 @@
 					9C21DBFB38865E5AFE367C6F,
 					80C1B737D2C2CB519D1787D7,
 					C055D09224D84121A3EBB29F,
-					56169D835A3E3029D6E3904C,
 					4FD13AA663EEE7CC2F83033D, ); name = Frameworks; sourceTree = "<group>"; };
 		FA0E0597ED415901958AD5AE = {isa = PBXGroup; children = (
 					99E1BC08B886CFDD2CCFD462, ); name = Products; sourceTree = "<group>"; };
@@ -3107,7 +3104,6 @@
 					E100912B2FCE36A30D097C95,
 					CAB9D9DEF279F93132B45F90,
 					CA4DCF67B48352BE633A616D,
-					FD4865450F4C47FF3C6327FE,
 					512D7D16D0A95BDD0D6D6E45, ); runOnlyForDeploymentPostprocessing = 0; };
 		609761DEC9151D2CDD50270C = {isa = PBXNativeTarget; buildConfigurationList = B0259CB1FA28CEC89ED4FA14; buildPhases = (
 					256EEB2E7946EFA9B0774D25,

--- a/JuceLibraryCode/AppConfig.h
+++ b/JuceLibraryCode/AppConfig.h
@@ -186,7 +186,7 @@
 #endif
 
 #ifndef    JUCE_QUICKTIME
- //#define JUCE_QUICKTIME
+ #define   JUCE_QUICKTIME 0
 #endif
 
 #ifndef    JUCE_USE_CAMERA

--- a/JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsContext.mm
+++ b/JuceLibraryCode/modules/juce_graphics/native/juce_mac_CoreGraphicsContext.mm
@@ -507,7 +507,7 @@ void CoreGraphicsContext::drawImage (const Image& sourceImage, const AffineTrans
        #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
         // There's a bug in CGContextDrawTiledImage that makes it incredibly slow
         // if it's doing a transformation - it's quicker to just draw lots of images manually
-        if (CGContextDrawTiledImage != 0 && transform.isOnlyTranslation())
+        if (&CGContextDrawTiledImage != 0 && transform.isOnlyTranslation())
             CGContextDrawTiledImage (context, imageRect, image);
         else
        #endif

--- a/JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_FileChooser.mm
+++ b/JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_FileChooser.mm
@@ -172,7 +172,10 @@ void FileChooser::showPlatformDialog (Array<File>& results,
         [panel setDirectoryURL: [NSURL fileURLWithPath: juceStringToNS (directory)]];
         [panel setNameFieldStringValue: juceStringToNS (filename)];
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         if ([panel runModal] == NSOKButton)
+#pragma GCC diagnostic pop
        #else
         if ([panel runModalForDirectory: juceStringToNS (directory)
                                    file: juceStringToNS (filename)] == NSOKButton)

--- a/JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
+++ b/JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
@@ -555,7 +555,10 @@ public:
 
        #if defined (MAC_OS_X_VERSION_10_6) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
         if ([NSWindow respondsToSelector: @selector (windowNumberAtPoint:belowWindowWithWindowNumber:)]
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
              && [NSWindow windowNumberAtPoint: [[ev window] convertBaseToScreen: [ev locationInWindow]]
+#pragma GCC diagnostic pop
                   belowWindowWithWindowNumber: 0] != [window windowNumber])
         {
             // moved into another window which overlaps this one, so trigger an exit

--- a/JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_Windowing.mm
+++ b/JuceLibraryCode/modules/juce_gui_basics/native/juce_mac_Windowing.mm
@@ -45,8 +45,11 @@ public:
     {
         switch (getRawResult())
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             case NSAlertDefaultReturn:  return 1;
             case NSAlertOtherReturn:    return 2;
+#pragma GCC diagnostic pop
             default:                    return 0;
         }
     }
@@ -97,9 +100,12 @@ private:
 
         switch (iconType)
         {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             case AlertWindow::InfoIcon:     return NSRunInformationalAlertPanel (ttl, msg, b1, b2, b3);
             case AlertWindow::WarningIcon:  return NSRunCriticalAlertPanel      (ttl, msg, b1, b2, b3);
             default:                        return NSRunAlertPanel              (ttl, msg, b1, b2, b3);
+#pragma GCC diagnostic pop
         }
     }
 };
@@ -185,6 +191,8 @@ bool DragAndDropContainer::performExternalDragDropOfFiles (const StringArray& fi
         dragPosition.x -= 16;
         dragPosition.y -= 16;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         [view dragImage: [[NSWorkspace sharedWorkspace] iconForFile: juceStringToNS (files[0])]
                      at: dragPosition
                  offset: NSMakeSize (0, 0)
@@ -192,6 +200,7 @@ bool DragAndDropContainer::performExternalDragDropOfFiles (const StringArray& fi
              pasteboard: pboard
                  source: view
               slideBack: YES];
+#pragma GCC diagnostic pop
     }
 
     return true;

--- a/JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Toolbar.cpp
+++ b/JuceLibraryCode/modules/juce_gui_basics/widgets/juce_Toolbar.cpp
@@ -591,8 +591,8 @@ void Toolbar::itemDragMove (const SourceDetails& dragSourceDetails)
             {
                 const Rectangle<int> previousPos (animator.getComponentDestination (prev));
 
-                if (abs (dragObjectLeft - (vertical ? previousPos.getY() : previousPos.getX())
-                      < abs (dragObjectRight - (vertical ? current.getBottom() : current.getRight()))))
+                if (abs (dragObjectLeft - (vertical ? previousPos.getY() : previousPos.getX()))
+                      < abs (dragObjectRight - (vertical ? current.getBottom() : current.getRight())))
                 {
                     newIndex = getIndexOfChildComponent (prev);
                 }
@@ -602,8 +602,8 @@ void Toolbar::itemDragMove (const SourceDetails& dragSourceDetails)
             {
                 const Rectangle<int> nextPos (animator.getComponentDestination (next));
 
-                if (abs (dragObjectLeft - (vertical ? current.getY() : current.getX())
-                     > abs (dragObjectRight - (vertical ? nextPos.getBottom() : nextPos.getRight()))))
+                if (abs (dragObjectLeft - (vertical ? current.getY() : current.getX()))
+                     > abs (dragObjectRight - (vertical ? nextPos.getBottom() : nextPos.getRight())))
                 {
                     newIndex = getIndexOfChildComponent (next) + 1;
                 }

--- a/JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_osx.h
+++ b/JuceLibraryCode/modules/juce_opengl/native/juce_OpenGL_osx.h
@@ -40,7 +40,10 @@ public:
             NSOpenGLPFAOpenGLProfile, version >= openGL3_2 ? NSOpenGLProfileVersion3_2Core : NSOpenGLProfileVersionLegacy,
            #endif
             NSOpenGLPFADoubleBuffer,
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             NSOpenGLPFAMPSafe,
+#pragma GCC diagnostic pop
             NSOpenGLPFAClosestPolicy,
             NSOpenGLPFANoRecovery,
             NSOpenGLPFAColorSize,   (NSOpenGLPixelFormatAttribute) (pixFormat.redBits + pixFormat.greenBits + pixFormat.blueBits),

--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -52,7 +52,7 @@ void setRecordingStatus(bool enable)
     getControlPanel()->setRecordState(enable);
 }
 
-void sendStatusMessage(String& text)
+void sendStatusMessage(const String& text)
 {
     getBroadcaster()->sendActionMessage(text);
 }

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -43,7 +43,7 @@ bool getRecordingStatus();
 void setRecordingStatus(bool enable);
 
 /** Sends a string to the message bar */
-void sendStatusMessage(String& text);
+void sendStatusMessage(const String& text);
 
 /** Sends a string to the message bar */
 void sendStatusMessage(const char* text);

--- a/Source/Processors/ArduinoOutput/ArduinoOutput.cpp
+++ b/Source/Processors/ArduinoOutput/ArduinoOutput.cpp
@@ -27,7 +27,7 @@
 #include <stdio.h>
 
 ArduinoOutput::ArduinoOutput()
-    : GenericProcessor("Arduino Output"), state(true), deviceSelected(false), outputChannel(13), inputChannel(-1)
+    : GenericProcessor("Arduino Output"), outputChannel(13), inputChannel(-1), state(true), deviceSelected(false)
 {
 
 }
@@ -101,7 +101,7 @@ void ArduinoOutput::handleEvent(int eventType, MidiMessage& event, int sampleNum
     {
         const uint8* dataptr = event.getRawData();
 
-        int eventNodeId = *(dataptr+1);
+        //int eventNodeId = *(dataptr+1);
         int eventId = *(dataptr+2);
         int eventChannel = *(dataptr+3);
 

--- a/Source/Processors/Channel/Channel.cpp
+++ b/Source/Processors/Channel/Channel.cpp
@@ -24,7 +24,7 @@
 #include "Channel.h"
 
 
-Channel::Channel(GenericProcessor* p, int n, ChannelType t) : index(n), processor(p), type(t), nodeIndex(0), mappedIndex(0)
+Channel::Channel(GenericProcessor* p, int n, ChannelType t) : nodeIndex(0), index(n), mappedIndex(0), processor(p), type(t)
 {
     reset();
 }

--- a/Source/Processors/ChannelMappingNode/ChannelMappingNode.cpp
+++ b/Source/Processors/ChannelMappingNode/ChannelMappingNode.cpp
@@ -64,7 +64,6 @@ AudioProcessorEditor* ChannelMappingNode::createEditor()
 
 void ChannelMappingNode::updateSettings()
 {
-    int j;
     if (getNumInputs() > 0)
         channelBuffer.setSize(getNumInputs(), 10000);
 

--- a/Source/Processors/DataThreads/RHD2000Editor.cpp
+++ b/Source/Processors/DataThreads/RHD2000Editor.cpp
@@ -37,7 +37,7 @@ inline double round(double x)
 #endif
 #endif
 
-FPGAchannelList::FPGAchannelList(GenericProcessor* proc_, Viewport* p, FPGAcanvas* c) : viewport(p), canvas(c), chainUpdate(false)
+FPGAchannelList::FPGAchannelList(GenericProcessor* proc_, Viewport* p, FPGAcanvas* c) : chainUpdate(false), viewport(p), canvas(c)
 {
     proc = (SourceNode*)proc_;
     channelComponents.clear();
@@ -131,7 +131,7 @@ void FPGAchannelList::update()
 
     // find out which streams are active.
     bool hsActive[MAX_NUM_HEADSTAGES+1];
-    bool adcActive = false;
+    //bool adcActive = false;
     int numActiveHeadstages = 0;
     int hsColumn[MAX_NUM_HEADSTAGES + 1];
     int numChannelsPerHeadstage[MAX_NUM_HEADSTAGES + 1];
@@ -336,7 +336,7 @@ void FPGAchannelList::updateImpedance(Array<int> streams, Array<int> channels, A
 
 /****************************************************/
 FPGAchannelComponent::FPGAchannelComponent(FPGAchannelList* cl, int ch, int gainIndex_, String N, Array<float> gains_, ChannelType type_) :
-gains(gains_), channelList(cl), channel(ch), name(N), gainIndex(gainIndex_), type(type_)
+type(type_), gains(gains_), channelList(cl), channel(ch), name(N), gainIndex(gainIndex_)
 {
     Font f = Font("Small Text", 13, Font::plain);
 
@@ -531,8 +531,8 @@ void FPGAcanvas::update()
 
 void FPGAcanvas::resized()
 {
-    int screenWidth = getWidth();
-    int screenHeight = getHeight();
+    //int screenWidth = getWidth();
+    //int screenHeight = getHeight();
 
     int scrollBarThickness = channelsViewport->getScrollBarThickness();
     int numChannels = 35; // max channels per stream? (32+3)*2

--- a/Source/Processors/DataThreads/RHD2000Thread.cpp
+++ b/Source/Processors/DataThreads/RHD2000Thread.cpp
@@ -451,6 +451,7 @@ void RHD2000Thread::scanPorts()
         Rhd2000EvalBoard::PortD2
     };
 
+    /*
     Rhd2000EvalBoard::BoardDataSource initStreamDdrPorts[8] =
     {
         Rhd2000EvalBoard::PortA1Ddr,
@@ -462,6 +463,7 @@ void RHD2000Thread::scanPorts()
         Rhd2000EvalBoard::PortD1Ddr,
         Rhd2000EvalBoard::PortD2Ddr
     };
+     */
 
     chipId.insertMultiple(0,-1,8);
     Array<int> tmpChipId(chipId);
@@ -776,8 +778,8 @@ void RHD2000Thread::setDefaultChannelNames()
     int aux_counter = 1;
     int channelNumber = 1;
     String oldName;
-    int dummy;
-    float oldGain;
+    //int dummy;
+    //float oldGain;
     StringArray stream_prefix;
     stream_prefix.add("A1");
     stream_prefix.add("A2");
@@ -1724,7 +1726,7 @@ void RHD2000Thread::runImpedanceTest(ImpedanceData* data)
 
 
 RHDHeadstage::RHDHeadstage(Rhd2000EvalBoard::BoardDataSource stream) :
-    numStreams(0), channelsPerStream(32), dataStream(stream), halfChannels(false)
+    dataStream(stream), numStreams(0), channelsPerStream(32), halfChannels(false)
 {
 	streamIndex = -1;
 }
@@ -1879,8 +1881,9 @@ int RHDImpedanceMeasure::loadAmplifierData(queue<Rhd2000DataBlock>& dataQueue,
 	int numBlocks, int numDataStreams)
 {
 
-	int block, t, channel, stream, i, j;
+	int block, t, channel, stream;
 	int indexAmp = 0;
+    /*
 	int indexAux = 0;
 	int indexSupply = 0;
 	int indexAdc = 0;
@@ -1894,6 +1897,7 @@ int RHDImpedanceMeasure::loadAmplifierData(queue<Rhd2000DataBlock>& dataQueue,
 
 	bool triggerFound = false;
 	const double AnalogTriggerThreshold = 1.65;
+     */
 
 
 	for (block = 0; block < numBlocks; ++block)
@@ -2044,7 +2048,7 @@ void RHDImpedanceMeasure::runImpedanceMeasurement()
 	int commandSequenceLength, stream, channel, capRange;
 	double cSeries;
 	vector<int> commandList;
-	int triggerIndex;                       // dummy reference variable; not used
+	//int triggerIndex;                       // dummy reference variable; not used
 	queue<Rhd2000DataBlock> bufferQueue;    // dummy reference variable; not used
 	int numdataStreams = board->evalBoard->getNumEnabledDataStreams();
 

--- a/Source/Processors/Dsp/ChebyshevI.cpp
+++ b/Source/Processors/Dsp/ChebyshevI.cpp
@@ -118,8 +118,8 @@ void AnalogLowShelf::design(int numPoles,
 
         gainDb = -gainDb;
 
-        if (rippleDb >= abs(gainDb))
-            rippleDb = abs(gainDb);
+        if (rippleDb >= std::abs(gainDb))
+            rippleDb = std::abs(gainDb);
         if (gainDb<0)
             rippleDb = -rippleDb;
 

--- a/Source/Processors/Dsp/ChebyshevII.cpp
+++ b/Source/Processors/Dsp/ChebyshevII.cpp
@@ -117,8 +117,8 @@ void AnalogLowShelf::design(int numPoles,
 
         gainDb = -gainDb;
 
-        if (stopBandDb >= abs(gainDb))
-            stopBandDb = abs(gainDb);
+        if (stopBandDb >= std::abs(gainDb))
+            stopBandDb = std::abs(gainDb);
         if (gainDb<0)
             stopBandDb = -stopBandDb;
 

--- a/Source/Processors/Dsp/Elliptic.cpp
+++ b/Source/Processors/Dsp/Elliptic.cpp
@@ -141,17 +141,17 @@ void AnalogLowPass::design(int numPoles,
             double d = 1+m_p[r]+m_q1[r];
             m_b1[r] = (1+m_p[r]/2)*fbb/d;
             m_zf1[r] = fb/pow(d, .25);
-            m_zq1[r] = 1/sqrt(abs(2*(1-m_b1[r]/(m_zf1[r]*m_zf1[r]))));
+            m_zq1[r] = 1/sqrt(std::abs(2*(1-m_b1[r]/(m_zf1[r]*m_zf1[r]))));
             m_zw1[r] = tp*m_zf1[r];
 
             m_rootR[r] = -.5*m_zw1[r]/m_zq1[r];
             m_rootR[r+m_em/2] = m_rootR[r];
-            m_rootI[r] = .5*sqrt(abs(m_zw1[r]*m_zw1[r]/(m_zq1[r]*m_zq1[r]) - 4*m_zw1[r]*m_zw1[r]));
+            m_rootI[r] = .5*sqrt(std::abs(m_zw1[r]*m_zw1[r]/(m_zq1[r]*m_zq1[r]) - 4*m_zw1[r]*m_zw1[r]));
             m_rootI[r+m_em/2] = -m_rootI[r];
 
             complex_t pole(
                 -.5*m_zw1[r]/m_zq1[r],
-                .5*sqrt(abs(m_zw1[r]*m_zw1[r]/(m_zq1[r]*m_zq1[r]) - 4*m_zw1[r]*m_zw1[r])));
+                .5*sqrt(std::abs(m_zw1[r]*m_zw1[r]/(m_zq1[r]*m_zq1[r]) - 4*m_zw1[r]*m_zw1[r])));
 
             complex_t zero(0, m_zeros[r-1]);
 
@@ -273,7 +273,7 @@ double AnalogLowPass::findfact(int t)
             p0 += ddp;
             double dq = (m_b1[t]*m_c1[x2]-m_b1[x1]*(m_c1[x1]-m_b1[x1]))/x4;
             q0 += dq;
-            if (abs(ddp+dq) < 1e-6)
+            if (std::abs(ddp+dq) < 1e-6)
                 break;
         }
         m_p[i1] = p0;

--- a/Source/Processors/Editors/NetworkEventsEditor.cpp
+++ b/Source/Processors/Editors/NetworkEventsEditor.cpp
@@ -83,7 +83,7 @@ NetworkEventsEditor::NetworkEventsEditor(GenericProcessor* parentNode, bool useD
 
 void NetworkEventsEditor::buttonEvent(Button* button)
 {
-			NetworkEvents *processor  = (NetworkEvents*) getProcessor();
+			//NetworkEvents *processor  = (NetworkEvents*) getProcessor();
 	if (button == restartConnection)
 	{
 		NetworkEvents *p= (NetworkEvents *)getProcessor();

--- a/Source/Processors/FileReader/FileSource.h
+++ b/Source/Processors/FileReader/FileSource.h
@@ -36,7 +36,7 @@ class FileSource
 {
 public:
     FileSource();
-    ~FileSource();
+    virtual ~FileSource();
 
     int getNumRecords();
     String getRecordName(int index);

--- a/Source/Processors/FilterNode/FilterNode.cpp
+++ b/Source/Processors/FilterNode/FilterNode.cpp
@@ -126,7 +126,7 @@ AudioProcessorEditor* FilterNode::createEditor()
 
 void FilterNode::updateSettings()
 {
-    int id = nodeId;
+    //int id = nodeId;
     int numInputs = getNumInputs();
     int numfilt = filters.size();
     if (numInputs < 1024 && numInputs != numfilt)

--- a/Source/Processors/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Source/Processors/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -1371,6 +1371,7 @@ int LfpDisplay::getRange(ChannelType type)
         if (channels[i]->getType() == type)
             return channels[i]->getRange();
     }
+    return 0;
 }
 
 
@@ -1803,7 +1804,7 @@ void LfpChannelDisplay::paint(Graphics& g)
                 // // pixel wise line plot has no anti-aliasing, but runs much faster
                 double a = (canvas->getYCoordMax(chan, i)/range*channelHeightFloat)+getHeight()/2;
                 double b = (canvas->getYCoordMin(chan, i)/range*channelHeightFloat)+getHeight()/2;
-                double m = (canvas->getYCoordMean(chan, i)/range*channelHeightFloat)+getHeight()/2;
+                //double m = (canvas->getYCoordMean(chan, i)/range*channelHeightFloat)+getHeight()/2;
                 if (a<b)
                 {
                     from = (a);
@@ -2008,7 +2009,7 @@ void LfpChannelDisplayInfo::buttonClicked(Button* button)
 
     display->setEnabledState(state, chan);
 
-    UtilityButton* b = (UtilityButton*) button;
+    //UtilityButton* b = (UtilityButton*) button;
 
     // if (state)
     // {

--- a/Source/Processors/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Source/Processors/LfpDisplayNode/LfpDisplayNode.cpp
@@ -155,7 +155,7 @@ void LfpDisplayNode::handleEvent(int eventType, MidiMessage& event, int sampleNu
     {
         const uint8* dataptr = event.getRawData();
 
-        int eventNodeId = *(dataptr+1);
+        //int eventNodeId = *(dataptr+1);
         int eventId = *(dataptr+2);
         int eventChannel = *(dataptr+3);
         int eventTime = event.getTimeStamp();

--- a/Source/Processors/Merger/Merger.cpp
+++ b/Source/Processors/Merger/Merger.cpp
@@ -30,9 +30,9 @@
 
 Merger::Merger()
     : GenericProcessor("Merger"),
-      sourceNodeA(0), sourceNodeB(0), activePath(0), 
       mergeEventsA(true), mergeContinuousA(true),
-      mergeEventsB(true), mergeContinuousB(true)
+      mergeEventsB(true), mergeContinuousB(true),
+      sourceNodeA(0), sourceNodeB(0), activePath(0)
 {
     sendSampleCount = false;
 }

--- a/Source/Processors/MessageCenter/MessageCenter.cpp
+++ b/Source/Processors/MessageCenter/MessageCenter.cpp
@@ -30,7 +30,7 @@
 
 MessageCenter::MessageCenter() :
     GenericProcessor("Message Center"), newEventAvailable(false), isRecording(false), sourceNodeId(0), 
-	lastTime(0), softTimestamp(0), timestampSource(nullptr)
+	timestampSource(nullptr), lastTime(0), softTimestamp(0)
 {
 
     setPlayConfigDetails(0, // number of inputs
@@ -142,7 +142,7 @@ void MessageCenter::process(AudioSampleBuffer& buffer, MidiBuffer& eventBuffer)
 
     if (newEventAvailable)
     {
-        int numBytes = 0;
+        //int numBytes = 0;
 
         String eventString = messageCenterEditor->getLabelString();
 

--- a/Source/Processors/MessageCenter/MessageCenterEditor.cpp
+++ b/Source/Processors/MessageCenter/MessageCenterEditor.cpp
@@ -25,10 +25,10 @@
 
 MessageCenterEditor::MessageCenterEditor(MessageCenter* owner) :
     AudioProcessorEditor(owner),
+    acquisitionIsActive(false),
     messageCenter(owner),
     incomingBackground(100, 100, 100),
-    outgoingBackground(100, 100, 100),
-    acquisitionIsActive(false)
+    outgoingBackground(100, 100, 100)
 {
 
     incomingMessageDisplayArea = new MessageLabel("Message Display Area","No new messages.");

--- a/Source/Processors/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Processors/NetworkEvents/NetworkEvents.cpp
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../../AccessClass.h"
 #include "../MessageCenter/MessageCenterEditor.h"
 
-//const int MAX_MESSAGE_LENGTH = 64000;
+const int MAX_MESSAGE_LENGTH = 64000;
 
 
 #ifdef WIN32

--- a/Source/Processors/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Processors/NetworkEvents/NetworkEvents.cpp
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../../AccessClass.h"
 #include "../MessageCenter/MessageCenterEditor.h"
 
-const int MAX_MESSAGE_LENGTH = 64000;
+//const int MAX_MESSAGE_LENGTH = 64000;
 
 
 #ifdef WIN32

--- a/Source/Processors/PSTH/PeriStimulusTimeHistogramEditor.cpp
+++ b/Source/Processors/PSTH/PeriStimulusTimeHistogramEditor.cpp
@@ -794,7 +794,7 @@ void PeriStimulusTimeHistogramCanvas::resized()
     screenWidth = getWidth();
     screenHeight = getHeight();
 
-    int scrollBarThickness = viewport->getScrollBarThickness();
+    //int scrollBarThickness = viewport->getScrollBarThickness();
 
     viewport->setBounds(0,30,getWidth()-conditionWidth,getHeight()-30);
     int totalHeight = numRows * heightPerElectrodePix;
@@ -1031,7 +1031,7 @@ void ConditionList::buttonClicked(Button* btn)
     // also inform trial circular buffer about visibility change.
     if (btn == titleButton)
     {
-        int x = 5;
+        //int x = 5;
     }
     else if (btn == noneButton)
     {
@@ -1082,8 +1082,8 @@ void ConditionList::buttonClicked(Button* btn)
 //
 
 GenericPlot::GenericPlot(String name,PeriStimulusTimeHistogramDisplay* dsp, int plotID_, xyPlotTypes plotType_,
-                         TrialCircularBuffer* tcb_, int electrodeID_, int subID_, int row_, int col_, bool rasterMode_, bool panM) :  tcb(tcb_), electrodeID(electrodeID_), plotID(plotID_),
-    plotType(plotType_), subID(subID_), row(row_), col(col_), rasterMode(rasterMode_),display(dsp),plotName(name),inPanMode(panM)
+                         TrialCircularBuffer* tcb_, int electrodeID_, int subID_, int row_, int col_, bool rasterMode_, bool panM) :  display(dsp),tcb(tcb_), plotID(plotID_),
+    plotType(plotType_), electrodeID(electrodeID_), subID(subID_), row(row_), col(col_), rasterMode(rasterMode_),inPanMode(panM),plotName(name)
 {
     fullScreenMode = false;
     mlp = new MatlabLikePlot();

--- a/Source/Processors/PSTH/PeriStimulusTimeHistogramNode.cpp
+++ b/Source/Processors/PSTH/PeriStimulusTimeHistogramNode.cpp
@@ -65,7 +65,7 @@ void PeriStimulusTimeHistogramNode::loadCustomParametersFromXml()
         {
             if (mainNode->hasTagName("PSTH"))
             {
-                int numElectrodes = mainNode->getIntAttribute("numElectrodes");
+                //int numElectrodes = mainNode->getIntAttribute("numElectrodes");
 
                 saveEyeTracking = mainNode->getBoolAttribute("saveEyeTracking");
                 saveTTLs = mainNode->getBoolAttribute("saveTTLs");

--- a/Source/Processors/PSTH/TrialCircularBuffer.cpp
+++ b/Source/Processors/PSTH/TrialCircularBuffer.cpp
@@ -1284,7 +1284,7 @@ void SmartSpikeCircularBuffer::addSpikeToBuffer(int64 spikeTimeSoftware,int64 sp
     numSpikesStored++;
 
     if (numSpikesStored > bufferSize)
-        numSpikesStored = numSpikesStored;
+        numSpikesStored = bufferSize;
 }
 
 

--- a/Source/Processors/PSTH/TrialCircularBuffer.cpp
+++ b/Source/Processors/PSTH/TrialCircularBuffer.cpp
@@ -100,7 +100,7 @@ void setDefaultColors(uint8& R, uint8& G, uint8& B, int ID)
 
 
 /******************************/
-PSTH::PSTH(int ID, TrialCircularBufferParams params_, bool vis) : conditionID(ID),params(params_),numTrials(0),visible(vis)
+PSTH::PSTH(int ID, TrialCircularBufferParams params_, bool vis) : conditionID(ID),visible(vis),numTrials(0),params(params_)
 {
     // if approximate is on, we won't sample exactly xmin and xmax
     if (params.approximate)
@@ -582,7 +582,7 @@ void ChannelPSTHs::clearStatistics()
 
 /***********************************************/
 UnitPSTHs::UnitPSTHs(int ID,TrialCircularBufferParams params_, uint8 R, uint8 G, uint8 B):
-    unitID(ID), params(params_), spikeBuffer(params_.maxTrialTimeSeconds, params_.maxTrialsInMemory, params_.sampleRate)
+    spikeBuffer(params_.maxTrialTimeSeconds, params_.maxTrialsInMemory, params_.sampleRate), unitID(ID), params(params_)
 {
     colorRGB[0] = R;
     colorRGB[1] = G;
@@ -952,7 +952,7 @@ bool SmartContinuousCircularBuffer::getAlignedData(std::vector<int> channels, Tr
     }
 
     // consider search_back_ptr the buffer index pointing at time t=0
-    float t0 = hardwareTS[search_back_ptr];
+    //float t0 = hardwareTS[search_back_ptr];
     int t0_indx = search_back_ptr;
 
     float trial_length_sec = float(trial->endTS-trial->alignTS)/numTicksPerSecond;
@@ -1243,7 +1243,7 @@ SmartSpikeCircularBuffer::SmartSpikeCircularBuffer(float maxTrialTimeSeconds, in
 
     if (bufferSize == 0)
     {
-        int dbg = 1;
+        //int dbg = 1;
     }
 
     bufferIndex = 0;
@@ -2772,7 +2772,7 @@ std::vector<std::vector<float>> TrialCircularBuffer::getTrialsAverageUnitRespons
     const ScopedLock myScopedLock(psthMutex);
     //const ScopedLock myScopedLock (conditionMutex);
 
-    bool fisrtTime = true;
+    //bool fisrtTime = true;
     for (int electrodeIndex=0; electrodeIndex<electrodesPSTH.size(); electrodeIndex++)
     {
         if (electrodesPSTH[electrodeIndex].electrodeID == electrodeID)
@@ -2874,7 +2874,7 @@ std::vector<std::vector<float>> TrialCircularBuffer::getTrialsAverageChannelResp
 
     //lockPSTH();
     //lockConditions();
-    bool fisrtTime = true;
+    //bool fisrtTime = true;
     for (int electrodeIndex=0; electrodeIndex<electrodesPSTH.size(); electrodeIndex++)
     {
         if (electrodesPSTH[electrodeIndex].electrodeID == electrodeID)
@@ -3027,7 +3027,7 @@ int TrialCircularBuffer::getNumTrialTypesInChannel(int electrodeID, int channelI
 
     //lockPSTH();
     //lockConditions();
-    bool fisrtTime = true;
+    //bool fisrtTime = true;
     for (int electrodeIndex=0; electrodeIndex<electrodesPSTH.size(); electrodeIndex++)
     {
         if (electrodesPSTH[electrodeIndex].electrodeID == electrodeID)
@@ -3061,7 +3061,7 @@ int TrialCircularBuffer::getNumTrialTypesInUnit(int electrodeID, int unitID)
 
     //lockPSTH();
     //lockConditions();
-    bool fisrtTime = true;
+    //bool fisrtTime = true;
     for (int electrodeIndex=0; electrodeIndex<electrodesPSTH.size(); electrodeIndex++)
     {
         if (electrodesPSTH[electrodeIndex].electrodeID == electrodeID)
@@ -3095,7 +3095,7 @@ int TrialCircularBuffer::getNumTrialsInChannel(int electrodeID, int channelID)
 
     //lockPSTH();
     //lockConditions();
-    bool fisrtTime = true;
+    //bool fisrtTime = true;
     for (int electrodeIndex=0; electrodeIndex<electrodesPSTH.size(); electrodeIndex++)
     {
         if (electrodesPSTH[electrodeIndex].electrodeID == electrodeID)
@@ -3128,7 +3128,7 @@ int TrialCircularBuffer::getNumTrialsInUnit(int electrodeID, int unitID)
 
     //lockPSTH();
     //lockConditions();
-    bool fisrtTime = true;
+    //bool fisrtTime = true;
     for (int electrodeIndex=0; electrodeIndex<electrodesPSTH.size(); electrodeIndex++)
     {
         if (electrodesPSTH[electrodeIndex].electrodeID == electrodeID)
@@ -3189,7 +3189,7 @@ juce::Image TrialCircularBuffer::getTrialsAverageResponseAsJuceImage(int  ymin, 
 
     for (int i=0; i<imageHeight; i++)
     {
-        int yoffset = 3 * imageWidth;
+        //int yoffset = 3 * imageWidth;
         if (numTrialRepeats[ymin+i] == 0)
         {
             // special case, make all pixels black...
@@ -3270,9 +3270,9 @@ void TrialCircularBuffer::process(AudioSampleBuffer& buffer, int nSamples, int64
 
     Time t;
 
-    long startTime = t.getHighResolutionTicks();
+    //long startTime = t.getHighResolutionTicks();
 
-    double MaxPSTHprocessingTime = 50/1000; // 50 ms
+    //double MaxPSTHprocessingTime = 50/1000; // 50 ms
 
     if (electrodesPSTH.size() > 0 && aliveTrials.size() > 0)
     {
@@ -3284,9 +3284,9 @@ void TrialCircularBuffer::process(AudioSampleBuffer& buffer, int nSamples, int64
         for (int k = 0; k < aliveTrials.size(); k++)
         {
             Trial topTrial = aliveTrials.front();
-            int64 ticksElapsed = software_timestamp - topTrial.endTS;
+            //int64 ticksElapsed = software_timestamp - topTrial.endTS;
             //std::cout << "Ticks elapsed: " << ticksElapsed << std::endl;
-            float timeElapsedSec = float(ticksElapsed)/ numTicksPerSecond;
+            //float timeElapsedSec = float(ticksElapsed)/ numTicksPerSecond;
             //std::cout << "Time elapsed: " << timeElapsedSec << std::endl;
             bool trialEndedAndEnoughDataInBuffer;
 
@@ -3315,7 +3315,7 @@ void TrialCircularBuffer::process(AudioSampleBuffer& buffer, int nSamples, int64
                 //printf("Exiting updatePSTHwithTrial\n");
             }
 
-            long endTime = t.getHighResolutionTicks();
+            //long endTime = t.getHighResolutionTicks();
 
             //std::cout << "End time: " << endTime << std::endl;
 
@@ -3334,7 +3334,7 @@ void TrialCircularBuffer::process(AudioSampleBuffer& buffer, int nSamples, int64
 
 
 TrialCircularBufferThread::TrialCircularBufferThread(TrialCircularBuffer* tcb_,  std::vector<int>* conditions, Trial* trial_, int jobID_, int jobType_, int electrodeID_, int subID_) : ThreadPoolJob("Job "+String(jobID)),
-    tcb(tcb_),jobID(jobID_), jobType(jobType_), electrodeID(electrodeID_), subID(subID_), trial(trial_), conditionsNeedUpdate(conditions)
+    tcb(tcb_), trial(trial_), conditionsNeedUpdate(conditions), jobID(jobID_), jobType(jobType_), electrodeID(electrodeID_), subID(subID_)
 {
 
 }

--- a/Source/Processors/RecordNode/EngineConfigWindow.cpp
+++ b/Source/Processors/RecordNode/EngineConfigWindow.cpp
@@ -40,6 +40,10 @@ EngineParameterComponent::EngineParameterComponent(EngineParameter& param)
         lab->setFont(Font("Small Text",10,Font::plain));
         switch (param.type)
         {
+            case EngineParameter::BOOL:
+                lab->setText(String(param.boolParam.value),dontSendNotification);
+                lab->setBounds(120,0,50,20);
+                break;
             case EngineParameter::INT:
                 lab->setText(String(param.intParam.value),dontSendNotification);
                 lab->setBounds(120,0,50,20);

--- a/Source/Processors/RecordNode/HDF5Recording.cpp
+++ b/Source/Processors/RecordNode/HDF5Recording.cpp
@@ -163,7 +163,6 @@ void HDF5Recording::closeFiles()
 
 void HDF5Recording::writeData(AudioSampleBuffer& buffer)
 {
-    int index;
     for (int i = 0; i < buffer.getNumChannels(); i++)
     {
         if (getChannel(i)->getRecordState())

--- a/Source/Processors/RecordNode/OriginalRecording.cpp
+++ b/Source/Processors/RecordNode/OriginalRecording.cpp
@@ -243,7 +243,7 @@ void OriginalRecording::openMessageFile(File rootFolder)
 
     File f = File(fullPath);
 
-    bool fileExists = f.exists();
+    //bool fileExists = f.exists();
 
     diskWriteLock.enter();
 

--- a/Source/Processors/SpikeSorter/SpikeSortBoxes.cpp
+++ b/Source/Processors/SpikeSorter/SpikeSortBoxes.cpp
@@ -659,8 +659,8 @@ void SpikeSortBoxes::loadCustomParametersFromXml(XmlElement* electrodeNode)
     {
         if (spikesortNode->hasTagName("SPIKESORTING"))
         {
-            int numBoxUnit  = spikesortNode->getIntAttribute("numBoxUnits");
-            int numPCAUnit  = spikesortNode->getIntAttribute("numPCAUnits");
+            //int numBoxUnit  = spikesortNode->getIntAttribute("numBoxUnits");
+            //int numPCAUnit  = spikesortNode->getIntAttribute("numPCAUnits");
             selectedUnit  = spikesortNode->getIntAttribute("selectedUnit");
             selectedBox =  spikesortNode->getIntAttribute("selectedBox");
 
@@ -875,7 +875,7 @@ void SpikeSortBoxes::projectOnPrincipalComponents(SpikeObject* so)
         }
         if (so->pcProj[0] > 1e5 || so->pcProj[0] < -1e5 || so->pcProj[1] > 1e5 || so->pcProj[1] < -1e5)
         {
-            int dbg = 1;
+            //int dbg = 1;
         }
     }
     else

--- a/Source/Processors/SpikeSorter/SpikeSorter.cpp
+++ b/Source/Processors/SpikeSorter/SpikeSorter.cpp
@@ -506,7 +506,7 @@ bool SpikeSorter::removeElectrode(int index)
     String eventlog = "RemoveElectrode " + String(electrodes[index]->electrodeID);
     //addNetworkEventToQueue(StringTS(eventlog));
 
-    int idToRemove = electrodes[index]->electrodeID;
+    //int idToRemove = electrodes[index]->electrodeID;
     electrodes.remove(index);
 
     //(idToRemove);
@@ -1296,7 +1296,7 @@ void SpikeSorter::loadCustomParametersFromXml()
 
             if (mainNode->hasTagName("SpikeSorter"))
             {
-                int numElectrodes = mainNode->getIntAttribute("numElectrodes");
+                //int numElectrodes = mainNode->getIntAttribute("numElectrodes");
                 currentElectrode = mainNode->getIntAttribute("activeElectrode");
                 numPreSamples = mainNode->getIntAttribute("numPreSamples");
                 numPostSamples = mainNode->getIntAttribute("numPostSamples");

--- a/Source/Processors/SpikeSorter/SpikeSorterCanvas.cpp
+++ b/Source/Processors/SpikeSorter/SpikeSorterCanvas.cpp
@@ -182,7 +182,7 @@ void SpikeSorterCanvas::processSpikeEvents()
 {
 
 
-    Electrode* e = ((SpikeSorter*) processor)->getActiveElectrode();
+    //Electrode* e = ((SpikeSorter*) processor)->getActiveElectrode();
 
     //	e->spikeSort->lstLastSpikes
     //    processor->setParameter(2, 0.0f); // request redraw
@@ -1090,7 +1090,7 @@ void WaveformAxes::plotSpike(const SpikeObject& s, Graphics& g)
     // sample based upon which channel is getting plotted
     int offset = channel*s.nSamples; //spikeBuffer[0].nSamples * type; //
 
-    int dSamples = 1;
+    //int dSamples = 1;
 
     float x = 0.0f;
 
@@ -1867,8 +1867,8 @@ void PCAProjectionAxes::paint(Graphics& g)
     if (redrawSpikes)
     {
         // recompute image
-        int w = getWidth();
-        int h = getHeight();
+        //int w = getWidth();
+        //int h = getHeight();
         projectionImage.clear(juce::Rectangle<int>(0, 0, projectionImage.getWidth(), projectionImage.getHeight()),
                               Colours::black);
 
@@ -1905,8 +1905,8 @@ void PCAProjectionAxes::redraw(bool subsample)
     Graphics g(projectionImage);
 
     // recompute image
-    int w = getWidth();
-    int h = getHeight();
+    //int w = getWidth();
+    //int h = getHeight();
     projectionImage.clear(juce::Rectangle<int>(0, 0, projectionImage.getWidth(), projectionImage.getHeight()),
                           Colours::black);
 

--- a/Source/Processors/SpikeSorter/SpikeSorterEditor.cpp
+++ b/Source/Processors/SpikeSorter/SpikeSorterEditor.cpp
@@ -45,7 +45,7 @@ SpikeSorterEditor::SpikeSorterEditor(GenericProcessor* parentNode, bool useDefau
 
     desiredWidth = 300;
 
-    SpikeSorter* processor = (SpikeSorter*) getProcessor();
+    //SpikeSorter* processor = (SpikeSorter*) getProcessor();
 
     advancerList = new ComboBox("Advancers");
     advancerList->addListener(this);
@@ -635,11 +635,11 @@ void SpikeSorterEditor::labelTextChanged(Label* label)
     if (label == depthOffsetEdit)
     {
         // update electrode depth offset.
-        Value v = depthOffsetEdit->getTextValue();
-        double offset = v.getValue();
+        //Value v = depthOffsetEdit->getTextValue();
+        //double offset = v.getValue();
 
-        int electrodeIndex = electrodeList->getSelectedId()-1;
-        SpikeSorter* processor = (SpikeSorter*) getProcessor();
+        //int electrodeIndex = electrodeList->getSelectedId()-1;
+        //SpikeSorter* processor = (SpikeSorter*) getProcessor();
         //if (electrodeIndex >= 0)
         //	processor->setElectrodeAdvancerOffset(electrodeIndex, offset);
 

--- a/Source/Processors/Visualization/MatlabLikePlot.cpp
+++ b/Source/Processors/Visualization/MatlabLikePlot.cpp
@@ -401,7 +401,7 @@ void MatlabLikePlot::mouseDoubleClick(const juce::MouseEvent& event)
 }
 
 /*************************************************************************/
-AxesComponent::AxesComponent(bool horizontal, bool flip) : horiz(horizontal), flipDirection(flip)
+AxesComponent::AxesComponent(bool horizontal, bool flip) : flipDirection(flip), horiz(horizontal)
 {
 	minv = -1e4;
 	maxv = 1e4;
@@ -608,7 +608,7 @@ void AxesComponent::paint(Graphics &g)
 
 }
 /*************************************************************************/
-XYline::XYline(float x0_, float dx_, std::vector<float> y_, float gain_, juce::Colour color_) : x0(x0_), y(y_), dx(dx_),color(color_), gain(gain_)
+XYline::XYline(float x0_, float dx_, std::vector<float> y_, float gain_, juce::Colour color_) : gain(gain_), dx(dx_), x0(x0_), y(y_), color(color_)
 {
 	// adjust gain
 	numpts = y.size();
@@ -1124,7 +1124,7 @@ void DrawComponent::drawTicks(Graphics &g)
 	float tickThickness = 2;
 	double rangeX = (xmax-xmin);
 	double rangeY = (ymax-ymin);
-	if (abs(rangeX) < 1e-6 || abs(rangeY) < 1e-6)
+	if (std::abs(rangeX) < 1e-6 || std::abs(rangeY) < 1e-6)
 		return;
 
 	int plotWidth = getWidth();
@@ -1135,14 +1135,14 @@ void DrawComponent::drawTicks(Graphics &g)
 	{
 		// convert to screen coordinates.
 		float tickloc = (xtick[k]- xmin) / rangeX * plotWidth;
-		if (abs(tickloc) < 1e10)
+		if (std::abs(tickloc) < 1e10)
 			g.drawLine(tickloc,plotHeight,tickloc,plotHeight-(tickHeight),tickThickness);
 	}
 	for (int k=0;k < ytick.size();k++)
 	{
 		// convert to screen coordinates.
 		float tickloc = (ytick[k]- ymin) / rangeY * plotHeight;
-		if (abs(tickloc) < 1e10)
+		if (std::abs(tickloc) < 1e10)
 			g.drawLine(0,plotHeight-tickloc,tickHeight,plotHeight-tickloc, tickThickness);
 	}
 }
@@ -1151,7 +1151,7 @@ void DrawComponent::drawTicks(Graphics &g)
 void DrawComponent::plotxy(XYline l)
 {
 	l.getYRange(xmin,xmax,lowestValue, highestValue);
-	if (abs(lowestValue) < 1e10 && abs(highestValue) < 1e10)
+	if (std::abs(lowestValue) < 1e10 && std::abs(highestValue) < 1e10)
 		lines.push_back(l);
 }
 	
@@ -1188,7 +1188,7 @@ void DrawComponent::paint(Graphics &g)
 		// now draw curves.
 		for (int k=0;k<lines.size();k++) 
 		{
-			if (abs(ymin) < 1e10 & abs(ymax) < 1e10)
+			if (std::abs(ymin) < 1e10 & std::abs(ymax) < 1e10)
 				lines[k].draw(g,xmin,xmax,ymin,ymax,w,h,showBounds);
 		}
 		if (lines.size() > 0)
@@ -1425,7 +1425,7 @@ void DrawComponent::mouseMove(const juce::MouseEvent& event)
 	// convert threshold line to pixels.
 	float thresholdLineValuePix = h - ((thresholdLineValue-ymin) / (ymax-ymin) * h);
 	// check if we are close to the threshold line...
-	overThresholdLine = abs(event.y - thresholdLineValuePix) < 5;
+	overThresholdLine = std::abs(event.y - thresholdLineValuePix) < 5;
 
 }
 

--- a/Source/Processors/Visualization/SpikeObject.cpp
+++ b/Source/Processors/Visualization/SpikeObject.cpp
@@ -401,7 +401,7 @@ int microSecondsToSpikeTimeBin(SpikeObject *s, float t, int ch)
 
 
 SpikeChannel::SpikeChannel(SpikeDataType type, int nChans, void* ptr, int size)
-	: dataType(type), numChannels(nChans), ChannelExtraData(ptr, size)
+	: ChannelExtraData(ptr, size), dataType(type), numChannels(nChans)
 {
 }
 

--- a/Source/UI/GraphViewer.cpp
+++ b/Source/UI/GraphViewer.cpp
@@ -434,8 +434,6 @@ void GraphNode::switchIO(int path)
 void GraphNode::updateBoundaries()
 {
 
-    int level = getLevel();
-
     int horzShift = gv->getHorizontalShift(this);
 
     setBounds(20+horzShift*140, 20+getLevel()*40, 150, 50);

--- a/open-ephys.jucer
+++ b/open-ephys.jucer
@@ -740,7 +740,7 @@
       <FILE id="z41Hy7g" name="Main.cpp" compile="1" resource="0" file="Source/Main.cpp"/>
     </GROUP>
   </MAINGROUP>
-  <JUCEOPTIONS/>
+  <JUCEOPTIONS JUCE_QUICKTIME="disabled"/>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="1"/>
     <MODULE id="juce_audio_devices" showAllCode="1" useLocalCopy="1"/>


### PR DESCRIPTION
The theme of these changes is getting the GUI to build, cleanly, under Xcode 6.3.1 (although many of the issues are not specific to Xcode/OS X).  The changes include three bug fixes, each in its own commit.  The remaining changes eliminate the many compiler warnings generated by Clang.  These fall in to a few general categories:

* Unused variables
* Mismatch between order of member initializer lists and [actual initialization order](http://en.cppreference.com/w/cpp/language/initializer_list#Initialization_order)
* Use of [abs](http://en.cppreference.com/w/c/numeric/math/abs) (instead of [std::abs](http://en.cppreference.com/w/cpp/numeric/math/fabs)) on floating-point values
* OS X deprecation warnings

Apart from the bug fixes, these commits should introduce no functional changes.