### PR TITLE
Fixed the value of bufferIndex, line 173 and following, as previous v…

### DIFF
--- a/Source/Processors/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Source/Processors/LfpDisplayNode/LfpDisplayNode.cpp
@@ -171,6 +171,10 @@ void LfpDisplayNode::handleEvent(int eventType, MidiMessage& event, int sampleNu
          //            << channelForEventSource[eventSourceNode] << std::endl;
         ////
         int bufferIndex = (displayBufferIndex[channelForEventSource[eventSourceNodeId]] + eventTime - nSamples) % displayBuffer->getNumSamples();
+        
+        bufferIndex = bufferIndex >= 0 ? bufferIndex :
+        displayBuffer->getNumSamples() + bufferIndex;
+
 
         if (eventId == 1)
         {


### PR DESCRIPTION
Fixed the value of bufferIndex, line 173 and following, as previous version caused buffer index to be negative, triggering an assert, and most likely access violations and crashes. 
See the group message here 
https://groups.google.com/forum/#!searchin/open-ephys/assertion$20failure/open-ephys/7Jdkkhjj9u4/nfF8zE9TajAJ


The important point is that in C99 the '%' operator is a 'remainder' and not a 'modulo' operator, so counterintuitively enough, it will give a negative results for negative numerators...
