### PR TITLE
Implemented record control via network events (new version using CoreServices namespace)

### DIFF
--- a/Resources/Python/record_control_example_client.py
+++ b/Resources/Python/record_control_example_client.py
@@ -1,0 +1,69 @@
+"""
+    A zmq client to test remote control of open-ephys GUI
+"""
+
+import zmq
+import os
+import time
+
+
+def run_client():
+
+    # Basic start/stop commands
+    start_cmd = 'StartRecord'
+    stop_cmd = 'StopRecord'
+
+    # Example settings
+    rec_dir = os.path.join(os.getcwd(), 'Output_RecordControl')
+    print "Saving data to:", rec_dir
+
+    # Some commands
+    commands = [start_cmd + ' RecDir=%s' % rec_dir,
+                start_cmd + ' PrependText=Session01 AppendText=Condition01',
+                start_cmd + ' PrependText=Session01 AppendText=Condition02',
+                start_cmd + ' PrependText=Session02 AppendText=Condition01',
+                start_cmd,
+                start_cmd + ' CreateNewDir=1']
+
+    # Connect network handler
+    ip = '127.0.0.1'
+    port = 5556
+    timeout = 1.
+
+    url = "tcp://%s:%d" % (ip, port)
+
+    with zmq.Context() as context:
+        with context.socket(zmq.REQ) as socket:
+            socket.RCVTIMEO = int(timeout * 1000)  # timeout in milliseconds
+            socket.connect(url)
+
+            # Finally, start data acquisition
+            socket.send('StartAcquisition')
+            answer = socket.recv()
+            print answer
+            time.sleep(5)
+
+            for start_cmd in commands:
+
+                for cmd in [start_cmd, stop_cmd]:
+                    socket.send(cmd)
+                    answer = socket.recv()
+                    print answer
+
+                    if 'StartRecord' in cmd:
+                        # Record data for 5 seconds
+                        time.sleep(5)
+                    else:
+                        # Stop for 1 second
+                        time.sleep(1)
+
+            # Finally, stop data acquisition; it might be a good idea to 
+            # wait a little bit until all data have been written to hard drive
+            time.sleep(0.5)
+            socket.send('StopAcquisition')
+            answer = socket.recv()
+            print answer
+
+
+if __name__ == '__main__':
+    run_client()

--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -52,6 +52,16 @@ void setRecordingStatus(bool enable)
     getControlPanel()->setRecordState(enable);
 }
 
+bool getAcquisitionStatus()
+{
+	return getControlPanel()->getAcquisitionState();
+}
+
+void setAcquisitionStatus(bool enable)
+{
+    getControlPanel()->setAcquisitionState(enable);
+}
+
 void sendStatusMessage(const String& text)
 {
     getBroadcaster()->sendActionMessage(text);
@@ -75,6 +85,26 @@ int64 getGlobalTimestamp()
 int64 getSoftwareTimestamp()
 {
 	return getMessageCenter()->getTimestamp(true);
+}
+
+void setRecordingDirectory(String dir)
+{
+    getControlPanel()->setRecordingDirectory(dir);
+}
+
+void createNewRecordingDir()
+{
+   getControlPanel()->labelTextChanged(NULL);
+}
+
+void setPrependTextToRecordingDir(String text)
+{
+    getControlPanel()->setPrependText(text);
+}
+
+void setAppendTextToRecordingDir(String text)
+{
+    getControlPanel()->setAppendText(text);
 }
 
 namespace RecordNode

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -42,6 +42,12 @@ bool getRecordingStatus();
 /** Activated or deactivates recording */
 void setRecordingStatus(bool enable);
 
+/** Returns true if the GUI is acquiring data */
+bool getAcquisitionStatus();
+
+/** Activates or deactivates data acquisition */
+void setAcquisitionStatus(bool enable);
+
 /** Sends a string to the message bar */
 void sendStatusMessage(const String& text);
 
@@ -58,6 +64,18 @@ int64 getGlobalTimestamp();
 
 /** Gets the software timestamp based on a high resolution timer aligned to the start of each processing block */
 int64 getSoftwareTimestamp();
+
+/** Set new recording directory */
+void setRecordingDirectory(String dir);
+
+/** Create new recording directory */
+void createNewRecordingDir();
+
+/** Manually set the text to be prepended to the recording directory */
+void setPrependTextToRecordingDir(String text);
+
+/** Manually set the text to be appended to the recording directory */
+void setAppendTextToRecordingDir(String text);
 
 namespace RecordNode
 {

--- a/Source/Processors/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Processors/NetworkEvents/NetworkEvents.cpp
@@ -405,7 +405,31 @@ String NetworkEvents::handleSpecialMessages(StringTS msg)
     }
 
     */
-    return String("NotHandled");
+
+	/** Start/stop data acquisition */
+	String s = msg.getString();
+
+	const MessageManagerLock mmLock;
+	if (s.compareIgnoreCase("StartAcquisition") == 0)
+	{
+		if (!CoreServices::getAcquisitionStatus())
+	    {
+	        CoreServices::setAcquisitionStatus(true);
+	    }
+		return String("StartedAcquisition");
+	}
+	else if (s.compareIgnoreCase("StopAcquisition") == 0)
+	{
+		if (CoreServices::getAcquisitionStatus())
+	    {
+	        CoreServices::setAcquisitionStatus(false);
+	    }
+		return String("StoppedAcquisition");
+	}
+	else
+	{
+	    return String("NotHandled");
+	}
 }
 
 void NetworkEvents::process(AudioSampleBuffer& buffer,

--- a/Source/Processors/RecordControl/RecordControl.h
+++ b/Source/Processors/RecordControl/RecordControl.h
@@ -26,8 +26,8 @@
 
 #include "../../../JuceLibraryCode/JuceHeader.h"
 #include "../GenericProcessor/GenericProcessor.h"
+#include "../NetworkEvents/NetworkEvents.h"
 #include "RecordControlEditor.h"
-#include "../RecordNode/RecordNode.h"
 
 /**
 
@@ -47,6 +47,11 @@ public:
     void setParameter(int, float);
     void updateTriggerChannel(int newChannel);
     void handleEvent(int eventType, MidiMessage& event, int);
+	void handleNetworkEvent(MidiMessage& event);
+
+	//* Split network message into name/value pairs (name1=val1 name2=val2 etc) */
+	StringPairArray parseNetworkMessage(String msg);
+
     bool enable();
 
     bool isUtility()

--- a/Source/UI/ControlPanel.cpp
+++ b/Source/UI/ControlPanel.cpp
@@ -489,6 +489,33 @@ void ControlPanel::setRecordState(bool t)
 
 }
 
