### PR TITLE
Fix LFP time axis to show time labels > 10000 ms

### DIFF
--- a/Source/Processors/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Source/Processors/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -1124,7 +1124,7 @@ void LfpTimescale::setTimebase(float t)
     {
         String labelString = String(timebase/10.0f*1000.0f*i);
 
-        labels.add(labelString.substring(0,4));
+        labels.add(labelString.substring(0,6));
     }
 
     repaint();


### PR DESCRIPTION
Small correction made to LFP display window. I noticed when 20s from time base is chosen, the least significant digit for time labels > 10000 does not appear. Modified code to show up to 6 digits.