### PR TITLE
Some bug fixes

### DIFF
--- a/Source/Processors/DataThreads/RHD2000Thread.cpp
+++ b/Source/Processors/DataThreads/RHD2000Thread.cpp
@@ -44,6 +44,10 @@
 #define REGISTER_59_MISO_B  58
 #define RHD2132_16CH_OFFSET 8
 
+#ifndef DEBUG_EMULATE_HEADSTAGES
+#define DEBUG_EMULATE_HEADSTAGES 0
+#endif
+
 // Allocates memory for a 3-D array of doubles.
 void allocateDoubleArray3D(std::vector<std::vector<std::vector<double> > >& array3D,
                            int xSize, int ySize, int zSize)
@@ -583,14 +587,14 @@ void RHD2000Thread::scanPorts()
 #if DEBUG_EMULATE_HEADSTAGES > 0
     for (int nd = 0; nd < MAX_NUM_DATA_STREAMS; ++nd)
     {
-        if ((nd < DEBUG_EMULATE_HEADSTAGES) &&(tmpChipId[0] > 0))
+        if (nd < DEBUG_EMULATE_HEADSTAGES)
         {
             evalBoard->setDataSource(nd,initStreamPorts[0]);
             enableHeadstage(nd,true);
         }
         else
         {
-            enableHeadstage(stream,false);
+            enableHeadstage(nd,false);
         }
     }
 #else

--- a/Source/Processors/Editors/ChannelSelector.cpp
+++ b/Source/Processors/Editors/ChannelSelector.cpp
@@ -329,7 +329,10 @@ void ChannelSelector::setActiveChannels(Array<int> a)
 
     for (int i = 0; i < a.size(); i++)
     {
-        parameterButtons[a[i]]->setToggleState(true, dontSendNotification);
+        if (a[i] < parameterButtons.size())
+        {
+            parameterButtons[a[i]]->setToggleState(true, dontSendNotification);
+        }
     }
 }
 

--- a/Source/Processors/PSTH/PeriStimulusTimeHistogramNode.cpp
+++ b/Source/Processors/PSTH/PeriStimulusTimeHistogramNode.cpp
@@ -133,7 +133,10 @@ void PeriStimulusTimeHistogramNode::updateSettings()
 
 void PeriStimulusTimeHistogramNode::setHardwareTriggerAlignmentChannel(int chan)
 {
-    trialCircularBuffer->setHardwareTriggerAlignmentChannel(chan);
+    if (trialCircularBuffer != nullptr)
+    {
+        trialCircularBuffer->setHardwareTriggerAlignmentChannel(chan);
+    }
 }
 
 bool PeriStimulusTimeHistogramNode::enable()


### PR DESCRIPTION
These changes fix a crash in `PeriStimulusTimeHistogramNode::setHardwareTriggerAlignmentChannel` and resolve some issues in the `DEBUG_EMULATE_HEADSTAGES` code path in `RHD2000Thread::scanPorts`.