### PR TITLE
Network events improvements

### DIFF
--- a/Source/Processors/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Processors/NetworkEvents/NetworkEvents.cpp
@@ -240,45 +240,6 @@ void NetworkEvents::setParameter(int parameterIndex, float newValue)
 
 }
 
-void NetworkEvents::initSimulation()
-{
-    Time t;
-
-    int64 secondsToTicks = t.getHighResolutionTicksPerSecond();
-    simulationStartTime=3*secondsToTicks + t.getHighResolutionTicks(); // start 10 seconds after
-
-    simulation.push(StringTS("ClearDesign",simulationStartTime));
-    simulation.push(StringTS("NewDesign Test",simulationStartTime+0.5*secondsToTicks));
-    simulation.push(StringTS("AddCondition Name GoRight TrialTypes 1 2 3",simulationStartTime+0.6*secondsToTicks));
-    simulation.push(StringTS("AddCondition Name GoLeft TrialTypes 4 5 6",simulationStartTime+0.6*secondsToTicks));
-
-
-
-}
-
-void NetworkEvents::simulateDesignAndTrials(juce::MidiBuffer& events)
-{
-    Time t;
-    while (simulation.size() > 0)
-    {
-        int64 currenttime = t.getHighResolutionTicks();
-        StringTS S = simulation.front();
-        if (currenttime > S.timestamp)
-        {
-
-            // handle special messages
-            handleSpecialMessages(S);
-
-            postTimestamppedStringToMidiBuffer(S,events);
-            //getUIComponent()->getLogWindow()->addLineToLog(S.getString());
-            simulation.pop();
-        }
-        else
-            break;
-    }
-
-}
-
 
 void NetworkEvents::handleEvent(int eventType, juce::MidiMessage& event, int samplePosition)
 {
@@ -301,55 +262,6 @@ void NetworkEvents::postTimestamppedStringToMidiBuffer(StringTS s, MidiBuffer& e
              msg_with_ts);
 
     delete msg_with_ts;
-}
-
-void NetworkEvents::simulateStopRecord()
-{
-    Time t;
-    simulation.push(StringTS("StopRecord",t.getHighResolutionTicks()));
-
-}
-
-void NetworkEvents::simulateStartRecord()
-{
-    Time t;
-    simulation.push(StringTS("StartRecord",t.getHighResolutionTicks()));
-
-}
-
-void NetworkEvents::simulateSingleTrial()
-{
-
-    std::cout << "Simulating trial." << std::endl;
-
-    int numTrials = 1;
-    float ITI = 0.7;
-    float TrialLength = 0.4;
-    Time t;
-
-    if (firstTime)
-    {
-        firstTime = false;
-        initSimulation();
-    }
-
-    int64 secondsToTicks = t.getHighResolutionTicksPerSecond();
-    simulationStartTime=3*secondsToTicks + t.getHighResolutionTicks(); // start 10 seconds after
-
-    // trial every 5 seconds
-    for (int k=0; k<numTrials; k++)
-    {
-        simulation.push(StringTS("TrialStart",simulationStartTime+ITI*k*secondsToTicks));
-        if (k%2 == 0)
-            simulation.push(StringTS("TrialType 2",simulationStartTime+(ITI*k+0.1)*secondsToTicks)); // 100 ms after trial start
-        else
-            simulation.push(StringTS("TrialType 4",simulationStartTime+(ITI*k+0.1)*secondsToTicks)); // 100 ms after trial start
-
-        simulation.push(StringTS("TrialAlign",simulationStartTime+(ITI*k+0.1)*secondsToTicks)); // 100 ms after trial start
-        simulation.push(StringTS("TrialOutcome 1",simulationStartTime+(ITI*k+0.3)*secondsToTicks)); // 300 ms after trial start
-        simulation.push(StringTS("TrialEnd",simulationStartTime+(ITI*k+TrialLength)*secondsToTicks)); // 400 ms after trial start
-
-    }
 }
 
 
@@ -416,7 +328,6 @@ void NetworkEvents::process(AudioSampleBuffer& buffer,
     //printf("Entering NetworkEvents::process\n");
     setTimestamp(events,CoreServices::getGlobalTimestamp());
     checkForEvents(events);
-    //simulateDesignAndTrials(events);
 
     //std::cout << *buffer.getSampleData(0, 0) << std::endl;
     lock.enter();

--- a/Source/Processors/NetworkEvents/NetworkEvents.h
+++ b/Source/Processors/NetworkEvents/NetworkEvents.h
@@ -78,18 +78,13 @@ public:
     ~NetworkEvents();
     AudioProcessorEditor* createEditor();
     int64 getExtrapolatedHardwareTimestamp(int64 softwareTS);
-    void initSimulation();
-    void simulateDesignAndTrials(juce::MidiBuffer& events);
     void process(AudioSampleBuffer& buffer, MidiBuffer& midiMessages);
     void setParameter(int parameterIndex, float newValue);
     String handleSpecialMessages(StringTS msg);
     std::vector<String> splitString(String S, char sep);
 
-    void simulateSingleTrial();
     bool isSource();
 
-    void simulateStartRecord();
-    void simulateStopRecord();
     bool closesocket();
     void run();
     void opensocket();

--- a/Source/Processors/NetworkEvents/NetworkEvents.h
+++ b/Source/Processors/NetworkEvents/NetworkEvents.h
@@ -74,6 +74,8 @@ public:
 class NetworkEvents : public GenericProcessor,  public Thread
 {
 public:
+    static std::shared_ptr<void> getZMQContext();
+    
     NetworkEvents();
     ~NetworkEvents();
     AudioProcessorEditor* createEditor();
@@ -87,7 +89,6 @@ public:
 
     bool closesocket();
     void run();
-    void opensocket();
 
     void updateSettings();
 
@@ -107,19 +108,15 @@ public:
 
     int urlport;
     String socketStatus;
-    bool threadRunning ;
 private:
     void handleEvent(int eventType, MidiMessage& event, int samplePos);
-    void createZmqContext();
 
     StringTS createStringTS(String S, int64 t);
 
-    static void* zmqcontext;
-    void* responder;
+    const std::shared_ptr<void> zmqcontext;
     float threshold;
     float bufferZone;
     bool state;
-    bool shutdown;
     Time timer;
     std::queue<StringTS> networkMessagesQueue;
 


### PR DESCRIPTION
This change set removes some unused methods from and improves the implementation of NetworkEvents.

It also makes the ZeroMQ context used by NetworkEvents available to other components via a static, public method.  However, given the discussion in #288, maybe this method should be in CoreServices instead?  If so, I can update the pull request with that change.
