### PR TITLE
Network events fixes

### DIFF
--- a/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX/open-ephys.xcodeproj/project.pbxproj
@@ -2879,6 +2879,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"_DEBUG=1",
 					"DEBUG=1",
+					"ZEROMQ",
 					"JUCER_XCODE_MAC_F6D2F4CF=1",
 					"JUCE_APP_VERSION=0.3.5",
 					"JUCE_APP_VERSION_HEX=0x305", );
@@ -2888,7 +2889,7 @@
 				INSTALL_PATH = "$(HOME)/Applications";
 				LIBRARY_SEARCH_PATHS = ("$(inherited)", "\"/opt/local/lib\"", "\"/usr/local/lib\"");
 				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
-				OTHER_LDFLAGS = "-lhdf5 -lhdf5_cpp";
+				OTHER_LDFLAGS = "-lhdf5 -lhdf5_cpp -lzmq";
 				SDKROOT_ppc = macosx10.5; }; name = Debug; };
 		7A6F9B742B69F66DC3E29FA8 = {isa = XCBuildConfiguration; buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
@@ -2901,6 +2902,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"_NDEBUG=1",
 					"NDEBUG=1",
+					"ZEROMQ",
 					"JUCER_XCODE_MAC_F6D2F4CF=1",
 					"JUCE_APP_VERSION=0.3.5",
 					"JUCE_APP_VERSION_HEX=0x305", );
@@ -2911,7 +2913,7 @@
 				INSTALL_PATH = "$(HOME)/Applications";
 				LIBRARY_SEARCH_PATHS = ("$(inherited)", "\"/opt/local/lib\"", "\"/usr/local/lib\"");
 				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
-				OTHER_LDFLAGS = "-lhdf5 -lhdf5_cpp";
+				OTHER_LDFLAGS = "-lhdf5 -lhdf5_cpp -lzmq";
 				SDKROOT_ppc = macosx10.5; }; name = Release; };
 		C8018C9A4DA633CA60663294 = {isa = XCBuildConfiguration; buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;

--- a/Resources/Python/network_events_console.py
+++ b/Resources/Python/network_events_console.py
@@ -1,0 +1,28 @@
+from __future__ import print_function, unicode_literals
+
+import zmq
+
+try:
+    raw_input
+except NameError:
+    # Python 3
+    raw_input = input
+
+
+def run(hostname='localhost', port=5556):
+    with zmq.Context() as ctx:
+        with ctx.socket(zmq.REQ) as sock:
+            sock.connect('tcp://%s:%d' % (hostname, port))
+            while True:
+                try:
+                    req = raw_input('> ')
+                    sock.send_string(req)
+                    rep = sock.recv_string()
+                    print(rep)
+                except EOFError:
+                    print()  # Add final newline
+                    break
+
+
+if __name__ == '__main__':
+    run()

--- a/Source/Processors/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Processors/NetworkEvents/NetworkEvents.cpp
@@ -449,7 +449,7 @@ void NetworkEvents::run()
     if (rc != 0)
     {
         // failed to open socket?
-        std::cout << "Failed to open socket." << std::endl;
+        std::cout << "Failed to open socket: " << zmq_strerror(zmq_errno()) << std::endl;
         return;
     }
 
@@ -562,7 +562,7 @@ void NetworkEvents::loadCustomParametersFromXml()
 void NetworkEvents::createZmqContext()
 {
 #ifdef ZEROMQ
-    if (zmqcontext != nullptr)
+    if (zmqcontext == nullptr)
         zmqcontext = zmq_ctx_new(); //<-- this is only available in version 3+
 #endif
 }

--- a/open-ephys.jucer
+++ b/open-ephys.jucer
@@ -12,7 +12,8 @@
               includeBinaryInAppConfig="1">
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" vstFolder="~/SDKs/vstsdk2.4" rtasFolder="~/SDKs/PT_80_SDK"
-               extraLinkerFlags="-lhdf5 -lhdf5_cpp" objCExtraSuffix="fea2mT">
+               extraLinkerFlags="-lhdf5 -lhdf5_cpp -lzmq" objCExtraSuffix="fea2mT"
+               extraDefs="ZEROMQ">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="3" targetName="open-ephys"
                        osxSDK="default" osxCompatibility="default" osxArchitecture="default"


### PR DESCRIPTION
These changes:

* Enable the network node on OS X
* Fix a bug that prevented creation of a ZeroMQ context
* Add an example Python script for generating network events