### PR TITLE
SpikeDetector: set electrode ID on spike events

### DIFF
--- a/Source/Processors/SpikeDetector/SpikeDetector.cpp
+++ b/Source/Processors/SpikeDetector/SpikeDetector.cpp
@@ -29,7 +29,8 @@
 SpikeDetector::SpikeDetector()
     : GenericProcessor("Spike Detector"),
       overflowBuffer(2,100), dataBuffer(nullptr),
-      overflowBufferSize(100), currentElectrode(-1)
+      overflowBufferSize(100), currentElectrode(-1),
+      uniqueID(0)
 {
     //// the standard form:
     electrodeTypes.add("single electrode");
@@ -97,7 +98,7 @@ void SpikeDetector::updateSettings()
 
 }
 
-bool SpikeDetector::addElectrode(int nChans)
+bool SpikeDetector::addElectrode(int nChans, int electrodeID)
 {
 
     std::cout << "Adding electrode with " << nChans << " channels." << std::endl;
@@ -155,6 +156,13 @@ bool SpikeDetector::addElectrode(int nChans)
         *(newElectrode->isActive+i) = true;
     }
 
+    if (electrodeID > 0) {
+        newElectrode->electrodeID = electrodeID;
+        uniqueID = std::max(uniqueID, electrodeID);
+    } else {
+        newElectrode->electrodeID = ++uniqueID;
+    }
+    
     newElectrode->sourceNodeId = channels[*newElectrode->channels]->sourceNodeId;
 
     resetElectrode(newElectrode);
@@ -505,7 +513,7 @@ void SpikeDetector::process(AudioSampleBuffer& buffer,
                         newSpike.source = i;
                         newSpike.nChannels = electrode->numChannels;
                         newSpike.sortedId = 0;
-                        newSpike.electrodeID = 0;
+                        newSpike.electrodeID = electrode->electrodeID;
                         newSpike.channel = 0;
                         newSpike.samplingFrequencyHz = sampleRateForElectrode;
 
@@ -676,6 +684,7 @@ void SpikeDetector::saveCustomParametersToXml(XmlElement* parentElement)
         electrodeNode->setAttribute("numChannels", electrodes[i]->numChannels);
         electrodeNode->setAttribute("prePeakSamples", electrodes[i]->prePeakSamples);
         electrodeNode->setAttribute("postPeakSamples", electrodes[i]->postPeakSamples);
+        electrodeNode->setAttribute("electrodeID", electrodes[i]->electrodeID);
 
         for (int j = 0; j < electrodes[i]->numChannels; j++)
         {
@@ -712,8 +721,9 @@ void SpikeDetector::loadCustomParametersFromXml()
                 std::cout << "ELECTRODE>>>" << std::endl;
 
                 int channelsPerElectrode = xmlNode->getIntAttribute("numChannels");
+                int electrodeID = xmlNode->getIntAttribute("electrodeID");
 
-                sde->addElectrode(channelsPerElectrode);
+                sde->addElectrode(channelsPerElectrode, electrodeID);
 
                 setElectrodeName(electrodeIndex+1, xmlNode->getStringAttribute("name"));
                 sde->refreshElectrodeList();

--- a/Source/Processors/SpikeDetector/SpikeDetector.h
+++ b/Source/Processors/SpikeDetector/SpikeDetector.h
@@ -40,6 +40,7 @@ struct SimpleElectrode
     int prePeakSamples, postPeakSamples;
     int lastBufferIndex;
     bool isMonitored;
+    int electrodeID;
     int sourceNodeId;
 
     int* channels;
@@ -104,7 +105,7 @@ public:
     // CREATE AND DELETE ELECTRODES //
 
     /** Adds an electrode with n channels to be processed. */
-    bool addElectrode(int nChans);
+    bool addElectrode(int nChans, int electrodeID = 0);
 
     /** Removes an electrode with a given index. */
     bool removeElectrode(int index);
@@ -181,6 +182,7 @@ private:
     int64 timestamp;
 
     Array<SimpleElectrode*> electrodes;
+    int uniqueID;
 
     // void createSpikeEvent(int& peakIndex,
     // 					  int& electrodeNumber,

--- a/Source/Processors/SpikeDetector/SpikeDetectorEditor.cpp
+++ b/Source/Processors/SpikeDetector/SpikeDetectorEditor.cpp
@@ -432,11 +432,11 @@ void SpikeDetectorEditor::refreshElectrodeList()
     }
 }
 
-bool SpikeDetectorEditor::addElectrode(int nChans)
+bool SpikeDetectorEditor::addElectrode(int nChans, int electrodeID)
 {
     SpikeDetector* processor = (SpikeDetector*) getProcessor();
 
-    if (processor->addElectrode(nChans))
+    if (processor->addElectrode(nChans, electrodeID))
     {
         refreshElectrodeList();
         return true;
@@ -543,7 +543,7 @@ void SpikeDetectorEditor::comboBoxChanged(ComboBox* comboBox)
 
 void SpikeDetectorEditor::checkSettings()
 {
-    electrodeList->setSelectedItemIndex(0);
+    electrodeList->setSelectedId(0);
     drawElectrodeButtons(0);
 
 	CoreServices::updateSignalChain(this);

--- a/Source/Processors/SpikeDetector/SpikeDetectorEditor.h
+++ b/Source/Processors/SpikeDetector/SpikeDetectorEditor.h
@@ -93,7 +93,7 @@ public:
 
     void channelChanged(int chan);
 
-    bool addElectrode(int nChans);
+    bool addElectrode(int nChans, int electrodeID = 0);
     void removeElectrode(int index);
 
     void checkSettings();


### PR DESCRIPTION
These changes update `SpikeDetector` to set the `electrodeID` field on spike events (just as `SpikeSorter` does already).  They also fix a GUI initialization error in `SpikeDetectorEditor`.