### PR TITLE
Implemented record control via network events

### DIFF
--- a/Resources/Python/record_control_example_client.py
+++ b/Resources/Python/record_control_example_client.py
@@ -1,0 +1,60 @@
+"""
+    A zmq client to test remote control of open-ephys GUI
+"""
+
+import zmq
+import os
+import time
+
+
+def run_client():
+
+    # Basic start/stop commands
+    start_cmd = 'ProcessorCommunication RecordControl StartRecord'
+    stop_cmd = 'ProcessorCommunication RecordControl StopRecord'
+
+    # Example settings
+    rec_dir = os.path.join(os.getcwd(), 'Output_RecordControl')
+
+    # Some commands
+    commands = [start_cmd + ' RecordingDirectory=%s' % rec_dir,
+                start_cmd + ' CreateNewDateDirectory=1',
+                start_cmd + ' PrependText=Session001 AppendText=Condition001',
+                start_cmd + ' PrependText=Session001 AppendText=Condition002',
+                start_cmd + ' PrependText=Session002 AppendText=Condition001']
+
+    # Connect network handler
+    ip = '127.0.0.1'
+    port = 5556
+    timeout = 1.
+
+    url = "tcp://%s:%d" % (ip, port)
+
+    with zmq.Context() as context:
+        with context.socket(zmq.REQ) as socket:
+            socket.RCVTIMEO = int(timeout * 1000)  # timeout in milliseconds
+            socket.connect(url)
+
+            for start_cmd in commands:
+
+                for cmd in [start_cmd, stop_cmd]:
+                    socket.send(cmd)
+                    answer = socket.recv()
+                    print answer
+
+                    if 'StartRecord' in cmd:
+                        # Record data for 5 seconds
+                        time.sleep(5)
+                    else:
+                        # Stop for 1 second
+                        time.sleep(1)
+
+            # Finally, stop data acquisition
+            socket.send('ProcessorCommunication RecordControl StopAcquisition')
+            answer = socket.recv()
+            print answer
+
+
+if __name__ == '__main__':
+    run_client()
+

--- a/Source/Processors/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Processors/NetworkEvents/NetworkEvents.cpp
@@ -355,6 +355,39 @@ void NetworkEvents::simulateSingleTrial()
 
 String NetworkEvents::handleSpecialMessages(StringTS msg)
 {
+	std::vector<String> input = msg.splitString(' ');
+
+	if (input[0] == "ProcessorCommunication")
+	{
+		ProcessorGraph *g = AccessClass::getProcessorGraph();
+		Array<GenericProcessor*> p = g->getListOfProcessors();
+		for (int k=0; k<p.size(); k++)
+		{
+			String name = p[k]->getName().removeCharacters(" ");
+			if (name.toLowerCase() == input[1].toLowerCase())
+			{
+				String Query="";
+				for (int i=2;i<input.size();i++)
+				{
+					if (i == input.size()-1)
+						Query+=input[i];
+					else
+						Query+=input[i] + " ";
+				}
+
+				std::cout << "Network processor communication " << name << std::endl;
+				return p[k]->interProcessorCommunication(Query);
+			}
+		}
+
+  		return String("OK");      
+	} else
+	{
+		std::cout << "Network message: " << msg.getString() << std::endl;
+		CoreServices::sendStatusMessage(String("Network message: ") + msg.getString());
+		return String("NotHandled");
+	}
+
     /*
     std::vector<String> input = msg.splitString(' ');
     if (input[0] == "StartRecord")
@@ -405,7 +438,7 @@ String NetworkEvents::handleSpecialMessages(StringTS msg)
     }
 
     */
-    return String("NotHandled");
+    // return String("NotHandled");
 }
 
 void NetworkEvents::process(AudioSampleBuffer& buffer,

--- a/Source/Processors/RecordControl/RecordControl.h
+++ b/Source/Processors/RecordControl/RecordControl.h
@@ -48,6 +48,7 @@ public:
     void updateTriggerChannel(int newChannel);
     void handleEvent(int eventType, MidiMessage& event, int);
     bool enable();
+	String interProcessorCommunication(String command);
 
     bool isUtility()
     {

--- a/Source/UI/ControlPanel.cpp
+++ b/Source/UI/ControlPanel.cpp
@@ -1044,3 +1044,45 @@ void ControlPanel::setRecentlyUsedFilenames(const StringArray& filenames)
 {
     filenameComponent->setRecentlyUsedFilenames(filenames);
 }
+
+
+bool ControlPanel::getRecordState()
+{
+	return recordButton->getToggleState();
+}
+
+
+void ControlPanel::setRecordingDirectory(String path)
+{
+	File newFile(path);
+	filenameComponent->setCurrentFile(newFile, true, sendNotificationSync);
+
+    graph->getRecordNode()->newDirectoryNeeded = true;
+    masterClock->resetRecordTime();
+}
+
+
+bool ControlPanel::getAcquisitionState()
+{
+	return playButton->getToggleState();
+}
+
+
+void ControlPanel::setAcquisitionState(bool isRunning)
+{
+	playButton->setToggleState(isRunning, sendNotification);
+}
+
+
+void ControlPanel::setPrependText(String text)
+{
+	prependText->setText(text, sendNotificationSync);
+}
+
+
+void ControlPanel::setAppendText(String text)
+{
+	appendText->setText(text, sendNotificationSync);
+}
+
+

--- a/Source/UI/ControlPanel.h
+++ b/Source/UI/ControlPanel.h
@@ -340,6 +340,24 @@ public:
     /** Sets the list of recently used directories for saving data. */
     void setRecentlyUsedFilenames(const StringArray& filenames);
 
+	/* Get recording state */
+	bool getRecordState();
+
+	/* Set new recording directory path */ 
+	void setRecordingDirectory(String);
+
+	/* Set prepend string */
+	void setPrependText(String);
+
+	/* Set append string */
+	void setAppendText(String);
+
+	/* Get current aquisition state */
+	bool getAcquisitionState();
+
+	/* Used to manually turn on/off data acquisition */
+	void setAcquisitionState(bool isRunning);
+
     /** Adds the RecordNode as a listener of the FilenameComponent
     (so it knows when the data directory has changed).*/
     void updateChildComponents();


### PR DESCRIPTION
Added functionality to start/stop recording, setting the recording directory, prepend/append text etc via network events. To keep it consistent with the general processor design, the interProcessorCommunication method is used to forward network events to the RecordControl processor. I also added an example Python client.