+bool ControlPanel::getRecordingState()
+{
+
+	return recordButton->getToggleState();
+
+}
+
+void ControlPanel::setRecordingDirectory(String path)
+{
+    File newFile(path);
+    filenameComponent->setCurrentFile(newFile, true, sendNotificationSync);
+
+    graph->getRecordNode()->newDirectoryNeeded = true;
+    masterClock->resetRecordTime();
+}
+
+bool ControlPanel::getAcquisitionState()
+{
+	return playButton->getToggleState();
+}
+
+void ControlPanel::setAcquisitionState(bool state)
+{
+	playButton->setToggleState(state, sendNotification);
+}
+
+
 void ControlPanel::updateChildComponents()
 {
 
@@ -970,6 +997,16 @@ String ControlPanel::getTextToPrepend()
     {
         return t;
     }
+}
+
+void ControlPanel::setPrependText(String t)
+{
+    prependText->setText(t, sendNotificationSync);
+}
+
+void ControlPanel::setAppendText(String t)
+{
+    appendText->setText(t, sendNotificationSync);
 }
 
 void ControlPanel::setDateText(String t)

--- a/Source/UI/ControlPanel.h
+++ b/Source/UI/ControlPanel.h
@@ -301,6 +301,19 @@ public:
 
     /** Used to manually turn recording on and off.*/
     void setRecordState(bool isRecording);
+
+    /** Return current recording state.*/
+    bool getRecordingState();
+
+    /** Set recording directory and update FilenameComponent */
+    void setRecordingDirectory(String path);
+
+    /** Return current acquisition state.*/
+    bool getAcquisitionState();
+
+    /** Used to manually turn recording on and off.*/
+    void setAcquisitionState(bool state);
+
     /** Returns a boolean that indicates whether or not the FilenameComponet
         is visible. */
     bool isOpen()
@@ -316,6 +329,12 @@ public:
 
     /** Used by RecordNode to set the filename. */
     String getTextToAppend();
+
+    /** Manually set the text to be prepended to the recording directory */
+    void setPrependText(String text);
+
+    /** Manually set the text to be appended to the recording directory */
+    void setAppendText(String text);
 
     /** Set date text. */
     void setDateText(String);


### PR DESCRIPTION
Added functionality that allows starting/stopping acquisition/recording, setting the recording directory, and prepending/appending text to recording directory via network events. Includes an example Python client. Communication is done using events and some new functions in the CoreServices namespace.

note: the RecordControl processor must be in the same chain as the NetworkEvents processor. Using a merger and putting the RecordControl processor after the merger doesn't seem to work.